### PR TITLE
Sync Symbolic.ts/CAS lineage from mallory-ts; rename package to mallory-math

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm ci
+
+      - run: npm run typecheck
+
+      - run: npm run check
+
+      - run: npm test
+
+      - run: npm run build
+
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# mallory-ts
+# mallory
 
 **Advanced college-level mathematics for TypeScript** — a modern, fully-typed,
-test-covered port of the [Mallory](https://github.com/johnhenry/mallory)
-ActionScript 3 library (a project worked on, on and off, since 2004).
+test-covered port of the Mallory ActionScript 3 library (a project worked on,
+on and off, since 2004), published to npm as `mallory-math`.
 
 Complex numbers, linear algebra over arbitrary algebraic structures,
 combinatorics and number theory, an expression evaluator, and renderer-agnostic
@@ -10,7 +10,7 @@ graphing geometry — all rewritten in modern TypeScript with `node:test`
 (example-based and, for algebraic laws, property-based via `fast-check`).
 
 ```ts
-import { ComplexNumber, Structure, Vector, StringEvaluator } from "mallory-ts";
+import { ComplexNumber, Structure, Vector, StringEvaluator } from "mallory-math";
 
 ComplexNumber.E.power(new ComplexNumber(0, Math.PI)); // ≈ -1  (Euler)
 Structure.realField().determinant(/* 3×3 matrix, as Vector<Vector<number>> */);
@@ -132,7 +132,7 @@ Well beyond the original ActionScript scope, the library now spans:
 | Area | Module(s) | Highlights |
 |------|-----------|------------|
 | Numerical linear algebra | `MatrixMath` | LU, QR, Cholesky, symmetric eigen (Jacobi), SVD; `solve`, RREF, rank, null space, least squares, pseudo-inverse, norms, condition number |
-| Symbolic calculus | `Symbolic` | expression parser, symbolic differentiation, algebraic simplification, elementary integration, Taylor series |
+| Symbolic calculus | `Symbolic` | expression parser (41 unary elementary functions incl. inverse-trig, reciprocal-trig, hyperbolic/inverse-hyperbolic, `abs`/`log10`/`log2`/`cbrt`/`floor`/`ceil`/`round`/`sign`/`trunc`, and `expm1`/`log1p`/`sigmoid`/`erf`/`relu`, with `arcsin`/`logistic`-style aliases and `|x|` bar syntax, plus N-ary `atan2`/`hypot`/`min`/`max`/`gcd`/`lcm` and `log(base, x)`/`clamp(x, lo, hi)`), symbolic differentiation (incl. the multivariate chain rule for the N-ary functions), algebraic simplification with like-term collection and constant-folding, elementary integration (incl. by-parts and arctan/arcsin forms), Taylor series, `expand`/`substitute`, polynomial `solve`/`factor`, L'Hopital `limit`, LaTeX round-trip (`toLatex`/`fromLatex`, incl. `\operatorname{...}` for functions with no standard LaTeX command, and bracket notation for `abs`/`floor`/`ceil`/`cbrt`) |
 | Number types | `Rational`, `Quaternion`, `DualNumber`, `Interval` | exact bigint rationals, 3D-rotation quaternions, forward-mode autodiff, rigorous interval arithmetic — each also a `Structure` preset |
 | Number theory | `NumberTheory` | `bigint` modPow, extended GCD, CRT, Miller–Rabin, Pollard-rho factorization, Legendre/Jacobi |
 | Group theory | `GroupTheory` | Cayley tables, axiom checks, element order, generated subgroups, cosets, Lagrange, orbits, Sₙ/Zₙ |

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -1,19 +1,19 @@
 # Cookbook
 
-Task-oriented recipes across every domain mallory-ts covers. Each snippet is
+Task-oriented recipes across every domain mallory covers. Each snippet is
 self-contained, runnable, and pulled directly from the test suite (or verified
 against it) — see the linked test file if you want the full context.
 
 All examples assume:
 
 ```ts
-import { /* ... */ } from "mallory-ts";
+import { /* ... */ } from "mallory-math";
 ```
 
 ## Complex numbers & Euler's identity
 
 ```ts
-import { ComplexNumber } from "mallory-ts";
+import { ComplexNumber } from "mallory-math";
 
 const eulers = ComplexNumber.E.power(new ComplexNumber(0, Math.PI));
 // eulers ≈ -1 + 0i
@@ -24,7 +24,7 @@ See [`test/ComplexNumber.test.ts`](../test/ComplexNumber.test.ts).
 ## Descriptive statistics
 
 ```ts
-import { Statistics, Vector } from "mallory-ts";
+import { Statistics, Vector } from "mallory-math";
 
 const sample = Vector.fromArray([2, 4, 4, 4, 5, 5, 7, 9]);
 Statistics.mean(sample); // 5
@@ -39,7 +39,7 @@ For small dense matrices with a single number type, `Structure.realField()`
 API used for arbitrary fields below:
 
 ```ts
-import { Structure, Vector } from "mallory-ts";
+import { Structure, Vector } from "mallory-math";
 
 const A = Vector.fromArray([Vector.fromArray([4, 3]), Vector.fromArray([6, 3])]);
 const real = Structure.realField();
@@ -54,7 +54,7 @@ real.multiplyMatrix(A, inv); // ≈ identity
 finite fields, rationals, quaternions, dual numbers — via one generic API:
 
 ```ts
-import { Structure, Vector } from "mallory-ts";
+import { Structure, Vector } from "mallory-math";
 
 const gf7 = Structure.integersModulo(7); // GF(7), a finite field
 gf7.reciprocal(3); // 5  (3 * 5 = 15 ≡ 1 mod 7)
@@ -75,7 +75,7 @@ over those number types with no extra wiring. See
 `MatrixMath` accepts either a `Matrix<number>` or a plain `number[][]`:
 
 ```ts
-import { MatrixMath } from "mallory-ts";
+import { MatrixMath } from "mallory-math";
 
 const A = [
   [4, 3, 2],
@@ -100,7 +100,7 @@ See [`test/MatrixMath.test.ts`](../test/MatrixMath.test.ts).
 ## Evaluating math expression strings
 
 ```ts
-import { StringEvaluator } from "mallory-ts";
+import { StringEvaluator } from "mallory-math";
 
 const env = StringEvaluator.mathEnvironment(); // pi, e, sin, cos, sqrt, ...
 StringEvaluator.evaluate("sin(pi/2) + 2^3", env); // ComplexNumber ≈ 9
@@ -116,7 +116,7 @@ Real-number polynomials are `PolynomialRing(Structure.realField())`, plus two
 real-only helpers for the `"3*x^2-2*x+1"` string notation:
 
 ```ts
-import { PolynomialRing, Structure, parsePolynomial, polynomialToString } from "mallory-ts";
+import { PolynomialRing, Structure, parsePolynomial, polynomialToString } from "mallory-math";
 
 const R = new PolynomialRing(Structure.realField());
 const p = parsePolynomial("x^2 + 2x + 1"); // parses polynomialToString's own format
@@ -129,7 +129,7 @@ polynomialToString(p); // "1*x^2+2*x+1"
 ## Counting mathematics (combinatorics)
 
 ```ts
-import { Combinatorics } from "mallory-ts";
+import { Combinatorics } from "mallory-math";
 
 Combinatorics.factorial(5); // 120n
 Combinatorics.binomial(10, 3); // 120n  (nCk, symmetric: nCk = nC(n-k))
@@ -151,7 +151,7 @@ reaches 20. See
 ## Arbitrary-precision decimals
 
 ```ts
-import { Decimal, Structure } from "mallory-ts";
+import { Decimal, Structure } from "mallory-math";
 
 // Exact decimal arithmetic — no float drift:
 Decimal.from("0.1").add(Decimal.from("0.2")).toString(); // "0.3" (0.1 + 0.2 !== 0.3 in plain JS)
@@ -173,7 +173,7 @@ real numbers (as in the recipe above), and so on — mirroring `GroupTheory`'s
 idiom of taking the algebra as a constructor parameter:
 
 ```ts
-import { PolynomialRing, Structure } from "mallory-ts";
+import { PolynomialRing, Structure } from "mallory-math";
 
 const gf7 = Structure.integersModulo(7); // GF(7), a finite field
 const R = new PolynomialRing(gf7);
@@ -193,22 +193,106 @@ rationals. See
 ## Symbolic calculus
 
 ```ts
-import { Symbolic } from "mallory-ts";
+import { Symbolic } from "mallory-math";
 
 Symbolic.toString(Symbolic.differentiate("x^3")); // "3*x^2"
 Symbolic.toString(Symbolic.integrate("cos(x)")); // "sin(x)"
+Symbolic.toString(Symbolic.integrate("x*sin(x)")); // "sin(x) - x*cos(x)" — integration by parts
 Symbolic.toString(Symbolic.taylor("exp(x)", "x", 0, 4)); // Taylor series about 0
 Symbolic.evaluate("x^2 + 1", { x: 3 }); // 10
+
+// Algebraic simplification collects like terms, not just identities:
+Symbolic.toString(Symbolic.simplify("a*b + b*a")); // "2*(a*b)"
+Symbolic.toString(Symbolic.expand("(x+1)^2")); // "x^2 + 2*x + 1"
+Symbolic.toString(Symbolic.substitute("x^2 + 1", "x", "y+1")); // in terms of y
+
+// Polynomial solving/factoring (degree <= 6; real roots only):
+Symbolic.solve("x^2 - 5*x + 6").map(Symbolic.toString); // ["3", "2"]
+Symbolic.toString(Symbolic.factor("x^2 - 1")); // "(x - 1)*(x + 1)"
+
+Symbolic.limit("sin(x)/x", "x", 0); // 1 — via L'Hopital's rule
+Symbolic.toLatex("x^2/2"); // "\\frac{x^{2}}{2}"
+
+// fromLatex is the reverse of toLatex, for LaTeX-emitting math-field input:
+Symbolic.toString(Symbolic.fromLatex("\\frac{x^{2}}{2}")); // "x^2/2"
+Symbolic.toString(Symbolic.fromLatex("\\sqrt[3]{x}")); // "cbrt(x)" — not a fractional power,
+// since Math.cbrt(-8) = -2 but (-8)^(1/3) is NaN under JS's `**`.
+Symbolic.toString(Symbolic.fromLatex("\\sqrt[5]{x}")); // "x^(1/5)" — any other root stays a fractional power
+
+// arcsin/arccos/arctan/arcsinh/arccosh/arctanh are accepted as aliases for
+// asin/acos/atan/asinh/acosh/atanh — both spellings parse identically:
+Symbolic.toString(Symbolic.parse("arctan(x)")); // "atan(x)"
+Symbolic.toString(Symbolic.parse("logistic(x)")); // "sigmoid(x)" — logistic is an alias for sigmoid
+
+// |x| bar notation and \lfloor/\lceil round-trip too:
+Symbolic.toLatex("abs(x)"); // "\\left|x\\right|"
+Symbolic.toString(Symbolic.fromLatex("\\left\\lfloor x\\right\\rfloor")); // "floor(x)"
+Symbolic.evaluate(Symbolic.fromLatex("\\log_{2}(x)"), { x: 8 }); // 3 — \log defaults to base 10, or reads a subscript
+
+// Functions with no standard bare LaTeX command (sech, csch, arcsinh, arccosh,
+// arctanh, and the newer inverse-reciprocal/programmatic functions below)
+// round-trip through \operatorname{...}, matching KaTeX/MathJax:
+Symbolic.toLatex("sech(x)"); // "\\operatorname{sech}\\left(x\\right)"
+Symbolic.toString(Symbolic.fromLatex("\\operatorname{sech}(x)")); // "sech(x)"
+
+// N-ary functions (atan2/hypot/min/max/gcd/lcm) fold pairwise into nested
+// binary call2 nodes, so N >= 2 arguments all work:
+Symbolic.evaluate("hypot(3,4)", {}); // 5
+Symbolic.evaluate("min(3,7,-2,5)", {}); // -2
+Symbolic.evaluate("atan2(1,1)", {}); // 0.7853981633974483
+
+// log(base, x) and clamp(x, lo, hi) desugar into existing constructs at parse
+// time — they're not their own Expr node type:
+Symbolic.evaluate("log(2,8)", {}); // 3 — desugars to ln(x)/ln(base)
+Symbolic.evaluate("clamp(15,0,10)", {}); // 10 — desugars to min(max(x,lo),hi)
+
+// min/max/gcd round-trip through standard LaTeX commands; atan2/hypot/lcm
+// (no standard command) use \operatorname{...}, same as sech/csch above:
+Symbolic.toLatex("min(x,y)"); // "\\min\\left(x, y\\right)"
+Symbolic.toLatex("atan2(y,x)"); // "\\operatorname{atan2}\\left(y, x\\right)"
 ```
 
+`Symbolic.parse` recognizes 41 unary elementary functions:
+
+- `sin/cos/tan`, `asin/acos/atan` (+ `arcsin/arccos/arctan` aliases)
+- `sinh/cosh/tanh`, `asinh/acosh/atanh` (+ `arcsinh/arccosh/arctanh` aliases)
+- reciprocal-trig `cot/sec/csc` and reciprocal-hyperbolic `coth/sech/csch`
+- inverse-reciprocal-trig `acot/asec/acsc` (+ `arccot/arcsec/arccsc` aliases)
+  and inverse-reciprocal-hyperbolic `acoth/asech/acsch` (+ `arccoth/arcsech/arccsch` aliases)
+- `exp/ln/sqrt/cbrt/log10/log2`
+- `abs` (also via `|x|` bar syntax), `floor/ceil/round/trunc/sign` (+ `sgn` alias)
+- `expm1/log1p` (precision-preserving `e^x - 1` / `ln(1+x)`) and
+  `sigmoid` (+ `logistic` alias), `erf`, `relu` — common in numerical/ML code
+
+Plus six N-ary `BinaryFuncName`s (user-facing arity N >= 2, pairwise-folded
+into nested binary `call2` nodes at parse time; `atan2` alone requires exactly
+2 arguments) and two functions that desugar entirely into existing constructs:
+
+- `atan2(y, x)`, `hypot(x1, x2, ...)` — differentiate via the multivariate
+  chain rule
+- `min(a, b, ...)`, `max(a, b, ...)` — differentiate via a `sign`-based
+  formula, correct on both sides of the kink
+- `gcd(a, b, ...)`, `lcm(a, b, ...)` — integer-valued, derivative is `0`
+  (same convention as `floor`/`ceil`/`round`/`sign`/`trunc`)
+- `log(base, x)` desugars to `ln(x)/ln(base)`; `clamp(x, lo, hi)` desugars to
+  `min(max(x, lo), hi)` — neither is its own `Expr` node type
+
+`FUNCTION_NAMES` (exported alongside `Symbolic`) lists every recognized name —
+canonical and alias — for consumers that need to know what counts as a known
+function identifier without hand-duplicating this list (e.g. a UI's
+implicit-multiplication preprocessor deciding whether `arctan` is one
+identifier or four). Every one of these differentiates, evaluates, compiles,
+and round-trips through `toLatex`/`fromLatex`.
+
 Integration covers the elementary rules (power rule, `1/x`, linear-substitution
-`sin`/`cos`/`exp`); anything outside that set throws `NotIntegrableError`
+`sin`/`cos`/`exp`, integration by parts for a polynomial times `sin`/`cos`/`exp`,
+and arctan/arcsin forms); anything outside that set throws `NotIntegrableError`
 rather than returning a wrong answer — e.g. `Symbolic.integrate("sin(x^2)")`.
 
 ## Multivariable calculus
 
 ```ts
-import { DualNumber, VectorCalculus } from "mallory-ts";
+import { DualNumber, VectorCalculus } from "mallory-math";
 
 // f(x, y) = x^2*y + y^3
 const f = (xs: DualNumber[]) => xs[0].pow(2).multiply(xs[1]).add(xs[1].pow(3));
@@ -237,7 +321,7 @@ gradient, not of `f` itself. See
 ## Exact and specialized number types
 
 ```ts
-import { Rational, Quaternion, DualNumber, Interval } from "mallory-ts";
+import { Rational, Quaternion, DualNumber, Interval } from "mallory-math";
 
 // Exact fractions (no floating-point drift)
 Rational.from(1).divide(new Rational(3n)).add(Rational.from(1).divide(new Rational(6n))); // 1/2 exactly
@@ -258,7 +342,7 @@ See [`test/NumberTypes.test.ts`](../test/NumberTypes.test.ts).
 ## Number theory
 
 ```ts
-import { NumberTheory } from "mallory-ts";
+import { NumberTheory } from "mallory-math";
 
 NumberTheory.isProbablePrime(2n ** 61n - 1n); // true (Mersenne prime)
 NumberTheory.isProbablePrime(561n); // false (Carmichael number — not a false positive)
@@ -272,7 +356,7 @@ Everything here is `bigint`-based, so it's exact for arbitrarily large inputs
 ## Group theory
 
 ```ts
-import { Structure, GroupTheory } from "mallory-ts";
+import { Structure, GroupTheory } from "mallory-math";
 
 // GroupTheory composes with any Structure preset:
 const gf7 = Structure.integersModulo(7);
@@ -291,7 +375,7 @@ non-abelian example and the Lagrange's-theorem cosets/index check.
 ## Root-finding, quadrature, and ODEs
 
 ```ts
-import { Numerical } from "mallory-ts";
+import { Numerical } from "mallory-math";
 
 Numerical.newton((x) => x * x - 2, 1); // √2, quadratic convergence
 Numerical.brent((x) => x * x - 2, 0, 2); // hybrid bisection/secant/inverse-quadratic
@@ -305,7 +389,7 @@ Numerical.rk4((_t, y) => [y[0]], [1], 0, 1, 0.01); // y' = y, y(0)=1 -> y(1) ≈
 ## Special functions & probability
 
 ```ts
-import { SpecialFunctions, Distributions, HypothesisTests } from "mallory-ts";
+import { SpecialFunctions, Distributions, HypothesisTests } from "mallory-math";
 
 SpecialFunctions.gamma(5); // 24  (4!)
 SpecialFunctions.regularizedIncompleteBeta(0.5, 2, 3);
@@ -324,7 +408,7 @@ rather than numeric integration.
 ## FFT and convolution
 
 ```ts
-import { FFT } from "mallory-ts";
+import { FFT } from "mallory-math";
 
 FFT.fft([1, 0, 0, 0]); // flat spectrum (power-of-two length required)
 FFT.fftPadded([1, 2, 3]); // zero-pads to the next power of two
@@ -334,7 +418,7 @@ FFT.convolve([1, 2, 3], [4, 5, 6]); // [4, 13, 28, 27, 18], via FFT
 ## Computational geometry
 
 ```ts
-import { Geometry, Transform2D, type Point } from "mallory-ts";
+import { Geometry, Transform2D, type Point } from "mallory-math";
 
 const cloud: Point[] = [[0,0],[1,1],[2,2],[2,0],[0,2],[1,0.5]];
 Geometry.convexHull(cloud); // the 4 outer corners; interior/collinear points drop out
@@ -349,7 +433,7 @@ t.apply([1, 0]); // rotate then translate -> [1, 3]
 ## Graph algorithms
 
 ```ts
-import { Graph } from "mallory-ts";
+import { Graph } from "mallory-math";
 
 const g = new Graph<string>(true); // directed
 g.addEdge("a", "b", 1).addEdge("b", "c", 2).addEdge("a", "c", 10);
@@ -363,7 +447,7 @@ g.floydWarshall(); // { distances, order } — all-pairs shortest paths
 ## Permutations and cycles
 
 ```ts
-import { Permutation, Cycle } from "mallory-ts";
+import { Permutation, Cycle } from "mallory-math";
 
 const sigma = new Permutation([0, 1, 2], [1, 2, 0]); // 0->1, 1->2, 2->0
 Permutation.compose(sigma, sigma); // apply sigma twice

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mallory-ts",
-  "version": "0.2.0",
+  "name": "mallory-math",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mallory-ts",
-      "version": "0.2.0",
+      "name": "mallory-math",
+      "version": "0.0.2",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mallory-ts",
-  "version": "0.2.0",
+  "name": "mallory-math",
+  "version": "0.0.2",
   "description": "Advanced college-level mathematics library — a modern TypeScript port of the Mallory ActionScript 3 library.",
   "type": "module",
   "exports": {
@@ -45,12 +45,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/johnhenry/mallory-ts.git"
+    "url": "git+https://github.com/johnhenry/mallory.git"
   },
   "bugs": {
-    "url": "https://github.com/johnhenry/mallory-ts/issues"
+    "url": "https://github.com/johnhenry/mallory/issues"
   },
-  "homepage": "https://github.com/johnhenry/mallory-ts#readme",
+  "homepage": "https://github.com/johnhenry/mallory#readme",
   "devDependencies": {
     "@biomejs/biome": "^2.5.1",
     "fast-check": "^4.8.0",

--- a/src/Symbolic.ts
+++ b/src/Symbolic.ts
@@ -1,10 +1,57 @@
 /**
  * Symbolic — a small computer-algebra engine: an expression AST with parsing,
  * symbolic differentiation, algebraic simplification, basic symbolic
- * integration, Taylor expansion, and numeric evaluation.
+ * integration, Taylor expansion, polynomial equation solving/factoring,
+ * limits, LaTeX rendering, and numeric evaluation.
  */
+import { Rational } from "./Rational.ts";
+import { SpecialFunctions } from "./SpecialFunctions.ts";
 
-export type FuncName = "sin" | "cos" | "tan" | "exp" | "ln" | "sqrt";
+export type FuncName =
+  | "sin"
+  | "cos"
+  | "tan"
+  | "exp"
+  | "ln"
+  | "sqrt"
+  | "asin"
+  | "acos"
+  | "atan"
+  | "sinh"
+  | "cosh"
+  | "tanh"
+  | "cot"
+  | "sec"
+  | "csc"
+  | "asinh"
+  | "acosh"
+  | "atanh"
+  | "coth"
+  | "sech"
+  | "csch"
+  | "acot"
+  | "asec"
+  | "acsc"
+  | "acoth"
+  | "asech"
+  | "acsch"
+  | "abs"
+  | "log10"
+  | "log2"
+  | "cbrt"
+  | "floor"
+  | "ceil"
+  | "round"
+  | "sign"
+  | "trunc"
+  | "expm1"
+  | "log1p"
+  | "sigmoid"
+  | "erf"
+  | "relu";
+
+/** Elementary functions that take exactly two `Expr` operands (see the `call2` `Expr` variant). */
+export type BinaryFuncName = "atan2" | "hypot" | "min" | "max" | "gcd" | "lcm";
 
 export type Expr =
   | { type: "const"; value: number }
@@ -15,9 +62,97 @@ export type Expr =
   | { type: "div"; left: Expr; right: Expr }
   | { type: "pow"; base: Expr; exp: Expr }
   | { type: "neg"; arg: Expr }
-  | { type: "func"; name: FuncName; arg: Expr };
+  | { type: "func"; name: FuncName; arg: Expr }
+  | { type: "call2"; name: BinaryFuncName; left: Expr; right: Expr };
 
-const FUNCS: FuncName[] = ["sin", "cos", "tan", "exp", "ln", "sqrt"];
+const FUNCS: FuncName[] = [
+  "sin",
+  "cos",
+  "tan",
+  "exp",
+  "ln",
+  "sqrt",
+  "asin",
+  "acos",
+  "atan",
+  "sinh",
+  "cosh",
+  "tanh",
+  "cot",
+  "sec",
+  "csc",
+  "asinh",
+  "acosh",
+  "atanh",
+  "coth",
+  "sech",
+  "csch",
+  "acot",
+  "asec",
+  "acsc",
+  "acoth",
+  "asech",
+  "acsch",
+  "abs",
+  "log10",
+  "log2",
+  "cbrt",
+  "floor",
+  "ceil",
+  "round",
+  "sign",
+  "trunc",
+  "expm1",
+  "log1p",
+  "sigmoid",
+  "erf",
+  "relu",
+];
+
+/**
+ * `BinaryFuncName`s recognized by {@link Symbolic.parse}. `hypot`/`min`/`max`/
+ * `gcd`/`lcm` accept N ≥ 2 user-facing arguments, pairwise-folded into nested
+ * `call2` nodes at parse time; `atan2` takes exactly 2. `log(base, x)` and
+ * `clamp(x, lo, hi)` are also multi-arg but desugar entirely into existing
+ * constructs at parse time rather than becoming `call2` nodes.
+ */
+const BINARY_FUNCS: BinaryFuncName[] = ["atan2", "hypot", "min", "max", "gcd", "lcm"];
+
+/**
+ * Alternate plain-text spellings accepted by {@link Symbolic.parse}, mapped to
+ * their canonical `FuncName` — e.g. `arcsin(x)` parses identically to
+ * `asin(x)`.
+ */
+const FUNC_ALIASES: Record<string, FuncName> = {
+  arcsin: "asin",
+  arccos: "acos",
+  arctan: "atan",
+  arcsinh: "asinh",
+  arccosh: "acosh",
+  arctanh: "atanh",
+  arccot: "acot",
+  arcsec: "asec",
+  arccsc: "acsc",
+  arccoth: "acoth",
+  arcsech: "asech",
+  arccsch: "acsch",
+  sgn: "sign",
+  logistic: "sigmoid",
+};
+
+/**
+ * Every function name {@link Symbolic.parse} recognizes — canonical spellings
+ * plus alternate ones like `arcsin` — for consumers (e.g. a UI's implicit-
+ * multiplication preprocessor) that need to know what counts as a known
+ * identifier without hand-duplicating this list.
+ */
+export const FUNCTION_NAMES: readonly string[] = [
+  ...FUNCS,
+  ...Object.keys(FUNC_ALIASES),
+  ...BINARY_FUNCS,
+  "log",
+  "clamp",
+];
 
 // -- constructors -----------------------------------------------------------
 const num = (value: number): Expr => ({ type: "const", value });
@@ -29,6 +164,7 @@ const div = (left: Expr, right: Expr): Expr => ({ type: "div", left, right });
 const pow = (base: Expr, exp: Expr): Expr => ({ type: "pow", base, exp });
 const neg = (arg: Expr): Expr => ({ type: "neg", arg });
 const fn = (name: FuncName, arg: Expr): Expr => ({ type: "func", name, arg });
+const call2 = (name: BinaryFuncName, left: Expr, right: Expr): Expr => ({ type: "call2", name, left, right });
 
 const isConst = (e: Expr, value?: number): boolean => e.type === "const" && (value === undefined || e.value === value);
 const containsVar = (e: Expr, name: string): boolean => {
@@ -83,7 +219,7 @@ export class Symbolic {
   static simplify(expr: Expr | string): Expr {
     let e = typeof expr === "string" ? Symbolic.parse(expr) : expr;
     for (let i = 0; i < 30; i++) {
-      const next = simplifyOnce(e);
+      const next = collectLikeTerms(simplifyOnce(e));
       if (equal(next, e)) return next;
       e = next;
     }
@@ -113,6 +249,25 @@ export class Symbolic {
     return Symbolic.simplify(result);
   }
 
+  /** Replace every occurrence of a variable with a sub-expression (e.g. for changing variables or plugging in a solved value). */
+  static substitute(expr: Expr | string, variable: string, replacement: Expr | string): Expr {
+    const e = typeof expr === "string" ? Symbolic.parse(expr) : expr;
+    const r = typeof replacement === "string" ? Symbolic.parse(replacement) : replacement;
+    return Symbolic.simplify(subst(e, variable, r));
+  }
+
+  /** Distribute multiplication over addition/subtraction and expand small integer powers of sums, e.g. `(x+1)^2 -> x^2+2*x+1`. */
+  static expand(expr: Expr | string): Expr {
+    const e = typeof expr === "string" ? Symbolic.parse(expr) : expr;
+    let cur = e;
+    for (let i = 0; i < 30; i++) {
+      const next = Symbolic.simplify(expandOnce(cur));
+      if (equal(next, cur)) return next;
+      cur = next;
+    }
+    return cur;
+  }
+
   static evaluate(expr: Expr | string, env: Record<string, number> = {}): number {
     const e = typeof expr === "string" ? Symbolic.parse(expr) : expr;
     return evalExpr(e, env);
@@ -130,6 +285,79 @@ export class Symbolic {
 
   static toString(expr: Expr | string): string {
     return render(typeof expr === "string" ? Symbolic.parse(expr) : expr, 0);
+  }
+
+  /** Render `expr` as a LaTeX string, e.g. `"x/2"` -> `"\\frac{x}{2}"`. */
+  static toLatex(expr: Expr | string): string {
+    return toLatexRec(typeof expr === "string" ? Symbolic.parse(expr) : expr, 0);
+  }
+
+  /**
+   * Parse a LaTeX math string into an `Expr` — the reverse of {@link toLatex}.
+   * Round-trips everything `toLatex` produces: `\frac{a}{b}`, `\sqrt{a}` /
+   * `\sqrt[3]{a}` (as `cbrt`) / `\sqrt[n]{a}`, `\left(...\right)`,
+   * `\left|...\right|` (absolute value), `\left\lfloor...\right\rfloor` /
+   * `\left\lceil...\right\rceil`, `\log_{10}`/`\log_{2}`, `\cdot`/`\times`,
+   * `\pi`, `^{...}` exponents, `_{...}` subscripts, the named unary function
+   * commands (`\sin`, `\arcsin`, `\sinh`, `\operatorname{sech}`, ...), and the
+   * two-argument `BinaryFuncName` commands (`\min`, `\max`, `\gcd`,
+   * `\operatorname{atan2}`, `\operatorname{hypot}`, `\operatorname{lcm}`).
+   * Spacing commands (`\,`, `\;`, `\!`, `\quad`) are ignored.
+   *
+   * @throws on LaTeX constructs with no `Expr` equivalent, e.g. `\int` or `\sum`.
+   */
+  static fromLatex(latex: string): Expr {
+    return Symbolic.parse(latexToInfix(latex));
+  }
+
+  /**
+   * Solve `expr = 0` for `variable`, returning every *real* root mallory-math
+   * can find as an exact `Expr` (rationals and `sqrt`-radicals where
+   * possible) — complex roots are not returned (e.g. `x^2 + 1` yields `[]`).
+   * Supports polynomials up to degree 6: linear and quadratic are solved in
+   * closed form; degree ≥ 3 is solved by repeatedly finding a rational root
+   * (rational root theorem) and deflating via synthetic division, so a cubic
+   * or quartic with only irrational/complex roots left over after rational
+   * deflation cannot be fully solved this way.
+   *
+   * @throws if `expr` isn't a polynomial in `variable` of degree ≤ 6, or if a
+   *   degree ≥ 3 factor has no rational root to deflate on.
+   */
+  static solve(expr: Expr | string, variable = "x"): Expr[] {
+    const e = typeof expr === "string" ? Symbolic.parse(expr) : expr;
+    const coeffs = polynomialCoeffs(Symbolic.simplify(e), variable, 6);
+    if (!coeffs) {
+      throw new Error(`solve: expression is not a polynomial in "${variable}" of degree ≤ 6.`);
+    }
+    return solvePolynomial(coeffs).map((r) => Symbolic.simplify(r));
+  }
+
+  /**
+   * Factor a polynomial in `variable`: extracts a common numeric GCD and
+   * common power of `variable`, then repeatedly pulls out rational linear
+   * factors `(variable - r)` via the rational root theorem, falling back to
+   * the quadratic formula for a final degree-2 remainder. Any remaining
+   * factor mallory-math can't reduce further (e.g. an irreducible cubic) is
+   * left as-is. Returns `expr` unchanged (simplified) if it isn't a
+   * polynomial in `variable`.
+   */
+  static factor(expr: Expr | string, variable = "x"): Expr {
+    const e = typeof expr === "string" ? Symbolic.parse(expr) : expr;
+    const simplified = Symbolic.simplify(e);
+    const coeffs = polynomialCoeffs(simplified, variable, 6);
+    if (!coeffs) return simplified;
+    return factorPolynomial(coeffs, variable);
+  }
+
+  /**
+   * Numeric limit of `expr` as `variable` approaches `point`. Falls back to
+   * L'Hopital's rule (repeated symbolic differentiation of numerator and
+   * denominator) whenever direct evaluation of a `div` node hits a `0/0` or
+   * `∞/∞` indeterminate form.
+   */
+  static limit(expr: Expr | string, variable = "x", point = 0, direction: "left" | "right" | "both" = "both"): number {
+    const e = typeof expr === "string" ? Symbolic.parse(expr) : expr;
+    return limitAt(e, variable, point, direction, 0);
   }
 }
 
@@ -186,7 +414,13 @@ function diffTraced(e: Expr, x: string, steps: DifferentiationStep[]): Expr {
         result = mul(mul(e.exp, pow(e.base, num(e.exp.value - 1))), diffTraced(e.base, x, steps));
       } else {
         rule = "Generalized Power Rule";
-        result = mul(e, add(mul(diffTraced(e.exp, x, steps), fn("ln", e.base)), mul(e.exp, div(diffTraced(e.base, x, steps), e.base))));
+        result = mul(
+          e,
+          add(
+            mul(diffTraced(e.exp, x, steps), fn("ln", e.base)),
+            mul(e.exp, div(diffTraced(e.base, x, steps), e.base)),
+          ),
+        );
       }
       break;
     case "func": {
@@ -211,6 +445,129 @@ function diffTraced(e: Expr, x: string, steps: DifferentiationStep[]): Expr {
           break;
         case "sqrt":
           result = div(du, mul(num(2), fn("sqrt", u)));
+          break;
+        case "asin":
+          result = div(du, fn("sqrt", sub(num(1), pow(u, num(2)))));
+          break;
+        case "acos":
+          result = neg(div(du, fn("sqrt", sub(num(1), pow(u, num(2))))));
+          break;
+        case "atan":
+          result = div(du, add(num(1), pow(u, num(2))));
+          break;
+        case "sinh":
+          result = mul(fn("cosh", u), du);
+          break;
+        case "cosh":
+          result = mul(fn("sinh", u), du);
+          break;
+        case "tanh":
+          result = div(du, pow(fn("cosh", u), num(2)));
+          break;
+        case "cot":
+          result = neg(mul(pow(fn("csc", u), num(2)), du));
+          break;
+        case "sec":
+          result = mul(mul(fn("sec", u), fn("tan", u)), du);
+          break;
+        case "csc":
+          result = neg(mul(mul(fn("csc", u), fn("cot", u)), du));
+          break;
+        case "asinh":
+          result = div(du, fn("sqrt", add(pow(u, num(2)), num(1))));
+          break;
+        case "acosh":
+          result = div(du, fn("sqrt", sub(pow(u, num(2)), num(1))));
+          break;
+        case "atanh":
+          result = div(du, sub(num(1), pow(u, num(2))));
+          break;
+        case "coth":
+          result = neg(mul(pow(fn("csch", u), num(2)), du));
+          break;
+        case "sech":
+          result = neg(mul(mul(fn("sech", u), fn("tanh", u)), du));
+          break;
+        case "csch":
+          result = neg(mul(mul(fn("csch", u), fn("coth", u)), du));
+          break;
+        case "acot":
+          result = neg(div(du, add(num(1), pow(u, num(2)))));
+          break;
+        case "asec":
+          result = div(du, mul(fn("abs", u), fn("sqrt", sub(pow(u, num(2)), num(1)))));
+          break;
+        case "acsc":
+          result = neg(div(du, mul(fn("abs", u), fn("sqrt", sub(pow(u, num(2)), num(1))))));
+          break;
+        case "acoth":
+          result = div(du, sub(num(1), pow(u, num(2))));
+          break;
+        case "asech":
+          result = neg(div(du, mul(u, fn("sqrt", sub(num(1), pow(u, num(2)))))));
+          break;
+        case "acsch":
+          result = neg(div(du, mul(fn("abs", u), fn("sqrt", add(num(1), pow(u, num(2)))))));
+          break;
+        case "abs":
+          result = mul(fn("sign", u), du);
+          break;
+        case "log10":
+          result = div(du, mul(u, fn("ln", num(10))));
+          break;
+        case "log2":
+          result = div(du, mul(u, fn("ln", num(2))));
+          break;
+        case "cbrt":
+          result = div(du, mul(num(3), pow(fn("cbrt", u), num(2))));
+          break;
+        case "floor":
+        case "ceil":
+        case "round":
+        case "sign":
+        case "trunc":
+          result = num(0);
+          break;
+        case "expm1":
+          result = mul(fn("exp", u), du);
+          break;
+        case "log1p":
+          result = div(du, add(num(1), u));
+          break;
+        case "sigmoid":
+          result = mul(mul(fn("sigmoid", u), sub(num(1), fn("sigmoid", u))), du);
+          break;
+        case "erf":
+          result = mul(mul(div(num(2), fn("sqrt", num(Math.PI))), fn("exp", neg(pow(u, num(2))))), du);
+          break;
+        case "relu":
+          result = mul(div(add(num(1), fn("sign", u)), num(2)), du);
+          break;
+      }
+      break;
+    }
+    case "call2": {
+      rule = `Multivariable Chain Rule (${e.name})`;
+      const l = e.left;
+      const r = e.right;
+      const dl = diffTraced(l, x, steps);
+      const dr = diffTraced(r, x, steps);
+      switch (e.name) {
+        case "atan2":
+          result = div(sub(mul(r, dl), mul(l, dr)), add(pow(l, num(2)), pow(r, num(2))));
+          break;
+        case "hypot":
+          result = div(add(mul(l, dl), mul(r, dr)), call2("hypot", l, r));
+          break;
+        case "min":
+          result = sub(div(add(dl, dr), num(2)), mul(fn("sign", sub(l, r)), div(sub(dl, dr), num(2))));
+          break;
+        case "max":
+          result = add(div(add(dl, dr), num(2)), mul(fn("sign", sub(l, r)), div(sub(dl, dr), num(2))));
+          break;
+        case "gcd":
+        case "lcm":
+          result = num(0);
           break;
       }
       break;
@@ -247,7 +604,8 @@ function diff(e: Expr, x: string): Expr {
     case "func": {
       const u = e.arg;
       const du = diff(u, x);
-      switch (e.name) {
+      const name = e.name;
+      switch (name) {
         case "sin":
           return mul(fn("cos", u), du);
         case "cos":
@@ -260,6 +618,92 @@ function diff(e: Expr, x: string): Expr {
           return div(du, u);
         case "sqrt":
           return div(du, mul(num(2), fn("sqrt", u)));
+        case "asin":
+          return div(du, fn("sqrt", sub(num(1), pow(u, num(2)))));
+        case "acos":
+          return neg(div(du, fn("sqrt", sub(num(1), pow(u, num(2))))));
+        case "atan":
+          return div(du, add(num(1), pow(u, num(2))));
+        case "sinh":
+          return mul(fn("cosh", u), du);
+        case "cosh":
+          return mul(fn("sinh", u), du);
+        case "tanh":
+          return div(du, pow(fn("cosh", u), num(2)));
+        case "cot":
+          return neg(mul(pow(fn("csc", u), num(2)), du));
+        case "sec":
+          return mul(mul(fn("sec", u), fn("tan", u)), du);
+        case "csc":
+          return neg(mul(mul(fn("csc", u), fn("cot", u)), du));
+        case "asinh":
+          return div(du, fn("sqrt", add(pow(u, num(2)), num(1))));
+        case "acosh":
+          return div(du, fn("sqrt", sub(pow(u, num(2)), num(1))));
+        case "atanh":
+          return div(du, sub(num(1), pow(u, num(2))));
+        case "coth":
+          return neg(mul(pow(fn("csch", u), num(2)), du));
+        case "sech":
+          return neg(mul(mul(fn("sech", u), fn("tanh", u)), du));
+        case "csch":
+          return neg(mul(mul(fn("csch", u), fn("coth", u)), du));
+        case "acot":
+          return neg(div(du, add(num(1), pow(u, num(2)))));
+        case "asec":
+          return div(du, mul(fn("abs", u), fn("sqrt", sub(pow(u, num(2)), num(1)))));
+        case "acsc":
+          return neg(div(du, mul(fn("abs", u), fn("sqrt", sub(pow(u, num(2)), num(1))))));
+        case "acoth":
+          return div(du, sub(num(1), pow(u, num(2))));
+        case "asech":
+          return neg(div(du, mul(u, fn("sqrt", sub(num(1), pow(u, num(2)))))));
+        case "acsch":
+          return neg(div(du, mul(fn("abs", u), fn("sqrt", add(num(1), pow(u, num(2)))))));
+        case "abs":
+          return mul(fn("sign", u), du);
+        case "log10":
+          return div(du, mul(u, fn("ln", num(10))));
+        case "log2":
+          return div(du, mul(u, fn("ln", num(2))));
+        case "cbrt":
+          return div(du, mul(num(3), pow(fn("cbrt", u), num(2))));
+        case "floor":
+        case "ceil":
+        case "round":
+        case "sign":
+        case "trunc":
+          return num(0);
+        case "expm1":
+          return mul(fn("exp", u), du);
+        case "log1p":
+          return div(du, add(num(1), u));
+        case "sigmoid":
+          return mul(mul(fn("sigmoid", u), sub(num(1), fn("sigmoid", u))), du);
+        case "erf":
+          return mul(mul(div(num(2), fn("sqrt", num(Math.PI))), fn("exp", neg(pow(u, num(2))))), du);
+        case "relu":
+          return mul(div(add(num(1), fn("sign", u)), num(2)), du);
+      }
+      throw new Error(`Unhandled function: ${name}`);
+    }
+    case "call2": {
+      const l = e.left;
+      const r = e.right;
+      const dl = diff(l, x);
+      const dr = diff(r, x);
+      switch (e.name) {
+        case "atan2":
+          return div(sub(mul(r, dl), mul(l, dr)), add(pow(l, num(2)), pow(r, num(2))));
+        case "hypot":
+          return div(add(mul(l, dl), mul(r, dr)), call2("hypot", l, r));
+        case "min":
+          return sub(div(add(dl, dr), num(2)), mul(fn("sign", sub(l, r)), div(sub(dl, dr), num(2))));
+        case "max":
+          return add(div(add(dl, dr), num(2)), mul(fn("sign", sub(l, r)), div(sub(dl, dr), num(2))));
+        case "gcd":
+        case "lcm":
+          return num(0);
       }
     }
   }
@@ -275,6 +719,12 @@ function simplifyOnce(e: Expr): Expr {
     return neg(a);
   }
   if (e.type === "func") return fn(e.name, simplifyOnce(e.arg));
+  if (e.type === "call2") {
+    const l = simplifyOnce(e.left);
+    const r = simplifyOnce(e.right);
+    if (l.type === "const" && r.type === "const") return num(BINARY_FUNC_IMPLS[e.name](l.value, r.value));
+    return call2(e.name, l, r);
+  }
   if (e.type === "pow") {
     const b = simplifyOnce(e.base);
     const p = simplifyOnce(e.exp);
@@ -327,11 +777,221 @@ function equal(a: Expr, b: Expr): boolean {
       return equal(a.arg, (b as typeof a).arg);
     case "func":
       return a.name === (b as typeof a).name && equal(a.arg, (b as typeof a).arg);
+    case "call2":
+      return (
+        a.name === (b as typeof a).name && equal(a.left, (b as typeof a).left) && equal(a.right, (b as typeof a).right)
+      );
     case "pow":
       return equal(a.base, (b as typeof a).base) && equal(a.exp, (b as typeof a).exp);
     default:
       return equal(a.left, (b as typeof a).left) && equal(a.right, (b as typeof a).right);
   }
+}
+
+// -- substitution -------------------------------------------------------------
+function subst(e: Expr, name: string, r: Expr): Expr {
+  switch (e.type) {
+    case "const":
+      return e;
+    case "var":
+      return e.name === name ? r : e;
+    case "neg":
+      return neg(subst(e.arg, name, r));
+    case "func":
+      return fn(e.name, subst(e.arg, name, r));
+    case "call2":
+      return call2(e.name, subst(e.left, name, r), subst(e.right, name, r));
+    case "pow":
+      return pow(subst(e.base, name, r), subst(e.exp, name, r));
+    case "add":
+      return add(subst(e.left, name, r), subst(e.right, name, r));
+    case "sub":
+      return sub(subst(e.left, name, r), subst(e.right, name, r));
+    case "mul":
+      return mul(subst(e.left, name, r), subst(e.right, name, r));
+    case "div":
+      return div(subst(e.left, name, r), subst(e.right, name, r));
+  }
+}
+
+// -- expansion ----------------------------------------------------------------
+const MAX_EXPAND_POWER = 8;
+
+function expandOnce(e: Expr): Expr {
+  switch (e.type) {
+    case "const":
+    case "var":
+      return e;
+    case "neg":
+      return neg(expandOnce(e.arg));
+    case "func":
+      return fn(e.name, expandOnce(e.arg));
+    case "call2":
+      return call2(e.name, expandOnce(e.left), expandOnce(e.right));
+    case "add":
+      return add(expandOnce(e.left), expandOnce(e.right));
+    case "sub":
+      return sub(expandOnce(e.left), expandOnce(e.right));
+    case "div":
+      return div(expandOnce(e.left), expandOnce(e.right));
+    case "pow": {
+      const base = expandOnce(e.base);
+      if (
+        e.exp.type === "const" &&
+        Number.isInteger(e.exp.value) &&
+        e.exp.value >= 2 &&
+        e.exp.value <= MAX_EXPAND_POWER &&
+        (base.type === "add" || base.type === "sub")
+      ) {
+        let result: Expr = base;
+        for (let i = 1; i < e.exp.value; i++) result = distribute(result, base);
+        return result;
+      }
+      return pow(base, expandOnce(e.exp));
+    }
+    case "mul":
+      return distribute(expandOnce(e.left), expandOnce(e.right));
+  }
+}
+
+/** Distribute a product over any top-level +/- structure on either side. */
+function distribute(l: Expr, r: Expr): Expr {
+  if (l.type === "add") return add(distribute(l.left, r), distribute(l.right, r));
+  if (l.type === "sub") return sub(distribute(l.left, r), distribute(l.right, r));
+  if (r.type === "add") return add(distribute(l, r.left), distribute(l, r.right));
+  if (r.type === "sub") return sub(distribute(l, r.left), distribute(l, r.right));
+  return mul(l, r);
+}
+
+// -- like-term collection -----------------------------------------------------
+// Recognizes commutative/associative equivalence that raw tree-structural
+// `equal()` misses — e.g. `x + x` -> `2*x`, `a*b + b*a` -> `2*a*b`,
+// `x*x*x` -> `x^3` — by flattening a subtree into a canonical sum-of-monomials
+// form, grouping monomials with matching (sorted) factor signatures, and
+// rebuilding. Recurses into every sub-position, so nested sums (inside a
+// `func` arg, a `mul` factor, etc.) get collected too.
+
+interface Factor {
+  base: Expr;
+  exp: number;
+}
+interface Term {
+  coeff: number;
+  factors: Factor[];
+}
+
+function collectLikeTerms(e: Expr): Expr {
+  switch (e.type) {
+    case "const":
+    case "var":
+      return e;
+    case "func":
+      return fn(e.name, collectLikeTerms(e.arg));
+    case "call2":
+      return call2(e.name, collectLikeTerms(e.left), collectLikeTerms(e.right));
+    case "div":
+      return div(collectLikeTerms(e.left), collectLikeTerms(e.right));
+    case "pow":
+      return pow(collectLikeTerms(e.base), collectLikeTerms(e.exp));
+    case "neg":
+    case "add":
+    case "sub":
+    case "mul": {
+      const terms: Term[] = [];
+      flattenAdditive(e, 1, terms);
+      return rebuildAdditive(groupTerms(terms));
+    }
+  }
+}
+
+function flattenAdditive(e: Expr, sign: number, out: Term[]): void {
+  if (e.type === "add") {
+    flattenAdditive(e.left, sign, out);
+    flattenAdditive(e.right, sign, out);
+    return;
+  }
+  if (e.type === "sub") {
+    flattenAdditive(e.left, sign, out);
+    flattenAdditive(e.right, -sign, out);
+    return;
+  }
+  if (e.type === "neg") {
+    flattenAdditive(e.arg, -sign, out);
+    return;
+  }
+  const term = flattenMonomial(e);
+  out.push({ coeff: term.coeff * sign, factors: term.factors });
+}
+
+function flattenMonomial(e: Expr): Term {
+  if (e.type === "const") return { coeff: e.value, factors: [] };
+  if (e.type === "neg") {
+    const inner = flattenMonomial(e.arg);
+    return { coeff: -inner.coeff, factors: inner.factors };
+  }
+  if (e.type === "mul") {
+    const l = flattenMonomial(e.left);
+    const r = flattenMonomial(e.right);
+    return mergeFactors(l.coeff * r.coeff, [...l.factors, ...r.factors]);
+  }
+  // a power with a constant exponent contributes a single (base, exp) factor;
+  // the base itself is collected so nested sums inside it are also handled.
+  if (e.type === "pow" && e.exp.type === "const") {
+    return mergeFactors(1, [{ base: collectLikeTerms(e.base), exp: e.exp.value }]);
+  }
+  // opaque atom (var, func, div, or pow with a non-constant exponent)
+  return mergeFactors(1, [{ base: collectLikeTerms(e), exp: 1 }]);
+}
+
+function mergeFactors(coeff: number, factors: Factor[]): Term {
+  const merged: Factor[] = [];
+  for (const f of factors) {
+    const existing = merged.find((m) => equal(m.base, f.base));
+    if (existing) existing.exp += f.exp;
+    else merged.push({ ...f });
+  }
+  return { coeff, factors: merged.filter((f) => f.exp !== 0) };
+}
+
+function groupTerms(terms: Term[]): Term[] {
+  const groups = new Map<string, Term>();
+  const order: string[] = [];
+  for (const t of terms) {
+    const sorted = [...t.factors].sort((a, b) => render(a.base, 0).localeCompare(render(b.base, 0)));
+    const key = sorted.map((f) => `${render(f.base, 0)}^${f.exp}`).join("*");
+    const existing = groups.get(key);
+    if (existing) existing.coeff += t.coeff;
+    else {
+      groups.set(key, { coeff: t.coeff, factors: sorted });
+      order.push(key);
+    }
+  }
+  return order.map((k) => groups.get(k) as Term).filter((t) => t.coeff !== 0);
+}
+
+function buildMonomial(factors: Factor[]): Expr | null {
+  let result: Expr | null = null;
+  for (const f of factors) {
+    const factorExpr = f.exp === 1 ? f.base : pow(f.base, num(f.exp));
+    result = result === null ? factorExpr : mul(result, factorExpr);
+  }
+  return result;
+}
+
+function rebuildAdditive(terms: Term[]): Expr {
+  let result: Expr | null = null;
+  for (const t of terms) {
+    const monomial = buildMonomial(t.factors);
+    const magnitude = Math.abs(t.coeff);
+    const positivePart: Expr =
+      monomial === null ? num(magnitude) : magnitude === 1 ? monomial : mul(num(magnitude), monomial);
+    if (result === null) {
+      result = t.coeff < 0 ? neg(positivePart) : positivePart;
+    } else {
+      result = t.coeff < 0 ? sub(result, positivePart) : add(result, positivePart);
+    }
+  }
+  return result ?? num(0);
 }
 
 // -- integration (elementary) ----------------------------------------------
@@ -350,12 +1010,40 @@ function integ(e: Expr, x: string): Expr {
       // pull out a constant factor
       if (!containsVar(e.left, x)) return mul(e.left, integ(e.right, x));
       if (!containsVar(e.right, x)) return mul(e.right, integ(e.left, x));
+      // integration by parts: ∫ x^n · f(a·x + b) dx, f ∈ {sin, cos, exp}
+      for (const [poly, other] of [
+        [e.left, e.right],
+        [e.right, e.left],
+      ] as const) {
+        const n = xPowerDegree(poly, x);
+        if (n !== null && other.type === "func" && isByPartsFunc(other.name) && linearCoeffs(other.arg, x)) {
+          return ibpPolyTimesFunc(n, other, x);
+        }
+      }
       throw new NotIntegrableError();
     }
     case "div": {
       if (!containsVar(e.right, x)) return div(integ(e.left, x), e.right); // ∫ u/c
       // 1/x -> ln x
       if (isConst(e.left, 1) && e.right.type === "var" && e.right.name === x) return fn("ln", v(x));
+      // numerator constant wrt x — check rational/radical forms with an x^2 denominator
+      if (!containsVar(e.left, x)) {
+        const c = evalExpr(e.left, {});
+        // ∫ c / (x^2 + k) dx = (c/√k)·atan(x/√k)   (k > 0, no linear term)
+        const quad = quadraticCoeffs(e.right, x);
+        if (quad && Math.abs(quad.a - 1) < 1e-9 && Math.abs(quad.b) < 1e-9 && quad.c > 0) {
+          const s = Math.sqrt(quad.c);
+          return mul(num(c / s), fn("atan", div(v(x), num(s))));
+        }
+        // ∫ c / √(k - x^2) dx = c·asin(x/√k)   (k > 0)
+        if (e.right.type === "func" && e.right.name === "sqrt") {
+          const under = quadraticCoeffs(e.right.arg, x);
+          if (under && Math.abs(under.a + 1) < 1e-9 && Math.abs(under.b) < 1e-9 && under.c > 0) {
+            const s = Math.sqrt(under.c);
+            return mul(num(c), fn("asin", div(v(x), num(s))));
+          }
+        }
+      }
       throw new NotIntegrableError();
     }
     case "pow": {
@@ -405,6 +1093,56 @@ function linearCoeffs(e: Expr, x: string): { a: number; b: number } | null {
   }
 }
 
+/** If `e` is `a·x^2 + b·x + c` (a, b, c constant), return `{ a, b, c }`, else `null`. */
+function quadraticCoeffs(e: Expr, x: string): { a: number; b: number; c: number } | null {
+  try {
+    const at0 = evalExpr(e, { [x]: 0 });
+    const at1 = evalExpr(e, { [x]: 1 });
+    const atm1 = evalExpr(e, { [x]: -1 });
+    const c = at0;
+    const a = (at1 + atm1) / 2 - c;
+    const b = (at1 - atm1) / 2;
+    // verify quadratic-ness at a fourth point
+    const at2 = evalExpr(e, { [x]: 2 });
+    if (Math.abs(at2 - (4 * a + 2 * b + c)) > 1e-9) return null;
+    if (![a, b, c].every(Number.isFinite)) return null;
+    return { a, b, c };
+  } catch {
+    return null;
+  }
+}
+
+/** If `e` is `x` or `x^n` (positive integer n), return `n`, else `null`. */
+function xPowerDegree(e: Expr, x: string): number | null {
+  if (e.type === "var" && e.name === x) return 1;
+  if (
+    e.type === "pow" &&
+    e.base.type === "var" &&
+    e.base.name === x &&
+    e.exp.type === "const" &&
+    Number.isInteger(e.exp.value) &&
+    e.exp.value >= 1
+  ) {
+    return e.exp.value;
+  }
+  return null;
+}
+
+const BY_PARTS_FUNCS = new Set<FuncName>(["sin", "cos", "exp"]);
+function isByPartsFunc(name: FuncName): boolean {
+  return BY_PARTS_FUNCS.has(name);
+}
+
+/** ∫ x^n · f dx via repeated integration by parts, reducing the polynomial degree by 1 each step. */
+function ibpPolyTimesFunc(n: number, f: Expr, x: string): Expr {
+  if (n === 0) return integ(f, x);
+  const antideriv = integ(f, x);
+  const xn = n === 1 ? v(x) : pow(v(x), num(n));
+  const term = mul(xn, antideriv);
+  const rest = ibpPolyTimesFunc(n - 1, antideriv, x);
+  return sub(term, mul(num(n), rest));
+}
+
 // -- evaluation -------------------------------------------------------------
 function evalExpr(e: Expr, env: Record<string, number>): number {
   switch (e.type) {
@@ -426,7 +1164,8 @@ function evalExpr(e: Expr, env: Record<string, number>): number {
       return -evalExpr(e.arg, env);
     case "func": {
       const a = evalExpr(e.arg, env);
-      switch (e.name) {
+      const name = e.name;
+      switch (name) {
         case "sin":
           return Math.sin(a);
         case "cos":
@@ -439,12 +1178,101 @@ function evalExpr(e: Expr, env: Record<string, number>): number {
           return Math.log(a);
         case "sqrt":
           return Math.sqrt(a);
+        case "asin":
+          return Math.asin(a);
+        case "acos":
+          return Math.acos(a);
+        case "atan":
+          return Math.atan(a);
+        case "sinh":
+          return Math.sinh(a);
+        case "cosh":
+          return Math.cosh(a);
+        case "tanh":
+          return Math.tanh(a);
+        case "cot":
+          return cotImpl(a);
+        case "sec":
+          return secImpl(a);
+        case "csc":
+          return cscImpl(a);
+        case "asinh":
+          return Math.asinh(a);
+        case "acosh":
+          return Math.acosh(a);
+        case "atanh":
+          return Math.atanh(a);
+        case "coth":
+          return cothImpl(a);
+        case "sech":
+          return sechImpl(a);
+        case "csch":
+          return cschImpl(a);
+        case "acot":
+          return acotImpl(a);
+        case "asec":
+          return asecImpl(a);
+        case "acsc":
+          return acscImpl(a);
+        case "acoth":
+          return acothImpl(a);
+        case "asech":
+          return asechImpl(a);
+        case "acsch":
+          return acschImpl(a);
+        case "abs":
+          return Math.abs(a);
+        case "log10":
+          return Math.log10(a);
+        case "log2":
+          return Math.log2(a);
+        case "cbrt":
+          return Math.cbrt(a);
+        case "floor":
+          return Math.floor(a);
+        case "ceil":
+          return Math.ceil(a);
+        case "round":
+          return Math.round(a);
+        case "sign":
+          return Math.sign(a);
+        case "trunc":
+          return Math.trunc(a);
+        case "expm1":
+          return Math.expm1(a);
+        case "log1p":
+          return Math.log1p(a);
+        case "sigmoid":
+          return sigmoidImpl(a);
+        case "erf":
+          return SpecialFunctions.erf(a);
+        case "relu":
+          return Math.max(a, 0);
       }
+      throw new Error(`Unhandled function: ${name}`);
     }
+    case "call2":
+      return BINARY_FUNC_IMPLS[e.name](evalExpr(e.left, env), evalExpr(e.right, env));
   }
 }
 
 // -- compilation --------------------------------------------------------------
+const cotImpl = (x: number): number => 1 / Math.tan(x);
+const secImpl = (x: number): number => 1 / Math.cos(x);
+const cscImpl = (x: number): number => 1 / Math.sin(x);
+const cothImpl = (x: number): number => 1 / Math.tanh(x);
+const sechImpl = (x: number): number => 1 / Math.cosh(x);
+const cschImpl = (x: number): number => 1 / Math.sinh(x);
+// Inverse reciprocal-trig/hyperbolic functions expressed via their reciprocal-argument
+// counterparts (e.g. arcsec(x) = arccos(1/x)) — JS's Math object has no direct equivalents.
+const acotImpl = (x: number): number => Math.PI / 2 - Math.atan(x);
+const asecImpl = (x: number): number => Math.acos(1 / x);
+const acscImpl = (x: number): number => Math.asin(1 / x);
+const acothImpl = (x: number): number => Math.atanh(1 / x);
+const asechImpl = (x: number): number => Math.acosh(1 / x);
+const acschImpl = (x: number): number => Math.asinh(1 / x);
+const sigmoidImpl = (x: number): number => 1 / (1 + Math.exp(-x));
+
 const FUNC_IMPLS: Record<FuncName, (x: number) => number> = {
   sin: Math.sin,
   cos: Math.cos,
@@ -452,6 +1280,50 @@ const FUNC_IMPLS: Record<FuncName, (x: number) => number> = {
   exp: Math.exp,
   ln: Math.log,
   sqrt: Math.sqrt,
+  asin: Math.asin,
+  acos: Math.acos,
+  atan: Math.atan,
+  sinh: Math.sinh,
+  cosh: Math.cosh,
+  tanh: Math.tanh,
+  cot: cotImpl,
+  sec: secImpl,
+  csc: cscImpl,
+  asinh: Math.asinh,
+  acosh: Math.acosh,
+  atanh: Math.atanh,
+  coth: cothImpl,
+  sech: sechImpl,
+  csch: cschImpl,
+  acot: acotImpl,
+  asec: asecImpl,
+  acsc: acscImpl,
+  acoth: acothImpl,
+  asech: asechImpl,
+  acsch: acschImpl,
+  abs: Math.abs,
+  log10: Math.log10,
+  log2: Math.log2,
+  cbrt: Math.cbrt,
+  floor: Math.floor,
+  ceil: Math.ceil,
+  round: Math.round,
+  sign: Math.sign,
+  trunc: Math.trunc,
+  expm1: Math.expm1,
+  log1p: Math.log1p,
+  sigmoid: sigmoidImpl,
+  erf: SpecialFunctions.erf,
+  relu: (x: number) => Math.max(x, 0),
+};
+
+const BINARY_FUNC_IMPLS: Record<BinaryFuncName, (a: number, b: number) => number> = {
+  atan2: Math.atan2,
+  hypot: Math.hypot,
+  min: Math.min,
+  max: Math.max,
+  gcd: intGcd,
+  lcm: (a, b) => Math.abs(a * b) / intGcd(a, b),
 };
 
 function compileExpr(e: Expr): (env: Record<string, number>) => number {
@@ -498,6 +1370,12 @@ function compileExpr(e: Expr): (env: Record<string, number>) => number {
       const impl = FUNC_IMPLS[e.name];
       return (env) => impl(a(env));
     }
+    case "call2": {
+      const l = compileExpr(e.left);
+      const r = compileExpr(e.right);
+      const impl = BINARY_FUNC_IMPLS[e.name];
+      return (env) => impl(l(env), r(env));
+    }
   }
 }
 
@@ -511,6 +1389,8 @@ function render(e: Expr, parentPrec: number): string {
       return e.name;
     case "func":
       return `${e.name}(${render(e.arg, 0)})`;
+    case "call2":
+      return `${e.name}(${render(e.left, 0)}, ${render(e.right, 0)})`;
     case "neg":
       return wrap(`-${render(e.arg, PREC.neg)}`, PREC.neg, parentPrec);
     case "pow":
@@ -526,6 +1406,546 @@ function render(e: Expr, parentPrec: number): string {
   }
 }
 const wrap = (s: string, prec: number, parentPrec: number): string => (prec < parentPrec ? `(${s})` : s);
+
+// -- LaTeX rendering ----------------------------------------------------------
+const LATEX_FUNCS: Partial<Record<FuncName, string>> = {
+  sin: "\\sin",
+  cos: "\\cos",
+  tan: "\\tan",
+  exp: "\\exp",
+  ln: "\\ln",
+  asin: "\\arcsin",
+  acos: "\\arccos",
+  atan: "\\arctan",
+  sinh: "\\sinh",
+  cosh: "\\cosh",
+  tanh: "\\tanh",
+  cot: "\\cot",
+  sec: "\\sec",
+  csc: "\\csc",
+  coth: "\\coth",
+  // \sech/\csch and arc-hyperbolic names aren't standard LaTeX commands —
+  // render via \operatorname, same convention KaTeX/MathJax use for them.
+  sech: "\\operatorname{sech}",
+  csch: "\\operatorname{csch}",
+  asinh: "\\operatorname{arcsinh}",
+  acosh: "\\operatorname{arccosh}",
+  atanh: "\\operatorname{arctanh}",
+  acot: "\\operatorname{arccot}",
+  asec: "\\operatorname{arcsec}",
+  acsc: "\\operatorname{arccsc}",
+  acoth: "\\operatorname{arccoth}",
+  asech: "\\operatorname{arcsech}",
+  acsch: "\\operatorname{arccsch}",
+  round: "\\operatorname{round}",
+  sign: "\\operatorname{sgn}",
+  trunc: "\\operatorname{trunc}",
+  expm1: "\\operatorname{expm1}",
+  log1p: "\\operatorname{log1p}",
+  sigmoid: "\\operatorname{sigmoid}",
+  erf: "\\operatorname{erf}",
+  relu: "\\operatorname{relu}",
+};
+
+/** LaTeX commands for `BinaryFuncName`s — `\min`/`\max`/`\gcd` are standard LaTeX; the rest use `\operatorname`. */
+const LATEX_BINARY_FUNCS: Record<BinaryFuncName, string> = {
+  atan2: "\\operatorname{atan2}",
+  hypot: "\\operatorname{hypot}",
+  min: "\\min",
+  max: "\\max",
+  gcd: "\\gcd",
+  lcm: "\\operatorname{lcm}",
+};
+
+function toLatexRec(e: Expr, parentPrec: number): string {
+  switch (e.type) {
+    case "const":
+      if (Math.abs(e.value - Math.PI) < 1e-12) return "\\pi";
+      if (Math.abs(e.value - Math.E) < 1e-12) return "e";
+      return `${e.value}`;
+    case "var":
+      return e.name;
+    case "func":
+      if (e.name === "sqrt") return `\\sqrt{${toLatexRec(e.arg, 0)}}`;
+      if (e.name === "cbrt") return `\\sqrt[3]{${toLatexRec(e.arg, 0)}}`;
+      if (e.name === "abs") return `\\left|${toLatexRec(e.arg, 0)}\\right|`;
+      if (e.name === "floor") return `\\left\\lfloor ${toLatexRec(e.arg, 0)}\\right\\rfloor`;
+      if (e.name === "ceil") return `\\left\\lceil ${toLatexRec(e.arg, 0)}\\right\\rceil`;
+      if (e.name === "log10") return `\\log_{10}\\left(${toLatexRec(e.arg, 0)}\\right)`;
+      if (e.name === "log2") return `\\log_{2}\\left(${toLatexRec(e.arg, 0)}\\right)`;
+      return `${LATEX_FUNCS[e.name]}\\left(${toLatexRec(e.arg, 0)}\\right)`;
+    case "call2":
+      return `${LATEX_BINARY_FUNCS[e.name]}\\left(${toLatexRec(e.left, 0)}, ${toLatexRec(e.right, 0)}\\right)`;
+    case "neg":
+      return wrap(`-${toLatexRec(e.arg, PREC.neg)}`, PREC.neg, parentPrec);
+    case "pow":
+      return wrap(`${toLatexRec(e.base, PREC.pow + 1)}^{${toLatexRec(e.exp, 0)}}`, PREC.pow, parentPrec);
+    case "add":
+      return wrap(`${toLatexRec(e.left, PREC.add)} + ${toLatexRec(e.right, PREC.add)}`, PREC.add, parentPrec);
+    case "sub":
+      return wrap(`${toLatexRec(e.left, PREC.sub)} - ${toLatexRec(e.right, PREC.sub + 1)}`, PREC.sub, parentPrec);
+    case "mul":
+      return wrap(`${toLatexRec(e.left, PREC.mul)} \\cdot ${toLatexRec(e.right, PREC.mul + 1)}`, PREC.mul, parentPrec);
+    case "div":
+      // \frac is self-delimiting — never needs outer parens.
+      return `\\frac{${toLatexRec(e.left, 0)}}{${toLatexRec(e.right, 0)}}`;
+  }
+}
+
+// -- LaTeX parsing (fromLatex) ------------------------------------------------
+const LATEX_FUNC_NAMES: Partial<Record<string, FuncName>> = Object.fromEntries(
+  Object.entries(LATEX_FUNCS)
+    .filter(([, latex]) => !latex.startsWith("\\operatorname"))
+    .map(([name, latex]) => [latex, name as FuncName]),
+);
+
+/** Reverse lookup for the `\operatorname{name}` functions in {@link LATEX_FUNCS} (e.g. `sech` -> `"sech"`). */
+const OPERATORNAME_FUNC_NAMES: Partial<Record<string, FuncName>> = Object.fromEntries(
+  Object.entries(LATEX_FUNCS)
+    .filter((entry): entry is [string, string] => entry[1].startsWith("\\operatorname"))
+    .map(([name, latex]) => [/\\operatorname\{(\w+)\}/.exec(latex)?.[1], name as FuncName]),
+);
+
+/** Reverse lookup for the standard-LaTeX-command `BinaryFuncName`s (`\min`, `\max`, `\gcd`). */
+const LATEX_BINARY_FUNC_NAMES: Partial<Record<string, BinaryFuncName>> = Object.fromEntries(
+  Object.entries(LATEX_BINARY_FUNCS)
+    .filter((entry): entry is [BinaryFuncName, string] => !entry[1].startsWith("\\operatorname"))
+    .map(([name, latex]) => [latex, name as BinaryFuncName]),
+);
+
+/** Reverse lookup for the `\operatorname{name}` `BinaryFuncName`s (`atan2`, `hypot`, `lcm`). */
+const OPERATORNAME_BINARY_FUNC_NAMES: Partial<Record<string, BinaryFuncName>> = Object.fromEntries(
+  Object.entries(LATEX_BINARY_FUNCS)
+    .filter((entry): entry is [BinaryFuncName, string] => entry[1].startsWith("\\operatorname"))
+    .map(([name, latex]) => [/\\operatorname\{(\w+)\}/.exec(latex)?.[1], name as BinaryFuncName]),
+);
+
+/** Find the index of the delimiter matching `open` at `s[start]`, honoring nesting. */
+function findGroupEnd(s: string, start: number, open: string, close: string): number {
+  let depth = 0;
+  for (let i = start; i < s.length; i++) {
+    if (s[i] === open) depth++;
+    else if (s[i] === close) {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  throw new Error(`Unmatched '${open}' in LaTeX source`);
+}
+
+/** Extract the `{...}`/`(...)`/`[...]` group starting at `s[pos]` (the opening delimiter itself). */
+function extractGroup(s: string, pos: number): { content: string; next: number } {
+  const open = s[pos];
+  const close = open === "{" ? "}" : open === "(" ? ")" : open === "[" ? "]" : undefined;
+  if (!close) throw new Error(`Expected a group starting with '{', '(' or '[' at position ${pos}`);
+  const end = findGroupEnd(s, pos, open, close);
+  return { content: s.slice(pos + 1, end), next: end + 1 };
+}
+
+/** Split `s` on top-level commas, ignoring commas nested inside `{}`/`()`/`[]`. */
+function splitTopLevelCommas(s: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === "{" || ch === "(" || ch === "[") depth++;
+    else if (ch === "}" || ch === ")" || ch === "]") depth--;
+    else if (ch === "," && depth === 0) {
+      parts.push(s.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(s.slice(start));
+  return parts;
+}
+
+/** Convert a LaTeX math string into the plain-infix syntax `Symbolic.parse`'s `Parser` understands. */
+function latexToInfix(latex: string): string {
+  const cleaned = latex.replace(/\\left|\\right/g, "").replace(/\\(?:,|;|!|quad|qquad| )/g, "");
+  return transformLatex(cleaned);
+}
+
+function transformLatex(s: string): string {
+  let out = "";
+  let i = 0;
+
+  const readGroup = (): string => {
+    if (s[i] !== "{") throw new Error(`Expected '{' at position ${i} in LaTeX source: ${s}`);
+    const { content, next } = extractGroup(s, i);
+    i = next;
+    return content;
+  };
+
+  const readGroupOrParenOrToken = (): string => {
+    if (s[i] === "{" || s[i] === "(") {
+      const { content, next } = extractGroup(s, i);
+      i = next;
+      return content;
+    }
+    const m = /^[a-zA-Z_]\w*|^\d+\.?\d*(?:[eE][+-]?\d+)?/.exec(s.slice(i));
+    if (m) {
+      i += m[0].length;
+      return m[0];
+    }
+    throw new Error(`Expected an argument at position ${i} in LaTeX source: ${s}`);
+  };
+
+  /** Read a `(...)`/`{...}` group holding exactly 2 comma-separated arguments, for `call2` functions. */
+  const readArgPair = (): [string, string] => {
+    if (s[i] !== "(" && s[i] !== "{") throw new Error(`Expected '(' at position ${i} in LaTeX source: ${s}`);
+    const { content, next } = extractGroup(s, i);
+    i = next;
+    const parts = splitTopLevelCommas(content);
+    if (parts.length !== 2)
+      throw new Error(`Expected 2 comma-separated arguments at position ${i} in LaTeX source: ${s}`);
+    return [parts[0], parts[1]];
+  };
+
+  while (i < s.length) {
+    const ch = s[i];
+    if (ch === "\\") {
+      const cmdMatch = /^\\[a-zA-Z]+/.exec(s.slice(i));
+      if (!cmdMatch) throw new Error(`Unsupported LaTeX construct at position ${i}: ${s.slice(i, i + 10)}`);
+      const cmd = cmdMatch[0];
+      i += cmd.length;
+      if (cmd === "\\cdot" || cmd === "\\times") {
+        out += "*";
+        continue;
+      }
+      if (cmd === "\\pi") {
+        out += "pi";
+        continue;
+      }
+      if (cmd === "\\frac") {
+        const numerator = readGroup();
+        const denominator = readGroup();
+        out += `((${transformLatex(numerator)})/(${transformLatex(denominator)}))`;
+        continue;
+      }
+      if (cmd === "\\sqrt") {
+        if (s[i] === "[") {
+          const { content: root, next } = extractGroup(s, i);
+          i = next;
+          const arg = readGroup();
+          const transformedRoot = transformLatex(root).trim();
+          // \sqrt[3]{...} maps to cbrt(...) rather than a fractional power so
+          // negative arguments evaluate correctly (Math.cbrt(-8) = -2, but
+          // (-8)^(1/3) is NaN under JS's `**`).
+          out +=
+            transformedRoot === "3"
+              ? `cbrt(${transformLatex(arg)})`
+              : `((${transformLatex(arg)})^(1/(${transformedRoot})))`;
+        } else {
+          const arg = readGroup();
+          out += `sqrt(${transformLatex(arg)})`;
+        }
+        continue;
+      }
+      if (cmd === "\\log") {
+        let base = "10";
+        if (s[i] === "_" && s[i + 1] === "{") {
+          const { content, next } = extractGroup(s, i + 1);
+          i = next;
+          base = content.trim();
+        }
+        if (base !== "10" && base !== "2") {
+          throw new Error(`Unsupported LaTeX construct: \\log base ${base} (only base 10 and base 2 are supported)`);
+        }
+        const arg = readGroupOrParenOrToken();
+        out += `${base === "2" ? "log2" : "log10"}(${transformLatex(arg)})`;
+        continue;
+      }
+      if (cmd === "\\lfloor" || cmd === "\\lceil") {
+        const closeCmd = cmd === "\\lfloor" ? "\\rfloor" : "\\rceil";
+        const closeIdx = s.indexOf(closeCmd, i);
+        if (closeIdx === -1) throw new Error(`Unmatched '${cmd}' in LaTeX source`);
+        const inner = s.slice(i, closeIdx);
+        i = closeIdx + closeCmd.length;
+        out += `${cmd === "\\lfloor" ? "floor" : "ceil"}(${transformLatex(inner)})`;
+        continue;
+      }
+      if (cmd === "\\operatorname") {
+        const opName = readGroup();
+        const binaryName = OPERATORNAME_BINARY_FUNC_NAMES[opName];
+        if (binaryName) {
+          const [left, right] = readArgPair();
+          out += `${binaryName}(${transformLatex(left)}, ${transformLatex(right)})`;
+          continue;
+        }
+        const funcName = OPERATORNAME_FUNC_NAMES[opName];
+        if (!funcName) throw new Error(`Unsupported LaTeX construct: \\operatorname{${opName}}`);
+        const arg = readGroupOrParenOrToken();
+        out += `${funcName}(${transformLatex(arg)})`;
+        continue;
+      }
+      const binaryFuncName = LATEX_BINARY_FUNC_NAMES[cmd];
+      if (binaryFuncName) {
+        const [left, right] = readArgPair();
+        out += `${binaryFuncName}(${transformLatex(left)}, ${transformLatex(right)})`;
+        continue;
+      }
+      const funcName = LATEX_FUNC_NAMES[cmd];
+      if (funcName) {
+        const arg = readGroupOrParenOrToken();
+        out += `${funcName}(${transformLatex(arg)})`;
+        continue;
+      }
+      throw new Error(`Unsupported LaTeX construct: ${cmd}`);
+    }
+    if (ch === "|") {
+      const closeIdx = s.indexOf("|", i + 1);
+      if (closeIdx === -1) throw new Error("Unmatched '|' in LaTeX source");
+      const inner = s.slice(i + 1, closeIdx);
+      i = closeIdx + 1;
+      out += `abs(${transformLatex(inner)})`;
+      continue;
+    }
+    if (ch === "^" && s[i + 1] === "{") {
+      const { content, next } = extractGroup(s, i + 1);
+      i = next;
+      out += `^(${transformLatex(content)})`;
+      continue;
+    }
+    if (ch === "_" && s[i + 1] === "{") {
+      const { content, next } = extractGroup(s, i + 1);
+      i = next;
+      out += `_${content.replace(/\W/g, "")}`;
+      continue;
+    }
+    if (ch === "{") {
+      const { content, next } = extractGroup(s, i);
+      i = next;
+      out += `(${transformLatex(content)})`;
+      continue;
+    }
+    out += ch;
+    i++;
+  }
+  return out;
+}
+
+// -- equation solving & factoring ----------------------------------------------
+/** Best-effort exact `Expr` for a numeric value: an integer, a reduced fraction, or (as a last resort) the raw float. */
+function toExactExpr(value: number): Expr {
+  if (Number.isInteger(value)) return num(value);
+  const r = Rational.fromNumber(value, 10_000);
+  if (r.denominator === 1n) return num(Number(r.numerator));
+  return div(num(Number(r.numerator)), num(Number(r.denominator)));
+}
+
+function evalPoly(coeffsLowToHigh: number[], p: number): number {
+  let result = 0;
+  for (let i = coeffsLowToHigh.length - 1; i >= 0; i--) result = result * p + coeffsLowToHigh[i];
+  return result;
+}
+
+/**
+ * Extract `[c0, c1, ..., cn]` such that `expr = c0 + c1·x + ... + cn·x^n`, via
+ * Taylor coefficients at 0 (`f^(n)(0)/n!`), verified against `expr` at a few
+ * probe points so non-polynomial expressions (e.g. `sin(x)`) are rejected
+ * rather than silently truncated. Returns `null` if `expr` isn't a polynomial
+ * of degree ≤ `maxDegree` in `variable`.
+ */
+function polynomialCoeffs(expr: Expr, variable: string, maxDegree: number): number[] | null {
+  const coeffs: number[] = [];
+  let term = expr;
+  let factorial = 1;
+  for (let n = 0; n <= maxDegree; n++) {
+    if (n > 0) factorial *= n;
+    const c0 = evalExpr(term, { [variable]: 0 });
+    if (!Number.isFinite(c0)) return null;
+    coeffs.push(c0 / factorial);
+    // Simplify between differentiation steps: an unsimplified term like the
+    // derivative of x^0 (`0·x^-1`) evaluates to `0·Infinity = NaN` at x=0
+    // even though it is symbolically zero — simplifying collapses `0·anything`
+    // to `0` before that indeterminate form can arise.
+    term = Symbolic.simplify(diff(term, variable));
+  }
+  while (coeffs.length > 1 && Math.abs(coeffs[coeffs.length - 1]) < 1e-9) coeffs.pop();
+  for (const p of [1.3, -2.1, 3.7]) {
+    const actual = evalExpr(expr, { [variable]: p });
+    if (!Number.isFinite(actual)) return null;
+    if (Math.abs(evalPoly(coeffs, p) - actual) > 1e-6 * Math.max(1, Math.abs(actual))) return null;
+  }
+  return coeffs;
+}
+
+function intGcd(a: number, b: number): number {
+  let x = Math.abs(a);
+  let y = Math.abs(b);
+  while (y) [x, y] = [y, x % y];
+  return x || 1;
+}
+
+function divisorsOf(n: number): number[] {
+  const a = Math.round(Math.abs(n));
+  if (a === 0) return [1];
+  const result: number[] = [];
+  for (let i = 1; i <= a; i++) if (a % i === 0) result.push(i);
+  return result;
+}
+
+/** Rational-root-theorem search for one root of an integer-coefficient polynomial (low-to-high `coeffs`). */
+function findRationalRoot(coeffs: number[]): number | null {
+  const n = coeffs.length - 1;
+  const rounded = coeffs.map((c) => Math.round(c));
+  const isIntegerPoly = coeffs.every((c, i) => Math.abs(c - rounded[i]) < 1e-6);
+  if (!isIntegerPoly) return null;
+  const pCands = divisorsOf(rounded[0]);
+  const qCands = divisorsOf(rounded[n]);
+  const tried = new Set<number>();
+  for (const p of pCands) {
+    for (const q of qCands) {
+      for (const sign of [1, -1]) {
+        const candidate = (sign * p) / q;
+        if (tried.has(candidate)) continue;
+        tried.add(candidate);
+        if (Math.abs(evalPoly(rounded, candidate)) < 1e-6) return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+/** Synthetic division of a polynomial (low-to-high `coeffs`) by `(x - root)`; assumes `root` is an exact root. */
+function syntheticDivide(coeffsLowToHigh: number[], root: number): number[] {
+  const desc = [...coeffsLowToHigh].reverse();
+  const quotientDesc: number[] = [desc[0]];
+  for (let i = 1; i < desc.length - 1; i++) {
+    quotientDesc.push(desc[i] + root * quotientDesc[i - 1]);
+  }
+  return quotientDesc.reverse();
+}
+
+function solvePolynomial(coeffsIn: number[]): Expr[] {
+  const coeffs = [...coeffsIn];
+  while (coeffs.length > 1 && Math.abs(coeffs[coeffs.length - 1]) < 1e-9) coeffs.pop();
+  const n = coeffs.length - 1;
+  if (n <= 0) return [];
+  if (n === 1) {
+    const [c0, c1] = coeffs;
+    return [toExactExpr(-c0 / c1)];
+  }
+  if (n === 2) {
+    const [c0, c1, c2] = coeffs;
+    const disc = c1 * c1 - 4 * c2 * c0;
+    if (disc < -1e-9) return [];
+    const negB = -c1;
+    const twoA = 2 * c2;
+    if (Math.abs(disc) < 1e-9) return [toExactExpr(negB / twoA)];
+    const sqrtDisc = Math.sqrt(disc);
+    if (Math.abs(sqrtDisc - Math.round(sqrtDisc)) < 1e-9) {
+      return [toExactExpr((negB + sqrtDisc) / twoA), toExactExpr((negB - sqrtDisc) / twoA)];
+    }
+    const sqrtExpr = fn("sqrt", toExactExpr(disc));
+    return [
+      div(add(toExactExpr(negB), sqrtExpr), toExactExpr(twoA)),
+      div(sub(toExactExpr(negB), sqrtExpr), toExactExpr(twoA)),
+    ];
+  }
+  const root = findRationalRoot(coeffs);
+  if (root === null) {
+    throw new Error(
+      `solve: no closed-form root found for a degree-${n} polynomial (only rational roots are searched for degree ≥ 3).`,
+    );
+  }
+  const deflated = syntheticDivide(coeffs, root);
+  return [toExactExpr(root), ...solvePolynomial(deflated)];
+}
+
+/** Build `c0 + c1·x + c2·x^2 + ...` from low-to-high coefficients. */
+function polyToExpr(coeffs: number[], variable: string): Expr {
+  let result: Expr | null = null;
+  for (let i = 0; i < coeffs.length; i++) {
+    if (coeffs[i] === 0) continue;
+    const monomial =
+      i === 0 ? toExactExpr(coeffs[i]) : mul(toExactExpr(coeffs[i]), i === 1 ? v(variable) : pow(v(variable), num(i)));
+    result = result === null ? monomial : add(result, monomial);
+  }
+  return result ?? num(0);
+}
+
+function factorPolynomial(coeffsIn: number[], variable: string): Expr {
+  let coeffs = [...coeffsIn];
+  while (coeffs.length > 1 && Math.abs(coeffs[coeffs.length - 1]) < 1e-9) coeffs.pop();
+  if (coeffs.every((c) => Math.abs(c) < 1e-9)) return num(0);
+
+  let xPower = 0;
+  while (coeffs.length > 1 && Math.abs(coeffs[0]) < 1e-9) {
+    coeffs.shift();
+    xPower++;
+  }
+
+  const rounded = coeffs.map((c) => Math.round(c));
+  const isIntegerPoly = coeffs.every((c, i) => Math.abs(c - rounded[i]) < 1e-6);
+  let gcd = 1;
+  if (isIntegerPoly) {
+    gcd = rounded.reduce((g, c) => (c === 0 ? g : intGcd(g, Math.abs(c))), 0) || 1;
+    coeffs = rounded.map((c) => c / gcd);
+  }
+
+  const linearRoots: number[] = [];
+  let remaining = coeffs;
+  while (remaining.length - 1 >= 3) {
+    const root = findRationalRoot(remaining);
+    if (root === null) break;
+    linearRoots.push(root);
+    remaining = syntheticDivide(remaining, root);
+  }
+  if (remaining.length - 1 === 2) {
+    const [c0, c1, c2] = remaining;
+    const disc = c1 * c1 - 4 * c2 * c0;
+    if (disc >= 0) {
+      const sqrtDisc = Math.sqrt(disc);
+      if (Math.abs(sqrtDisc - Math.round(sqrtDisc)) < 1e-9) {
+        linearRoots.push((-c1 + sqrtDisc) / (2 * c2), (-c1 - sqrtDisc) / (2 * c2));
+        remaining = [c2];
+      }
+    }
+  } else if (remaining.length - 1 === 1) {
+    const [c0, c1] = remaining;
+    linearRoots.push(-c0 / c1);
+    remaining = [c1];
+  }
+
+  let result: Expr = toExactExpr(gcd);
+  if (xPower === 1) result = mul(result, v(variable));
+  else if (xPower > 1) result = mul(result, pow(v(variable), num(xPower)));
+  for (const r of linearRoots) {
+    result = mul(result, Math.abs(r) < 1e-9 ? v(variable) : sub(v(variable), toExactExpr(r)));
+  }
+  if (remaining.length > 1) {
+    result = mul(result, polyToExpr(remaining, variable));
+  } else if (Math.abs(remaining[0] - 1) > 1e-9) {
+    result = mul(result, toExactExpr(remaining[0]));
+  }
+  return Symbolic.simplify(result);
+}
+
+// -- limits ---------------------------------------------------------------------
+function evalNear(e: Expr, x: string, point: number, direction: "left" | "right" | "both"): number {
+  if (direction === "both") return evalExpr(e, { [x]: point });
+  const eps = direction === "right" ? 1e-6 : -1e-6;
+  return evalExpr(e, { [x]: point + eps });
+}
+
+function limitAt(e: Expr, x: string, point: number, direction: "left" | "right" | "both", depth: number): number {
+  const direct = evalNear(e, x, point, direction);
+  if (Number.isFinite(direct)) return direct;
+  if (e.type === "div" && depth < 12) {
+    const fAt = evalNear(e.left, x, point, direction);
+    const gAt = evalNear(e.right, x, point, direction);
+    const indeterminate =
+      (Math.abs(fAt) < 1e-6 && Math.abs(gAt) < 1e-6) || (!Number.isFinite(fAt) && !Number.isFinite(gAt));
+    if (indeterminate) {
+      const df = diff(e.left, x);
+      const dg = diff(e.right, x);
+      return limitAt(div(df, dg), x, point, direction, depth + 1);
+    }
+  }
+  return direct;
+}
 
 // -- recursive-descent parser ----------------------------------------------
 class Parser {
@@ -544,6 +1964,16 @@ class Parser {
 
   private peek(): string {
     return this.s[this.pos] ?? "";
+  }
+
+  /** Parse a comma-separated list of expressions, for multi-arg function calls. */
+  private argList(): Expr[] {
+    const args = [this.expr()];
+    while (this.peek() === ",") {
+      this.pos++;
+      args.push(this.expr());
+    }
+    return args;
   }
 
   private expr(): Expr {
@@ -587,6 +2017,13 @@ class Parser {
       this.pos++;
       return e;
     }
+    if (this.peek() === "|") {
+      this.pos++;
+      const e = this.expr();
+      if (this.peek() !== "|") throw new Error("Expected '|'");
+      this.pos++;
+      return fn("abs", e);
+    }
     // number
     const numMatch = /^\d+\.?\d*(?:[eE][+-]?\d+)?/.exec(this.s.slice(this.pos));
     if (numMatch) {
@@ -598,12 +2035,40 @@ class Parser {
     if (idMatch) {
       const name = idMatch[0];
       this.pos += name.length;
-      if ((FUNCS as string[]).includes(name) && this.peek() === "(") {
+      if ((name === "log" || name === "clamp") && this.peek() === "(") {
+        this.pos++;
+        const args = this.argList();
+        if (this.peek() !== ")") throw new Error("Expected ')'");
+        this.pos++;
+        if (name === "log") {
+          if (args.length !== 2) throw new Error(`log() expects 2 arguments (base, x), got ${args.length}`);
+          return div(fn("ln", args[1]), fn("ln", args[0]));
+        }
+        if (args.length !== 3) throw new Error(`clamp() expects 3 arguments (x, lo, hi), got ${args.length}`);
+        return call2("min", call2("max", args[0], args[1]), args[2]);
+      }
+      if ((BINARY_FUNCS as string[]).includes(name) && this.peek() === "(") {
+        const binaryName = name as BinaryFuncName;
+        this.pos++;
+        const args = this.argList();
+        if (this.peek() !== ")") throw new Error("Expected ')'");
+        this.pos++;
+        if (binaryName === "atan2") {
+          if (args.length !== 2) throw new Error(`atan2() expects exactly 2 arguments, got ${args.length}`);
+          return call2("atan2", args[0], args[1]);
+        }
+        if (args.length < 2) throw new Error(`${binaryName}() expects at least 2 arguments, got ${args.length}`);
+        return args.reduce((l, r) => call2(binaryName, l, r));
+      }
+      const canonical: FuncName | undefined = (FUNCS as string[]).includes(name)
+        ? (name as FuncName)
+        : FUNC_ALIASES[name];
+      if (canonical && this.peek() === "(") {
         this.pos++;
         const arg = this.expr();
         if (this.peek() !== ")") throw new Error("Expected ')'");
         this.pos++;
-        return fn(name as FuncName, arg);
+        return fn(canonical, arg);
       }
       if (name === "pi") return num(Math.PI);
       if (name === "e") return num(Math.E);

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,15 @@ export * as Statistics from "./Statistics.ts";
 export { StringEvaluator } from "./StringEvaluator.ts";
 // Algebraic structures & geometry
 export { Structure, type StructureOptions } from "./Structure.ts";
-export { type DifferentiationStep, type Expr, type FuncName, NotIntegrableError, Symbolic } from "./Symbolic.ts";
+export {
+  type BinaryFuncName,
+  type DifferentiationStep,
+  type Expr,
+  FUNCTION_NAMES,
+  type FuncName,
+  NotIntegrableError,
+  Symbolic,
+} from "./Symbolic.ts";
 export { Type, TypeTag } from "./Type.ts";
 // Utilities & leaves
 export { Utilities } from "./Utilities.ts";

--- a/test/Symbolic.test.ts
+++ b/test/Symbolic.test.ts
@@ -120,3 +120,436 @@ test("differentiateSteps on a bare constant/variable records a single leaf step"
   assert.equal(varSteps.length, 1);
   assert.equal(varSteps[0].rule, "Variable Rule");
 });
+
+test("differentiate inverse trig and hyperbolic functions", () => {
+  const cases: Array<[string, (x: number) => number]> = [
+    ["asin(x)", (x) => 1 / Math.sqrt(1 - x * x)],
+    ["acos(x)", (x) => -1 / Math.sqrt(1 - x * x)],
+    ["atan(x)", (x) => 1 / (1 + x * x)],
+    ["sinh(x)", (x) => Math.cosh(x)],
+    ["cosh(x)", (x) => Math.sinh(x)],
+    ["tanh(x)", (x) => 1 / Math.cosh(x) ** 2],
+  ];
+  for (const [expr, expected] of cases) {
+    const d = Symbolic.differentiate(expr);
+    assert.ok(Math.abs(Symbolic.evaluate(d, { x: 0.4 }) - expected(0.4)) < 1e-9, expr);
+  }
+});
+
+test("evaluate and compile agree on the new elementary functions", () => {
+  for (const expr of ["asin(x)", "acos(x)", "atan(x)", "sinh(x)", "cosh(x)", "tanh(x)"]) {
+    const evaluated = Symbolic.evaluate(expr, { x: 0.3 });
+    const compiled = Symbolic.compile(expr)({ x: 0.3 });
+    assert.ok(Math.abs(evaluated - compiled) < 1e-12, expr);
+  }
+});
+
+test("parses arcsin/arccos/arctan/arcsinh/arccosh/arctanh as aliases", () => {
+  for (const [alias, canonical] of [
+    ["arcsin", "asin"],
+    ["arccos", "acos"],
+    ["arctan", "atan"],
+    ["arcsinh", "asinh"],
+    ["arccosh", "acosh"],
+    ["arctanh", "atanh"],
+  ] as const) {
+    assert.equal(
+      Symbolic.toString(Symbolic.parse(`${alias}(x)`)),
+      Symbolic.toString(Symbolic.parse(`${canonical}(x)`)),
+    );
+  }
+});
+
+test("evaluates reciprocal-trig and reciprocal/inverse-hyperbolic functions", () => {
+  const cases: Array<[string, (x: number) => number]> = [
+    ["cot(x)", (x) => 1 / Math.tan(x)],
+    ["sec(x)", (x) => 1 / Math.cos(x)],
+    ["csc(x)", (x) => 1 / Math.sin(x)],
+    ["asinh(x)", (x) => Math.asinh(x)],
+    ["acosh(x)", (x) => Math.acosh(x)],
+    ["atanh(x)", (x) => Math.atanh(x)],
+    ["coth(x)", (x) => 1 / Math.tanh(x)],
+    ["sech(x)", (x) => 1 / Math.cosh(x)],
+    ["csch(x)", (x) => 1 / Math.sinh(x)],
+  ];
+  for (const [expr, fn] of cases) {
+    const x = expr === "acosh(x)" ? 2 : 0.7;
+    assert.ok(Math.abs(evalAt(expr, x) - fn(x)) < 1e-9, expr);
+    assert.ok(Math.abs(Symbolic.compile(expr)({ x }) - fn(x)) < 1e-9, `compile ${expr}`);
+  }
+});
+
+test("differentiate reciprocal-trig and reciprocal/inverse-hyperbolic functions", () => {
+  const cases: Array<[string, (x: number) => number]> = [
+    ["cot(x)", (x) => -1 / Math.sin(x) ** 2],
+    ["sec(x)", (x) => (1 / Math.cos(x)) * Math.tan(x)],
+    ["csc(x)", (x) => -(1 / Math.sin(x)) * (1 / Math.tan(x))],
+    ["asinh(x)", (x) => 1 / Math.sqrt(x * x + 1)],
+    ["acosh(x)", (x) => 1 / Math.sqrt(x * x - 1)],
+    ["atanh(x)", (x) => 1 / (1 - x * x)],
+    ["coth(x)", (x) => -1 / Math.sinh(x) ** 2],
+    ["sech(x)", (x) => -(1 / Math.cosh(x)) * Math.tanh(x)],
+    ["csch(x)", (x) => -(1 / Math.sinh(x)) * (1 / Math.tanh(x))],
+  ];
+  for (const [expr, expected] of cases) {
+    const x = expr === "acosh(x)" ? 2 : 0.4;
+    const d = Symbolic.differentiate(expr);
+    assert.ok(Math.abs(Symbolic.evaluate(d, { x }) - expected(x)) < 1e-9, expr);
+  }
+});
+
+test("evaluates and differentiates inverse-reciprocal-trig/hyperbolic functions", () => {
+  const cases: Array<[string, (x: number) => number, (x: number) => number]> = [
+    ["acot(x)", (x) => Math.PI / 2 - Math.atan(x), (x) => -1 / (1 + x * x)],
+    ["asec(x)", (x) => Math.acos(1 / x), (x) => 1 / (Math.abs(x) * Math.sqrt(x * x - 1))],
+    ["acsc(x)", (x) => Math.asin(1 / x), (x) => -1 / (Math.abs(x) * Math.sqrt(x * x - 1))],
+    ["acoth(x)", (x) => Math.atanh(1 / x), (x) => 1 / (1 - x * x)],
+    ["asech(x)", (x) => Math.acosh(1 / x), (x) => -1 / (x * Math.sqrt(1 - x * x))],
+    ["acsch(x)", (x) => Math.asinh(1 / x), (x) => -1 / (Math.abs(x) * Math.sqrt(1 + x * x))],
+  ];
+  for (const [expr, fn, dfn] of cases) {
+    const x = expr === "asech(x)" ? 0.5 : 2;
+    assert.ok(Math.abs(evalAt(expr, x) - fn(x)) < 1e-9, expr);
+    assert.ok(Math.abs(Symbolic.compile(expr)({ x }) - fn(x)) < 1e-9, `compile ${expr}`);
+    const d = Symbolic.differentiate(expr);
+    assert.ok(Math.abs(Symbolic.evaluate(d, { x }) - dfn(x)) < 1e-9, `d/dx ${expr}`);
+  }
+});
+
+test("evaluates and differentiates abs/log10/log2/cbrt/floor/ceil/round/sign", () => {
+  assert.equal(evalAt("abs(x)", -3), 3);
+  assert.equal(Symbolic.evaluate(Symbolic.differentiate("abs(x)"), { x: -3 }), -1);
+  assert.equal(Symbolic.evaluate(Symbolic.differentiate("abs(x)"), { x: 3 }), 1);
+
+  assert.ok(Math.abs(evalAt("log10(x)", 1000) - 3) < 1e-9);
+  assert.ok(Math.abs(Symbolic.evaluate(Symbolic.differentiate("log10(x)"), { x: 2 }) - 1 / (2 * Math.LN10)) < 1e-9);
+
+  assert.ok(Math.abs(evalAt("log2(x)", 8) - 3) < 1e-9);
+  assert.ok(Math.abs(Symbolic.evaluate(Symbolic.differentiate("log2(x)"), { x: 2 }) - 1 / (2 * Math.LN2)) < 1e-9);
+
+  assert.equal(evalAt("cbrt(x)", -8), -2);
+  assert.ok(Math.abs(Symbolic.evaluate(Symbolic.differentiate("cbrt(x)"), { x: 8 }) - 1 / (3 * 8 ** (2 / 3))) < 1e-6);
+
+  for (const [name, fn] of [
+    ["floor", Math.floor],
+    ["ceil", Math.ceil],
+    ["round", Math.round],
+    ["sign", Math.sign],
+  ] as const) {
+    assert.equal(evalAt(`${name}(x)`, 2.6), fn(2.6));
+    assert.equal(Symbolic.evaluate(Symbolic.differentiate(`${name}(x)`), { x: 2.6 }), 0);
+  }
+});
+
+test("evaluates and differentiates trunc/expm1/log1p/sigmoid/erf/relu", () => {
+  assert.equal(evalAt("trunc(x)", -2.7), Math.trunc(-2.7));
+  assert.equal(Symbolic.evaluate(Symbolic.differentiate("trunc(x)"), { x: 2.6 }), 0);
+
+  assert.ok(Math.abs(evalAt("expm1(x)", 1) - Math.expm1(1)) < 1e-12);
+  assert.ok(Math.abs(Symbolic.evaluate(Symbolic.differentiate("expm1(x)"), { x: 0.4 }) - Math.exp(0.4)) < 1e-9);
+
+  assert.ok(Math.abs(evalAt("log1p(x)", 1) - Math.log1p(1)) < 1e-12);
+  assert.ok(Math.abs(Symbolic.evaluate(Symbolic.differentiate("log1p(x)"), { x: 0.4 }) - 1 / 1.4) < 1e-9);
+
+  const sigmoid = (x: number) => 1 / (1 + Math.exp(-x));
+  assert.ok(Math.abs(evalAt("sigmoid(x)", 0) - 0.5) < 1e-12);
+  assert.ok(
+    Math.abs(Symbolic.evaluate(Symbolic.differentiate("sigmoid(x)"), { x: 0.4 }) - sigmoid(0.4) * (1 - sigmoid(0.4))) <
+      1e-9,
+  );
+  assert.equal(
+    JSON.stringify(Symbolic.parse("logistic(x)")),
+    JSON.stringify(Symbolic.parse("sigmoid(x)")),
+    "logistic is an alias for sigmoid",
+  );
+
+  assert.ok(Math.abs(evalAt("erf(x)", 1) - 0.8427007929497149) < 1e-6);
+  assert.ok(
+    Math.abs(
+      Symbolic.evaluate(Symbolic.differentiate("erf(x)"), { x: 0.4 }) - (2 / Math.sqrt(Math.PI)) * Math.exp(-0.16),
+    ) < 1e-9,
+  );
+
+  assert.equal(evalAt("relu(x)", -3), 0);
+  assert.equal(evalAt("relu(x)", 3), 3);
+  assert.equal(Symbolic.evaluate(Symbolic.differentiate("relu(x)"), { x: 3.2 }), 1);
+  assert.equal(Symbolic.evaluate(Symbolic.differentiate("relu(x)"), { x: -3.2 }), 0);
+});
+
+test("toLatex/fromLatex round-trip abs/floor/ceil/log10/log2/cbrt and the new operatorname functions", () => {
+  const barFloorCeilLog = [
+    ["abs(x)", "\\left|x\\right|"],
+    ["floor(x)", "\\left\\lfloor x\\right\\rfloor"],
+    ["ceil(x)", "\\left\\lceil x\\right\\rceil"],
+    ["log10(x)", "\\log_{10}\\left(x\\right)"],
+    ["log2(x)", "\\log_{2}\\left(x\\right)"],
+    ["cbrt(x)", "\\sqrt[3]{x}"],
+  ];
+  for (const [expr, expectedLatex] of barFloorCeilLog) {
+    const latex = Symbolic.toLatex(expr);
+    assert.equal(latex, expectedLatex, expr);
+    assert.equal(JSON.stringify(Symbolic.fromLatex(latex)), JSON.stringify(Symbolic.parse(expr)), `round-trip ${expr}`);
+  }
+
+  for (const name of [
+    "acot",
+    "asec",
+    "acsc",
+    "acoth",
+    "asech",
+    "acsch",
+    "round",
+    "sign",
+    "trunc",
+    "expm1",
+    "log1p",
+    "sigmoid",
+    "erf",
+    "relu",
+  ]) {
+    const expr = `${name}(x)`;
+    const latex = Symbolic.toLatex(expr);
+    assert.ok(latex.startsWith("\\operatorname{"), `${expr} -> ${latex}`);
+    assert.equal(JSON.stringify(Symbolic.fromLatex(latex)), JSON.stringify(Symbolic.parse(expr)), `round-trip ${expr}`);
+  }
+});
+
+test("evaluates atan2/hypot/min/max/gcd/lcm, including N-ary folding for hypot/min/max/gcd/lcm", () => {
+  assert.ok(Math.abs(Symbolic.evaluate("atan2(1,1)") - Math.atan2(1, 1)) < 1e-12);
+  assert.ok(Math.abs(Symbolic.evaluate("atan2(-1,1)") - Math.atan2(-1, 1)) < 1e-12);
+  assert.equal(Symbolic.evaluate("hypot(3,4)"), 5);
+  assert.equal(Symbolic.evaluate("hypot(3,4,12)"), 13);
+  assert.equal(Symbolic.evaluate("min(3,7)"), 3);
+  assert.equal(Symbolic.evaluate("min(3,7,-2,5)"), -2);
+  assert.equal(Symbolic.evaluate("max(3,7)"), 7);
+  assert.equal(Symbolic.evaluate("max(3,7,-2,5)"), 7);
+  assert.equal(Symbolic.evaluate("gcd(12,18)"), 6);
+  assert.equal(Symbolic.evaluate("gcd(12,18,30)"), 6);
+  assert.equal(Symbolic.evaluate("lcm(4,6)"), 12);
+  assert.equal(Symbolic.evaluate("lcm(4,6,10)"), 60);
+
+  assert.equal(
+    JSON.stringify(Symbolic.parse("min(a,b,c,d)")),
+    JSON.stringify(Symbolic.parse("min(min(min(a,b),c),d)")),
+    "N-ary min folds pairwise, left to right",
+  );
+});
+
+test("log(base, x) and clamp(x, lo, hi) desugar at parse time", () => {
+  assert.equal(Symbolic.evaluate("log(2,8)"), 3);
+  assert.equal(Symbolic.evaluate("log(10,100)"), 2);
+  assert.equal(Symbolic.evaluate("clamp(5,0,10)"), 5);
+  assert.equal(Symbolic.evaluate("clamp(-5,0,10)"), 0);
+  assert.equal(Symbolic.evaluate("clamp(15,0,10)"), 10);
+  assert.throws(() => Symbolic.parse("log(x)"), "log requires exactly 2 arguments");
+  assert.throws(() => Symbolic.parse("clamp(x,0)"), "clamp requires exactly 3 arguments");
+});
+
+test("atan2 requires exactly 2 arguments; hypot/min/max/gcd/lcm require at least 2", () => {
+  assert.throws(() => Symbolic.parse("atan2(x)"));
+  assert.throws(() => Symbolic.parse("atan2(x,y,z)"));
+  for (const name of ["hypot", "min", "max", "gcd", "lcm"]) {
+    assert.throws(() => Symbolic.parse(`${name}(x)`), `${name} requires >= 2 arguments`);
+  }
+});
+
+test("differentiates atan2/hypot/min/max via the multivariate chain rule; gcd/lcm are 0", () => {
+  const numDeriv = (f: (x: number) => number, x0: number, h = 1e-6) => (f(x0 + h) - f(x0 - h)) / (2 * h);
+
+  for (const [expr, at] of [
+    ["atan2(x,3)", 2],
+    ["atan2(3,x)", 2],
+    ["hypot(x,4)", 3],
+    ["min(x,5)", 2],
+    ["min(x,5)", 8],
+    ["max(x,5)", 2],
+    ["max(x,5)", 8],
+  ] as const) {
+    const symbolic = Symbolic.evaluate(Symbolic.differentiate(expr), { x: at });
+    const numeric = numDeriv((x) => Symbolic.evaluate(expr, { x }), at);
+    assert.ok(Math.abs(symbolic - numeric) < 1e-4, `d/dx ${expr} at x=${at}: ${symbolic} vs ${numeric}`);
+  }
+
+  assert.equal(Symbolic.evaluate(Symbolic.differentiate("gcd(x,6)"), { x: 10 }), 0);
+  assert.equal(Symbolic.evaluate(Symbolic.differentiate("lcm(x,6)"), { x: 10 }), 0);
+});
+
+test("simplify constant-folds call2 nodes; substitute/expand recurse into them", () => {
+  assert.equal(
+    Symbolic.toString(Symbolic.simplify("min(3,7) + max(2,9) + gcd(12,18) + lcm(4,6) + hypot(3,4)")),
+    `${3 + 9 + 6 + 12 + 5}`,
+  );
+  assert.equal(Symbolic.toString(Symbolic.substitute("hypot(x,y)", "x", "3")), "hypot(3, y)");
+  assert.equal(
+    Symbolic.toString(Symbolic.expand("hypot((x+1),y)")),
+    Symbolic.toString(Symbolic.parse("hypot(x + 1, y)")),
+  );
+});
+
+test("toLatex/fromLatex round-trip atan2/hypot/min/max/gcd/lcm", () => {
+  const expectedLatex: [string, string][] = [
+    ["atan2(x,y)", "\\operatorname{atan2}\\left(x, y\\right)"],
+    ["hypot(x,y)", "\\operatorname{hypot}\\left(x, y\\right)"],
+    ["min(x,y)", "\\min\\left(x, y\\right)"],
+    ["max(x,y)", "\\max\\left(x, y\\right)"],
+    ["gcd(x,y)", "\\gcd\\left(x, y\\right)"],
+    ["lcm(x,y)", "\\operatorname{lcm}\\left(x, y\\right)"],
+  ];
+  for (const [expr, latex] of expectedLatex) {
+    assert.equal(Symbolic.toLatex(expr), latex, expr);
+    assert.equal(JSON.stringify(Symbolic.fromLatex(latex)), JSON.stringify(Symbolic.parse(expr)), `round-trip ${expr}`);
+  }
+});
+
+test("integrate by parts", () => {
+  // ∫ x sin(x) dx = sin(x) - x cos(x)
+  const F = Symbolic.integrate("x*sin(x)");
+  const check1 = (x: number) => Math.sin(x) - x * Math.cos(x);
+  assert.ok(
+    Math.abs(Symbolic.evaluate(F, { x: 1.2 }) - Symbolic.evaluate(F, { x: 0 }) - (check1(1.2) - check1(0))) < 1e-9,
+  );
+  assert.ok(Math.abs(Symbolic.evaluate(Symbolic.differentiate(F), { x: 0.7 }) - 0.7 * Math.sin(0.7)) < 1e-9);
+
+  // ∫ x^2 exp(x) dx ; derivative recovers x^2 exp(x)
+  const G = Symbolic.integrate("x^2*exp(x)");
+  assert.ok(Math.abs(Symbolic.evaluate(Symbolic.differentiate(G), { x: 1.1 }) - 1.1 ** 2 * Math.exp(1.1)) < 1e-8);
+});
+
+test("integrate arctan/arcsin forms", () => {
+  // ∫ 1/(1+x^2) dx = atan(x)
+  const F = Symbolic.integrate("1/(1+x^2)");
+  assert.ok(Math.abs(Symbolic.evaluate(Symbolic.differentiate(F), { x: 0.5 }) - 1 / (1 + 0.25)) < 1e-9);
+
+  // ∫ 1/sqrt(1-x^2) dx = asin(x)
+  const G = Symbolic.integrate("1/sqrt(1-x^2)");
+  assert.ok(Math.abs(Symbolic.evaluate(Symbolic.differentiate(G), { x: 0.3 }) - 1 / Math.sqrt(1 - 0.09)) < 1e-9);
+});
+
+test("substitute replaces a variable with an expression", () => {
+  const result = Symbolic.substitute("x^2 + 1", "x", "y+1");
+  assert.equal(Symbolic.evaluate(result, { y: 2 }), Symbolic.evaluate("x^2 + 1", { x: 3 }));
+});
+
+test("expand distributes products over sums", () => {
+  assert.equal(Symbolic.toString(Symbolic.expand("(x+1)^2")), "x^2 + 2*x + 1");
+  assert.equal(Symbolic.toString(Symbolic.expand("(x-1)*(x+1)")), "x^2 - 1");
+});
+
+test("simplify collects like terms", () => {
+  assert.equal(Symbolic.toString(Symbolic.simplify("x + x")), "2*x");
+  assert.equal(Symbolic.toString(Symbolic.simplify("x*x")), "x^2");
+  assert.equal(Symbolic.toString(Symbolic.simplify("a*b + b*a")), "2*(a*b)");
+  assert.equal(Symbolic.toString(Symbolic.simplify("2*x - x")), "x");
+  assert.equal(Symbolic.toString(Symbolic.simplify("x + 2*x + 3")), "3*x + 3");
+});
+
+test("solve finds real roots of linear, quadratic, and higher-degree polynomials", () => {
+  const rootsOf = (expr: string) =>
+    Symbolic.solve(expr)
+      .map((e) => Symbolic.evaluate(e))
+      .sort((a, b) => a - b);
+  assert.deepEqual(rootsOf("x - 3"), [3]);
+  assert.deepEqual(rootsOf("x^2 - 5*x + 6"), [2, 3]);
+  assert.deepEqual(rootsOf("x^3 - 6*x^2 + 11*x - 6"), [1, 2, 3]);
+  // no real roots
+  assert.deepEqual(Symbolic.solve("x^2 + 1"), []);
+});
+
+test("solve verifies every root actually zeroes the polynomial", () => {
+  for (const expr of ["x^2 - 2*x - 3", "2*x^2 - 3*x - 2", "x^3 - 6*x^2 + 11*x - 6"]) {
+    for (const root of Symbolic.solve(expr)) {
+      const value = Symbolic.evaluate(expr, { x: Symbolic.evaluate(root) });
+      assert.ok(Math.abs(value) < 1e-6, `${expr} at root ${Symbolic.toString(root)}`);
+    }
+  }
+});
+
+test("solve rejects non-polynomial expressions", () => {
+  assert.throws(() => Symbolic.solve("sin(x)"));
+});
+
+test("factor extracts linear factors and common terms", () => {
+  const productAt = (expr: string, x: number) => Symbolic.evaluate(expr, { x });
+  for (const expr of ["x^2 - 1", "x^2 - 5*x + 6", "2*x^2 + 4*x", "x^3 - 6*x^2 + 11*x - 6"]) {
+    const factored = Symbolic.factor(expr);
+    for (const x of [0.3, 1.7, -2.2]) {
+      assert.ok(Math.abs(productAt(Symbolic.toString(factored), x) - productAt(expr, x)) < 1e-8, expr);
+    }
+  }
+});
+
+test("factor returns the simplified expression unchanged when not a polynomial", () => {
+  assert.equal(Symbolic.toString(Symbolic.factor("sin(x)")), "sin(x)");
+});
+
+test("limit evaluates removable discontinuities via L'Hopital's rule", () => {
+  assert.ok(Math.abs(Symbolic.limit("sin(x)/x", "x", 0) - 1) < 1e-6);
+  assert.ok(Math.abs(Symbolic.limit("(x^2-1)/(x-1)", "x", 1) - 2) < 1e-6);
+});
+
+test("limit respects one-sided direction", () => {
+  assert.ok(Symbolic.limit("1/x", "x", 0, "right") > 0);
+  assert.ok(Symbolic.limit("1/x", "x", 0, "left") < 0);
+});
+
+test("toLatex renders fractions, radicals, and named functions", () => {
+  assert.equal(Symbolic.toLatex("x^2/2"), "\\frac{x^{2}}{2}");
+  assert.equal(Symbolic.toLatex("sqrt(x+1)"), "\\sqrt{x + 1}");
+  assert.equal(Symbolic.toLatex("sin(x)/cos(x)"), "\\frac{\\sin\\left(x\\right)}{\\cos\\left(x\\right)}");
+});
+
+test("fromLatex round-trips everything toLatex produces", () => {
+  for (const src of [
+    "x^2/2",
+    "sqrt(x+1)",
+    "sin(x)/cos(x)",
+    "a*b + c",
+    "x^2 - 5*x + 6",
+    "sinh(x) + cosh(x)",
+    "cot(x) + sec(x) + csc(x)",
+    "sech(x) + csch(x) + coth(x)",
+    "asinh(x) + acosh(x) + atanh(x)",
+  ]) {
+    const roundTripped = Symbolic.toString(Symbolic.fromLatex(Symbolic.toLatex(src)));
+    assert.equal(roundTripped, Symbolic.toString(Symbolic.parse(src)));
+  }
+});
+
+test("toLatex/fromLatex use \\operatorname for functions with no standard LaTeX command", () => {
+  assert.equal(Symbolic.toLatex("sech(x)"), "\\operatorname{sech}\\left(x\\right)");
+  assert.equal(Symbolic.toLatex("csch(x)"), "\\operatorname{csch}\\left(x\\right)");
+  assert.equal(Symbolic.toLatex("asinh(x)"), "\\operatorname{arcsinh}\\left(x\\right)");
+  assert.equal(Symbolic.toLatex("acosh(x)"), "\\operatorname{arccosh}\\left(x\\right)");
+  assert.equal(Symbolic.toLatex("atanh(x)"), "\\operatorname{arctanh}\\left(x\\right)");
+  assert.equal(Symbolic.toString(Symbolic.fromLatex("\\operatorname{sech}(x)")), "sech(x)");
+  assert.throws(() => Symbolic.fromLatex("\\operatorname{bogus}(x)"));
+});
+
+test("fromLatex parses fractions, radicals, and named function commands", () => {
+  assert.equal(Symbolic.toString(Symbolic.fromLatex("\\frac{a}{b}")), "a/b");
+  assert.equal(Symbolic.toString(Symbolic.fromLatex("\\sqrt{x+1}")), "sqrt(x + 1)");
+  assert.equal(Symbolic.toString(Symbolic.fromLatex("\\sin\\left(x\\right)")), "sin(x)");
+  assert.equal(Symbolic.toString(Symbolic.fromLatex("\\arcsin(x)")), "asin(x)");
+  assert.equal(Symbolic.evaluate(Symbolic.fromLatex("\\sqrt[3]{x}"), { x: 8 }), 2);
+});
+
+test("fromLatex handles \\cdot/\\times, \\pi, braced exponents, and subscripts", () => {
+  assert.equal(Symbolic.toString(Symbolic.fromLatex("2 \\cdot x + 3 \\times y")), "2*x + 3*y");
+  assert.equal(Symbolic.evaluate(Symbolic.fromLatex("\\pi \\cdot x"), { x: 1 }), Math.PI);
+  assert.equal(Symbolic.evaluate(Symbolic.fromLatex("\\frac{x^{2}}{2}"), { x: 4 }), 8);
+  assert.equal(Symbolic.toString(Symbolic.fromLatex("x^{2} + y_{1}")), "x^2 + y_1");
+});
+
+test("fromLatex throws on constructs with no Expr equivalent", () => {
+  assert.throws(() => Symbolic.fromLatex("\\int_0^1 x\\,dx"));
+  assert.throws(() => Symbolic.fromLatex("\\sum_{i=1}^n i"));
+});
+
+test("fromLatex parses bar notation, floor/ceil, and log with subscript base", () => {
+  assert.equal(Symbolic.toString(Symbolic.fromLatex("\\left|x\\right|")), "abs(x)");
+  assert.equal(Symbolic.evaluate(Symbolic.fromLatex("\\left|x\\right|"), { x: -3 }), 3);
+  assert.equal(Symbolic.toString(Symbolic.fromLatex("\\left\\lfloor x\\right\\rfloor")), "floor(x)");
+  assert.equal(Symbolic.toString(Symbolic.fromLatex("\\left\\lceil x\\right\\rceil")), "ceil(x)");
+  assert.equal(Symbolic.evaluate(Symbolic.fromLatex("\\log_{2}(x)"), { x: 8 }), 3);
+  assert.equal(Symbolic.evaluate(Symbolic.fromLatex("\\log(x)"), { x: 100 }), 2);
+});


### PR DESCRIPTION
## Summary
- mallory's `src/Symbolic.ts` predated all of mallory-ts's CAS-deepening work — replaces it and its test suite wholesale with mallory-ts's current versions (substitute/expand/solve/factor/limit/toLatex/fromLatex, ~20 new elementary functions, N-ary `atan2`/`hypot`/`min`/`max`/`gcd`/`lcm` + `log`/`clamp` desugaring).
- Updates `index.ts` exports and README/COOKBOOK docs to match.
- Renames the package from `mallory-ts` to `mallory-math` (continuing the `mallory-math@0.0.1` npm lineage published from the mallory-ts repo), version `0.0.2`.
- Adds a `publish.yml` workflow matching mallory-ts's (release-triggered or manual `workflow_dispatch`). Needs an `NPM_TOKEN` repo secret before it can actually publish.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 343/343 passing
- [x] `npm run check` (biome) — clean
- [x] `npm run docs` — builds
- [x] `npm run test:build` — dist smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018T5JA91K57dZF94vVunLBp