### PR TITLE
Wave 5: nonlinear solve, verification pass, domain assumptions

### DIFF
--- a/src/Symbolic.ts
+++ b/src/Symbolic.ts
@@ -234,6 +234,48 @@ const collectFreeVars = (e: Expr, found: Set<string> = new Set()): Set<string> =
   }
 };
 
+export type Assumption = "positive" | "negative" | "nonnegative" | "nonpositive" | "nonzero";
+
+/** See {@link Symbolic.simplifyAssuming} -- the tree-walk applying each assumption's specific rewrite patterns. */
+function applyAssumptions(e: Expr, assumptions: Record<string, Assumption>): Expr {
+  const isNonneg = (name: string) => assumptions[name] === "positive" || assumptions[name] === "nonnegative";
+  const isNonpos = (name: string) => assumptions[name] === "negative" || assumptions[name] === "nonpositive";
+
+  function walk(node: Expr): Expr {
+    switch (node.type) {
+      case "const":
+      case "var":
+        return node;
+      case "neg":
+        return { type: "neg", arg: walk(node.arg) };
+      case "func": {
+        const arg = walk(node.arg);
+        if (node.name === "sqrt" && arg.type === "pow" && isConst(arg.exp, 2) && arg.base.type === "var") {
+          if (isNonneg(arg.base.name)) return arg.base;
+          if (isNonpos(arg.base.name)) return { type: "neg", arg: arg.base };
+        }
+        if (node.name === "abs" && arg.type === "var") {
+          if (isNonneg(arg.name)) return arg;
+          if (isNonpos(arg.name)) return { type: "neg", arg };
+        }
+        return { type: "func", name: node.name, arg };
+      }
+      case "pow":
+        return { type: "pow", base: walk(node.base), exp: walk(node.exp) };
+      case "piecewise":
+        return {
+          type: "piecewise",
+          branches: node.branches.map((br) => ({ cond: walk(br.cond), expr: walk(br.expr) })),
+          otherwise: walk(node.otherwise),
+        };
+      default:
+        return { ...node, left: walk(node.left), right: walk(node.right) };
+    }
+  }
+
+  return walk(e);
+}
+
 export class NotIntegrableError extends Error {
   constructor(message = "This expression cannot be integrated by the elementary rules implemented.") {
     super(message);
@@ -277,6 +319,13 @@ export class UndeclaredVariableError extends Error {
   }
 }
 
+export class SystemDidNotConvergeError extends Error {
+  constructor(message = "solveSystemNumeric: Newton's method did not converge from the given initial guess.") {
+    super(message);
+    this.name = "SystemDidNotConvergeError";
+  }
+}
+
 export class Symbolic {
   /** Parse an expression string such as `"sin(x^2) + 3*x"` into an AST. */
   static parse(input: string): Expr {
@@ -310,6 +359,28 @@ export class Symbolic {
       e = next;
     }
     return e;
+  }
+
+  /**
+   * Simplifies `expr` with additional domain knowledge about specific
+   * variables (e.g. "x is positive"), unlocking simplifications that aren't
+   * sound in general -- `sqrt(x^2) -> x` requires x >= 0 (otherwise the
+   * correct simplification is |x|), and `abs(x) -> x`/`-x` requires knowing
+   * x's sign. Runs ordinary `simplify` first, then a second tree-walk pass
+   * applying the specific patterns each assumption unlocks, then
+   * `simplify`s once more in case a rewrite exposes a further reduction
+   * (e.g. `sqrt(x^2)*2` -> `x*2` -> could combine with a like term
+   * elsewhere).
+   *
+   * NON-GOALS: a small, explicit pattern set (`sqrt(x^2)`, `abs(x)`), not a
+   * general constraint-propagation/theorem-proving simplifier; assumptions
+   * are a flat per-variable fact (`Assumption`), not compound/derived
+   * assumptions (e.g. "x+y is positive" isn't expressible).
+   */
+  static simplifyAssuming(expr: Expr | string, assumptions: Record<string, Assumption>): Expr {
+    const simplified = Symbolic.simplify(expr);
+    const rewritten = applyAssumptions(simplified, assumptions);
+    return Symbolic.simplify(rewritten);
   }
 
   /** Symbolic anti-derivative (elementary rules; throws {@link NotIntegrableError} otherwise). */
@@ -574,6 +645,130 @@ export class Symbolic {
       result[name] = x[i] as number;
     });
     return result;
+  }
+
+  /**
+   * Numerically solves a square system of (possibly nonlinear) equations
+   * via multivariable Newton's method with a finite-difference Jacobian,
+   * starting from `initialGuess` (default: all 1s). Unlike `solveSystem`,
+   * this never throws `NonLinearSystemError` -- a genuinely linear system
+   * just converges in one Newton step, since Newton's method reduces to a
+   * single linear solve whenever the Jacobian is already constant. Added as
+   * a separate opt-in method (not `solveSystem`'s new default behavior) so
+   * `solveSystem`'s existing "throw on nonlinear" contract, and the tests
+   * that rely on it, stay unchanged -- callers who want a nonlinear-capable
+   * solve opt in explicitly.
+   *
+   * NON-GOALS: plain (undamped) Newton steps, no line search/trust region,
+   * so a poor `initialGuess` can diverge even for a system with a real
+   * solution nearby a *better* guess; only ever finds one root near the
+   * initial guess, not every root of a system with multiple solutions.
+   *
+   * @throws {SystemDidNotConvergeError} if the residual doesn't shrink
+   *   below tolerance within the iteration budget, or evaluation produces a
+   *   non-finite value (e.g. leaving the function's domain) at some step.
+   */
+  static solveSystemNumeric(
+    equations: (Expr | string)[],
+    variables: string[],
+    initialGuess?: number[],
+  ): Record<string, number> {
+    const exprs = equations.map((eq) => (typeof eq === "string" ? Symbolic.parse(eq) : eq));
+    if (exprs.length !== variables.length) {
+      throw new Error(
+        `solveSystemNumeric: expected ${variables.length} equations for ${variables.length} variables, got ${exprs.length}.`,
+      );
+    }
+    const n = variables.length;
+    const compiled = exprs.map((e) => Symbolic.compile(e));
+    const evalF = (point: number[]): number[] => {
+      const env: Record<string, number> = {};
+      variables.forEach((v, i) => {
+        env[v] = point[i] as number;
+      });
+      return compiled.map((f) => f(env));
+    };
+
+    let x = initialGuess ? [...initialGuess] : new Array(n).fill(1);
+    const h = 1e-6;
+    const maxIterations = 100;
+    const tolerance = 1e-10;
+
+    for (let iter = 0; iter < maxIterations; iter++) {
+      const fx = evalF(x);
+      if (!fx.every(Number.isFinite)) {
+        throw new SystemDidNotConvergeError("solveSystemNumeric: evaluation produced a non-finite value.");
+      }
+      const residualNorm = Math.sqrt(fx.reduce((sum, v) => sum + v * v, 0));
+      if (residualNorm < tolerance) {
+        const result: Record<string, number> = {};
+        variables.forEach((name, i) => {
+          result[name] = x[i] as number;
+        });
+        return result;
+      }
+
+      const jacobian: number[][] = Array.from({ length: n }, () => new Array(n).fill(0));
+      for (let col = 0; col < n; col++) {
+        const perturbed = [...x];
+        perturbed[col] = (perturbed[col] as number) + h;
+        const fPerturbed = evalF(perturbed);
+        for (let row = 0; row < n; row++) {
+          (jacobian[row] as number[])[col] = ((fPerturbed[row] as number) - (fx[row] as number)) / h;
+        }
+      }
+
+      let delta: number[];
+      try {
+        delta = MatrixMath.solve(
+          jacobian,
+          fx.map((v) => -v),
+        );
+      } catch {
+        throw new SystemDidNotConvergeError("solveSystemNumeric: the Jacobian became singular during iteration.");
+      }
+      x = x.map((xi, i) => xi + (delta[i] as number));
+    }
+    throw new SystemDidNotConvergeError(
+      `solveSystemNumeric: did not converge within ${maxIterations} iterations from the given initial guess.`,
+    );
+  }
+
+  /**
+   * Numerically spot-checks that `candidate` is (approximately) a root of
+   * `equation` (the same "implicitly equals zero" convention `solve` uses):
+   * substitutes `candidate` for `variable` and checks the result is near
+   * zero. A lightweight reviewer/verification pass over a CAS result, not a
+   * proof of exactness -- catches an outright wrong candidate (e.g. from a
+   * heuristic search or a downstream bug) before it's presented, using the
+   * same probe-and-compare technique this codebase's own test suite already
+   * relies on for anything heuristic.
+   */
+  static verifySolution(
+    equation: Expr | string,
+    variable: string,
+    candidate: number,
+    env: Record<string, number> = {},
+    tolerance = 1e-6,
+  ): boolean {
+    const value = Symbolic.evaluate(equation, { ...env, [variable]: candidate });
+    return Number.isFinite(value) && Math.abs(value) < tolerance;
+  }
+
+  /**
+   * The `solveSystem`/`solveSystemNumeric` analog of {@link verifySolution}:
+   * substitutes `solution` into every equation and requires all of them to
+   * land near zero.
+   */
+  static verifySystemSolution(
+    equations: (Expr | string)[],
+    solution: Record<string, number>,
+    tolerance = 1e-6,
+  ): boolean {
+    return equations.every((eq) => {
+      const value = Symbolic.evaluate(eq, solution);
+      return Number.isFinite(value) && Math.abs(value) < tolerance;
+    });
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ export { StringEvaluator } from "./StringEvaluator.ts";
 // Algebraic structures & geometry
 export { Structure, type StructureOptions } from "./Structure.ts";
 export {
+  type Assumption,
   type BinaryFuncName,
   type CmpOp,
   type DifferentiationStep,
@@ -81,6 +82,7 @@ export {
   SeriesDivergesError,
   SingularSystemError,
   Symbolic,
+  SystemDidNotConvergeError,
   UndeclaredVariableError,
 } from "./Symbolic.ts";
 export { Type, TypeTag } from "./Type.ts";

--- a/test/Symbolic.test.ts
+++ b/test/Symbolic.test.ts
@@ -8,6 +8,7 @@ import {
   SeriesDivergesError,
   SingularSystemError,
   Symbolic,
+  SystemDidNotConvergeError,
   UndeclaredVariableError,
 } from "../src/Symbolic.ts";
 
@@ -895,4 +896,80 @@ test("evaluate/compile with declaredVariables: strict mode throws on an undeclar
   // Default (no options) behavior is unchanged: missing env entries silently resolve to NaN.
   assert.ok(Number.isNaN(Symbolic.evaluate("a*x", { x: 2 })));
   assert.equal(Symbolic.evaluate("a*x", { x: 2, a: 3 }, { declaredVariables: ["a", "x"] }), 6);
+});
+
+test("solveSystemNumeric solves a genuinely nonlinear system (circle x^2+y^2=25 meets line x-y=1)", () => {
+  const result = Symbolic.solveSystemNumeric(["x^2+y^2-25", "x-y-1"], ["x", "y"], [4, 3]);
+  // Exact intersection points: x-y=1 -> x=y+1; (y+1)^2+y^2=25 -> 2y^2+2y-24=0 -> y=3 or y=-4.
+  // Starting near (4,3) should converge to (4,3).
+  assert.ok(Math.abs(result.x - 4) < 1e-6);
+  assert.ok(Math.abs(result.y - 3) < 1e-6);
+  // Verify by substitution, not just proximity to the expected point.
+  assert.ok(Math.abs(result.x ** 2 + result.y ** 2 - 25) < 1e-6);
+  assert.ok(Math.abs(result.x - result.y - 1) < 1e-6);
+});
+
+test("solveSystemNumeric also solves a plain linear system (Newton reduces to one step)", () => {
+  const result = Symbolic.solveSystemNumeric(["2*x + y - 5", "x - y - 1"], ["x", "y"]);
+  assert.ok(Math.abs(result.x - 2) < 1e-9);
+  assert.ok(Math.abs(result.y - 1) < 1e-9);
+});
+
+test("solveSystemNumeric throws SystemDidNotConvergeError for a system with no real solution", () => {
+  assert.throws(() => Symbolic.solveSystemNumeric(["x^2+1"], ["x"]), SystemDidNotConvergeError);
+});
+
+test("solveSystemNumeric rejects a non-square system", () => {
+  assert.throws(() => Symbolic.solveSystemNumeric(["x + y - 1"], ["x", "y"]));
+});
+
+test("verifySolution accepts a genuine root and rejects a wrong candidate", () => {
+  assert.ok(Symbolic.verifySolution("x^2-4", "x", 2));
+  assert.ok(Symbolic.verifySolution("x^2-4", "x", -2));
+  assert.ok(!Symbolic.verifySolution("x^2-4", "x", 3));
+});
+
+test("verifySolution honors env for free constants alongside the solved variable", () => {
+  assert.ok(Symbolic.verifySolution("k*x-6", "x", 2, { k: 3 }));
+  assert.ok(!Symbolic.verifySolution("k*x-6", "x", 2, { k: 4 }));
+});
+
+test("verifySystemSolution requires every equation to zero out, not just one", () => {
+  const goodSolution = { x: 2, y: 1 };
+  assert.ok(Symbolic.verifySystemSolution(["2*x + y - 5", "x - y - 1"], goodSolution));
+  assert.ok(!Symbolic.verifySystemSolution(["2*x + y - 5", "x - y - 1"], { x: 2, y: 2 }));
+});
+
+test("simplifyAssuming reduces sqrt(x^2) to x when x is assumed positive/nonnegative", () => {
+  assert.equal(Symbolic.toString(Symbolic.simplifyAssuming("sqrt(x^2)", { x: "positive" })), "x");
+  assert.equal(Symbolic.toString(Symbolic.simplifyAssuming("sqrt(x^2)", { x: "nonnegative" })), "x");
+});
+
+test("simplifyAssuming reduces sqrt(x^2) to -x when x is assumed negative/nonpositive", () => {
+  assert.equal(Symbolic.toString(Symbolic.simplifyAssuming("sqrt(x^2)", { x: "negative" })), "-x");
+  assert.equal(Symbolic.toString(Symbolic.simplifyAssuming("sqrt(x^2)", { x: "nonpositive" })), "-x");
+});
+
+test("simplifyAssuming leaves sqrt(x^2) unchanged with no assumption (matches plain simplify)", () => {
+  assert.equal(
+    Symbolic.toString(Symbolic.simplifyAssuming("sqrt(x^2)", {})),
+    Symbolic.toString(Symbolic.simplify("sqrt(x^2)")),
+  );
+});
+
+test("simplifyAssuming reduces abs(x) to x or -x per the sign assumption", () => {
+  assert.equal(Symbolic.toString(Symbolic.simplifyAssuming("abs(x)", { x: "positive" })), "x");
+  assert.equal(Symbolic.toString(Symbolic.simplifyAssuming("abs(x)", { x: "negative" })), "-x");
+});
+
+test("simplifyAssuming applies its rewrite inside a larger expression, then re-simplifies", () => {
+  // sqrt(x^2) + 3*x -> x + 3*x -> 4*x, once x is assumed positive.
+  assert.equal(Symbolic.evaluate(Symbolic.simplifyAssuming("sqrt(x^2) + 3*x", { x: "positive" }), { x: 2 }), 8);
+});
+
+test("simplifyAssuming does not affect unrelated variables", () => {
+  assert.equal(
+    Symbolic.toString(Symbolic.simplifyAssuming("sqrt(y^2)", { x: "positive" })),
+    Symbolic.toString(Symbolic.simplify("sqrt(y^2)")),
+  );
 });


### PR DESCRIPTION
## Summary
- `solveSystemNumeric`: multivariable Newton's method for nonlinear systems, added alongside (not replacing) `solveSystem`'s existing linear-only contract.
- `verifySolution`/`verifySystemSolution`: lightweight numeric spot-checks for a CAS "reviewer" pass.
- `simplifyAssuming`: `sqrt(x^2)`/`abs(x)` simplification once a variable's sign is declared, via a new `Assumption` type.

Sigma/Pi as an embeddable `Expr` variant is consciously deferred (comparable in scope to the cmp/piecewise phase — a new AST variant touching the whole switch surface, parser, and LaTeX round-trip — deserves its own dedicated pass).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run check`
- [x] `npm test` (403 passing)

Part of the mallory-graph feature-adoption roadmap, Wave 5.

https://claude.ai/code/session_018T5JA91K57dZF94vVunLBp