### PR TITLE
math: Rubi-derived integration corpus — 771 curated real-world problems, self-checking via d/dx ∫f = f

### DIFF
--- a/packages/math/scripts/rubi-convert.mjs
+++ b/packages/math/scripts/rubi-convert.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Rubi corpus converter (issue #16): turns a checkout of the MIT-licensed
+ * RuleBasedIntegration/MaximaSyntaxTestSuite into the committed fixture
+ * test/fixtures/rubi-corpus.json consumed by test/RubiCorpus.test.ts.
+ *
+ *   node scripts/rubi-convert.mjs /path/to/MaximaSyntaxTestSuite
+ *
+ * Each .mac entry is a 4-tuple [integrand, variable, rubiStepCount,
+ * optimalAntiderivative] in Maxima's plain-infix syntax. Translation to
+ * Symbolic.parse's grammar is rename-level:
+ *   %pi -> pi                    (both natural-log)      log(x) -> ln(x)
+ *   %e  -> exp(1)                (JS half of signum)     signum -> sign
+ *   e   -> ee   -- CRITICAL: Maxima's plain `e` is a free PARAMETER
+ *                  (Euler's number is `%e`), but Symbolic.parse resolves
+ *                  bare `e` to Euler's constant. Without the rename every
+ *                  problem using the parameter e would silently bind it
+ *                  to 2.718... and the numeric check would test nonsense.
+ *
+ * Problems are kept only when every function called is one Symbolic
+ * supports (drops elliptic_e, polylog, the expintegral family, etc.) and
+ * every remaining identifier is a plain parameter. Curation is
+ * deterministic: per top-level category, every problem is parsed and an
+ * evenly-spaced sample up to PER_CATEGORY is kept — rerunning against the
+ * same suite commit reproduces the same fixture byte-for-byte.
+ */
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PER_CATEGORY = 90;
+
+const root = process.argv[2];
+if (!root) {
+  console.error("usage: node scripts/rubi-convert.mjs /path/to/MaximaSyntaxTestSuite");
+  process.exit(1);
+}
+
+/** Functions Symbolic.parse understands (canonical names after translation). */
+const SUPPORTED_FUNCS = new Set([
+  "sin", "cos", "tan", "cot", "sec", "csc",
+  "asin", "acos", "atan", "acot", "asec", "acsc",
+  "sinh", "cosh", "tanh", "coth", "sech", "csch",
+  "asinh", "acosh", "atanh", "acoth", "asech", "acsch",
+  "exp", "ln", "sqrt", "cbrt", "abs", "erf", "sign",
+  "log10", "log2", "floor", "ceil", "round", "trunc", "expm1", "log1p", "sigmoid", "relu",
+  "atan2", "hypot", "min", "max",
+]);
+
+function* macFiles(dir) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) yield* macFiles(p);
+    else if (entry.endsWith(".mac")) yield p;
+  }
+}
+
+/** Extract top-level [ ... ] groups after the `lst: '[` header. */
+function* entries(text) {
+  const start = text.indexOf("lst:");
+  if (start < 0) return;
+  let i = text.indexOf("[", start) + 1; // inside the outer list
+  let depth = 0;
+  let current = -1;
+  for (; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === "/" && text[i + 1] === "*") {
+      i = text.indexOf("*/", i) + 1;
+      continue;
+    }
+    if (ch === "[") {
+      if (depth === 0) current = i;
+      depth++;
+    } else if (ch === "]") {
+      depth--;
+      if (depth === 0 && current >= 0) {
+        yield text.slice(current + 1, i);
+        current = -1;
+      }
+      if (depth < 0) return; // closed the outer list
+    }
+  }
+}
+
+/** Split a tuple body on top-level commas. */
+function splitTopLevel(body) {
+  const parts = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === "(" || ch === "[") depth++;
+    else if (ch === ")" || ch === "]") depth--;
+    else if (ch === "," && depth === 0) {
+      parts.push(body.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(body.slice(start));
+  return parts.map((s) => s.trim());
+}
+
+function translate(maxima) {
+  let s = maxima.replace(/%pi/g, "pi").replace(/%e\b/g, "exp(1)");
+  // Token-level renames (never inside longer identifiers):
+  s = s.replace(/\blog\(/g, "ln(").replace(/\bsignum\(/g, "sign(").replace(/\be\b/g, "ee");
+  return s;
+}
+
+const IDENT_RE = /[A-Za-z_][A-Za-z0-9_]*/g;
+
+/** Validate a translated expression: every called identifier supported,
+ * every non-call identifier a plain parameter; no leftover Maxima syntax. */
+function analyze(expr) {
+  if (expr.includes("%") || expr.includes("!") || expr.includes(":=") || expr.includes("'")) return null;
+  const params = new Set();
+  for (const m of expr.matchAll(IDENT_RE)) {
+    const name = m[0];
+    const isCall = expr[m.index + name.length] === "(";
+    if (isCall) {
+      if (!SUPPORTED_FUNCS.has(name)) return null;
+    } else if (name !== "pi") {
+      if (name.length > 2) return null; // unexpected long symbol — likely an untranslated construct
+      params.add(name);
+    }
+  }
+  return params;
+}
+
+const categories = readdirSync(root).filter((d) => /^\d/.test(d) && statSync(join(root, d)).isDirectory());
+const fixture = [];
+let scanned = 0;
+let kept = 0;
+
+for (const category of categories.sort()) {
+  const candidates = [];
+  for (const file of macFiles(join(root, category))) {
+    const text = readFileSync(file, "utf8");
+    for (const [index, raw] of [...entries(text)].entries()) {
+      scanned++;
+      const parts = splitTopLevel(raw);
+      if (parts.length !== 4) continue;
+      const [integrandM, variable, stepsStr, antiM] = parts;
+      const steps = Number(stepsStr);
+      if (!Number.isInteger(steps) || variable !== "x") continue;
+      const integrand = translate(integrandM);
+      const antiderivative = translate(antiM);
+      const p1 = analyze(integrand);
+      const p2 = analyze(antiderivative);
+      if (!p1 || !p2) continue;
+      const params = [...new Set([...p1, ...p2])].filter((v) => v !== "x").sort();
+      candidates.push({
+        source: file.slice(root.length + 1),
+        index,
+        integrand,
+        variable: "x",
+        steps,
+        antiderivative,
+        params,
+      });
+    }
+  }
+  // Deterministic evenly-spaced sample.
+  const stride = Math.max(1, Math.floor(candidates.length / PER_CATEGORY));
+  const sampled = candidates.filter((_, i) => i % stride === 0).slice(0, PER_CATEGORY);
+  kept += sampled.length;
+  fixture.push(...sampled);
+  console.log(`${category}: ${candidates.length} convertible, kept ${sampled.length}`);
+}
+
+const out = {
+  attribution:
+    "Derived from RuleBasedIntegration/MaximaSyntaxTestSuite (https://github.com/RuleBasedIntegration/MaximaSyntaxTestSuite), MIT License, Copyright (c) 2018 Rule-based Integration. Converted by scripts/rubi-convert.mjs (Maxima -> mallory-math Symbolic syntax).",
+  problems: fixture,
+};
+writeFileSync(new URL("../test/fixtures/rubi-corpus.json", import.meta.url), `${JSON.stringify(out, null, 1)}\n`);
+console.log(`scanned ${scanned} entries, kept ${kept} -> test/fixtures/rubi-corpus.json`);

--- a/packages/math/test/RubiCorpus.test.ts
+++ b/packages/math/test/RubiCorpus.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Rubi-derived integration corpus (issue #16): 771 problems curated from
+ * the MIT-licensed RuleBasedIntegration/MaximaSyntaxTestSuite (72,254
+ * problems scanned; see test/fixtures/rubi-corpus.json's attribution field
+ * and scripts/rubi-convert.mjs for regeneration).
+ *
+ * Tier 1 — derivative verification, broad: for every problem, differentiate
+ * Rubi's OWN optimal antiderivative with Symbolic.differentiate and check
+ * numeric equivalence with the integrand at sampled in-domain points. The
+ * calculus identity d/dx ∫f = f is self-checking — no external oracle, no
+ * subprocess, plain CI — and exercises parse/differentiate/evaluate across
+ * hundreds of real-world expressions far gnarlier than any hand-written
+ * test.
+ *
+ * Tier 2 — integrate verification, narrow: for low-step-count problems that
+ * Symbolic.integrate accepts, its own antiderivative must differentiate
+ * back to the integrand numerically. Rubi's form is never string-compared
+ * (antiderivatives legitimately differ by constants and simplification);
+ * NotIntegrableError is an expected, counted outcome, not a failure.
+ *
+ * Sampling: parameters (a, b, c, ...) and x are bound from fixed value
+ * sets; a (params, x) combo counts only when integrand AND differentiated
+ * antiderivative both evaluate finite and moderate there (fractional powers
+ * of negatives, log of negatives, poles etc. make combos invalid, not
+ * wrong). Problems that never yield enough valid combos are counted and
+ * bounded — a coverage-collapse guard keeps the suite from going vacuous,
+ * per the Woxi exception discipline (no silent skips).
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Symbolic, NotIntegrableError, type Expr } from "../src/index.ts";
+
+interface RubiProblem {
+  source: string;
+  index: number;
+  integrand: string;
+  variable: string;
+  steps: number;
+  antiderivative: string;
+  params: string[];
+}
+
+const HERE = new URL(".", import.meta.url).pathname;
+const CORPUS = JSON.parse(readFileSync(join(HERE, "fixtures/rubi-corpus.json"), "utf8")) as {
+  attribution: string;
+  problems: RubiProblem[];
+};
+
+// Fixed parameter/point value sets — varied signs and magnitudes, nothing
+// at obvious symmetry points (0, 1) where a wrong formula could hide.
+const PARAM_SETS = [
+  { a: 2.3, b: 1.7, c: 0.6, d: 1.9, ee: 2.6, f: 1.3, g: 0.8, m: 2, n: 3, p: 2, q: 1.4, r: 0.9, s: 1.1 },
+  { a: 0.7, b: -1.2, c: 1.8, d: 0.5, ee: 1.1, f: -0.6, g: 1.5, m: 3, n: 2, p: 1, q: 0.8, r: 1.6, s: 0.4 },
+  { a: -1.4, b: 2.1, c: -0.9, d: 2.4, ee: 0.9, f: 1.8, g: -0.5, m: 2, n: 4, p: 3, q: -1.1, r: 0.6, s: 2.2 },
+] as const;
+const X_VALUES = [0.37, 0.81, 1.42, 2.19, -0.53, -1.27];
+
+const RTOL = 1e-5;
+const ATOL = 1e-7;
+const MAGNITUDE_CAP = 1e8;
+
+function evalFinite(expr: Expr, env: Record<string, number>): number | null {
+  try {
+    const v = Symbolic.evaluate(expr, env);
+    return Number.isFinite(v) && Math.abs(v) < MAGNITUDE_CAP ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+interface CheckOutcome {
+  compared: number;
+  mismatch?: { env: Record<string, number>; expected: number; got: number };
+}
+
+/** Compare d/dx(antiderivative) against integrand across the sample grid. */
+function checkDerivativeIdentity(integrand: Expr, derivative: Expr, params: readonly string[]): CheckOutcome {
+  let compared = 0;
+  for (const paramSet of PARAM_SETS) {
+    for (const x of X_VALUES) {
+      const env: Record<string, number> = { x };
+      for (const p of params) env[p] = (paramSet as Record<string, number>)[p] ?? 1.5;
+      const f = evalFinite(integrand, env);
+      const dF = evalFinite(derivative, env);
+      if (f === null || dF === null) continue; // out of domain / pole — invalid combo, not wrong
+      compared++;
+      if (Math.abs(f - dF) > ATOL + RTOL * Math.max(Math.abs(f), Math.abs(dF))) {
+        return { compared, mismatch: { env, expected: f, got: dF } };
+      }
+    }
+  }
+  return { compared };
+}
+
+const MIN_COMPARABLE_POINTS = 4;
+
+test(`tier 1: d/dx of Rubi's antiderivative matches the integrand (${CORPUS.problems.length} corpus problems)`, () => {
+  assert.ok(CORPUS.problems.length >= 700, `fixture shrank to ${CORPUS.problems.length} problems — regenerate or investigate`);
+  let verified = 0;
+  let insufficientDomain = 0;
+  const failures: string[] = [];
+
+  for (const problem of CORPUS.problems) {
+    let integrand: Expr;
+    let derivative: Expr;
+    try {
+      integrand = Symbolic.parse(problem.integrand);
+      derivative = Symbolic.differentiate(Symbolic.parse(problem.antiderivative), problem.variable);
+    } catch (e) {
+      failures.push(`${problem.source}#${problem.index}: parse/differentiate threw: ${(e as Error).message}`);
+      continue;
+    }
+    const outcome = checkDerivativeIdentity(integrand, derivative, problem.params);
+    if (outcome.mismatch) {
+      failures.push(
+        `${problem.source}#${problem.index}: ∫ ${problem.integrand}\n  d/dx(rubi antiderivative) = ${outcome.mismatch.got} but integrand = ${outcome.mismatch.expected} at ${JSON.stringify(outcome.mismatch.env)}`,
+      );
+    } else if (outcome.compared >= MIN_COMPARABLE_POINTS) {
+      verified++;
+    } else {
+      insufficientDomain++; // e.g. sqrt(a+b*x) real only on a sliver none of the fixed sets hit
+    }
+  }
+
+  assert.deepEqual(failures.slice(0, 10), [], `${failures.length} corpus problems diverged (first 10 shown)`);
+  // Coverage-collapse guard: most problems must actually be VERIFIED, not
+  // quietly domain-skipped — if this ratio drops, the sampling sets or the
+  // converter have drifted.
+  assert.ok(
+    verified >= CORPUS.problems.length * 0.7,
+    `only ${verified}/${CORPUS.problems.length} problems fully verified (${insufficientDomain} lacked in-domain sample coverage)`,
+  );
+});
+
+test("tier 2: where Symbolic.integrate accepts a low-step problem, its OWN antiderivative differentiates back to the integrand", () => {
+  const easy = CORPUS.problems.filter((p) => p.steps > 0 && p.steps <= 2);
+  assert.ok(easy.length >= 100, `corpus has only ${easy.length} 1-2 step problems`);
+  let attempted = 0;
+  let integrated = 0;
+  let declined = 0;
+  const failures: string[] = [];
+
+  for (const problem of easy) {
+    let integrand: Expr;
+    try {
+      integrand = Symbolic.parse(problem.integrand);
+    } catch {
+      continue;
+    }
+    attempted++;
+    let own: Expr;
+    try {
+      own = Symbolic.integrate(integrand, problem.variable);
+    } catch (e) {
+      if (e instanceof NotIntegrableError) {
+        declined++; // honest "outside my elementary rules" — expected, counted
+        continue;
+      }
+      failures.push(`${problem.source}#${problem.index}: integrate threw non-NotIntegrable: ${(e as Error).message}`);
+      continue;
+    }
+    let derivative: Expr;
+    try {
+      derivative = Symbolic.differentiate(own, problem.variable);
+    } catch (e) {
+      failures.push(`${problem.source}#${problem.index}: differentiating our own antiderivative threw: ${(e as Error).message}`);
+      continue;
+    }
+    const outcome = checkDerivativeIdentity(integrand, derivative, problem.params);
+    if (outcome.mismatch) {
+      failures.push(
+        `${problem.source}#${problem.index}: ∫ ${problem.integrand} — OUR antiderivative ${Symbolic.toString(own)} is WRONG: ` +
+          `d/dx gives ${outcome.mismatch.got}, integrand is ${outcome.mismatch.expected} at ${JSON.stringify(outcome.mismatch.env)}`,
+      );
+    } else if (outcome.compared >= MIN_COMPARABLE_POINTS) {
+      integrated++;
+    }
+  }
+
+  assert.deepEqual(failures.slice(0, 10), [], `${failures.length} of our own antiderivatives are wrong (first 10 shown)`);
+  // integrate() declining is fine; SUCCEEDING WRONGLY is the only failure.
+  // But require a floor so a regression to decline-everything can't pass
+  // silently. The floor is the MEASURED baseline at corpus-generation time
+  // (7 verified of 181 attempted, 174 honest declines -- Rubi's low-step
+  // problems lean on symbolic-exponent forms like (a+b*x)^m that are
+  // outside mallory's documented elementary-rule coverage), minus headroom.
+  // This is a coverage ratchet, not a correctness claim; raise it when
+  // integrate() grows.
+  assert.ok(
+    integrated >= 5,
+    `integrate() verified only ${integrated}/${attempted} low-step problems (declined ${declined}) — coverage regressed below the measured baseline of 7`,
+  );
+  console.log(`[rubi tier 2] ${integrated} integrated+verified, ${declined} honestly declined, of ${attempted} low-step problems`);
+});

--- a/packages/math/test/fixtures/rubi-corpus.json
+++ b/packages/math/test/fixtures/rubi-corpus.json
@@ -1,0 +1,9832 @@
+{
+ "attribution": "Derived from RuleBasedIntegration/MaximaSyntaxTestSuite (https://github.com/RuleBasedIntegration/MaximaSyntaxTestSuite), MIT License, Copyright (c) 2018 Rule-based Integration. Converted by scripts/rubi-convert.mjs (Maxima -> mallory-math Symbolic syntax).",
+ "problems": [
+  {
+   "source": "0 Independent test suites/Apostol Problems.mac",
+   "index": 0,
+   "integrand": "sqrt(1+2*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/3*(1+2*x)^(3/2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Apostol Problems.mac",
+   "index": 20,
+   "integrand": "(1-2*x+x^2)^(1/5)/(1-x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-5/2*(1-2*x+x^2)^(1/5)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Apostol Problems.mac",
+   "index": 38,
+   "integrand": "(a^2-x^2)^(5/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "5/24*a^2*x*(a^2-x^2)^(3/2)+1/6*x*(a^2-x^2)^(5/2)+5/16*a^6*atan(x/sqrt(a^2-x^2))+5/16*a^4*x*sqrt(a^2-x^2)",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Apostol Problems.mac",
+   "index": 57,
+   "integrand": "x*ln(x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-1/4*x^2+1/2*x^2*ln(x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Apostol Problems.mac",
+   "index": 77,
+   "integrand": "exp(1)^sqrt(x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-2*exp(1)^sqrt(x)+2*exp(1)^sqrt(x)*sqrt(x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Apostol Problems.mac",
+   "index": 95,
+   "integrand": "atan(sqrt(x))/((1+x)*sqrt(x))",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "atan(sqrt(x))^2",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Apostol Problems.mac",
+   "index": 113,
+   "integrand": "x/(4-x^2+sqrt(4-x^2))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-ln(1+sqrt(4-x^2))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Apostol Problems.mac",
+   "index": 131,
+   "integrand": "(1+x)/(-1+x^3)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2/3*ln(1-x)-1/3*ln(1+x+x^2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Apostol Problems.mac",
+   "index": 149,
+   "integrand": "sqrt(3-x^2)/x",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-atanh(sqrt(3-x^2)/sqrt(3))*sqrt(3)+sqrt(3-x^2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Bondarenko Problems.mac",
+   "index": 16,
+   "integrand": "sqrt(x+sqrt(1+x))/x^2",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-1/4*atan(1/2*(3+sqrt(1+x))/sqrt(x+sqrt(1+x)))+3/4*atanh(1/2*(1-3*sqrt(1+x))/sqrt(x+sqrt(1+x)))-sqrt(x+sqrt(1+x))/x",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Charlwood Problems.mac",
+   "index": 1,
+   "integrand": "x*asin(x)/sqrt(1-x^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "x-asin(x)*sqrt(1-x^2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Charlwood Problems.mac",
+   "index": 22,
+   "integrand": "x*atan(x)*ln(x+sqrt(1+x^2))/sqrt(1+x^2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-x*atan(x)+1/2*ln(1+x^2)-1/2*ln(x+sqrt(1+x^2))^2+atan(x)*ln(x+sqrt(1+x^2))*sqrt(1+x^2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Charlwood Problems.mac",
+   "index": 40,
+   "integrand": "ln(sin(x))*sqrt(1+sin(x))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-4*atanh(cos(x)/sqrt(1+sin(x)))+4*cos(x)/sqrt(1+sin(x))-2*cos(x)*ln(sin(x))/sqrt(1+sin(x))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 11,
+   "integrand": "x/((-a+x)*(-b+x)*(-c+x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "a*ln(a-x)/((a-b)*(a-c))-b*ln(b-x)/((a-b)*(b-c))+c*ln(c-x)/((a-c)*(b-c))",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 29,
+   "integrand": "1/(x^2*(a+b*x)^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(-1)/(a^2*x)-b/(a^2*(a+b*x))-2*b*ln(x)/a^3+2*b*ln(a+b*x)/a^3",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 47,
+   "integrand": "1/(2+x^6)",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "1/3*atan(x/2^(1/6))/2^(5/6)-1/6*atan(-2^(5/6)*x+sqrt(3))/2^(5/6)+1/6*atan(2^(5/6)*x+sqrt(3))/2^(5/6)-1/4*ln(2^(1/3)+x^2-2^(1/6)*x*sqrt(3))/(2^(5/6)*sqrt(3))+1/4*ln(2^(1/3)+x^2+2^(1/6)*x*sqrt(3))/(2^(5/6)*sqrt(3))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 68,
+   "integrand": "x^2*ln(b+a*x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/3*b^2*x/a^2+1/6*b*x^2/a-1/9*x^3+1/3*b^3*ln(b+a*x)/a^3+1/3*x^3*ln(b+a*x)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 88,
+   "integrand": "cos(x)^3",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "sin(x)-1/3*sin(x)^3",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 110,
+   "integrand": "1/sin(a+b*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-atanh(cos(a+b*x))/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 130,
+   "integrand": "cos(3*x)*sin(2*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/2*cos(x)-1/10*cos(5*x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 149,
+   "integrand": "exp(1)^x",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "exp(1)^x",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 174,
+   "integrand": "ln(x)/sqrt(b+a*x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "4*atanh(sqrt(b+a*x)/sqrt(b))*sqrt(b)/a-4*sqrt(b+a*x)/a+2*ln(x)*sqrt(b+a*x)/a",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 192,
+   "integrand": "x/sqrt(1-x^2)^(9/4)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "4/(1-x^2)^(1/8)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 220,
+   "integrand": "1/(x*(1+x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "ln(x)-ln(1+x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 239,
+   "integrand": "1/(1-(1+x)^(1/2))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-2*ln(1-sqrt(1+x))-2*sqrt(1+x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 258,
+   "integrand": "1/(5+x^3)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "1/3*ln(5^(1/3)+x)/5^(2/3)-1/6*ln(5^(2/3)-5^(1/3)*x+x^2)/5^(2/3)-atan((5^(1/3)-2*x)/(5^(1/3)*sqrt(3)))/(5^(2/3)*sqrt(3))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Hearn Problems.mac",
+   "index": 279,
+   "integrand": "x*(-sqrt(-4+x^2)+x^2*sqrt(-4+x^2)-4*sqrt(-1+x^2)+x^2*sqrt(-1+x^2))/((4-5*x^2+x^4)*(1+sqrt(-4+x^2)+sqrt(-1+x^2)))",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "ln(1+sqrt(-4+x^2)+sqrt(-1+x^2))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Moses Problems.mac",
+   "index": 2,
+   "integrand": "(x+x^2)/sqrt(x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "2/3*x^(3/2)+2/5*x^(5/2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Moses Problems.mac",
+   "index": 22,
+   "integrand": "exp(1)^x*cos(exp(1)^x)^2*sin(exp(1)^x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/3*cos(exp(1)^x)^3",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Moses Problems.mac",
+   "index": 43,
+   "integrand": "exp(1)^x*x",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-exp(1)^x+exp(1)^x*x",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Moses Problems.mac",
+   "index": 65,
+   "integrand": "1/(x*(1+ln(x)^2))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "atan(ln(x))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Moses Problems.mac",
+   "index": 90,
+   "integrand": "cos(x)*sin(x)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/3*sin(x)^3",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Moses Problems.mac",
+   "index": 108,
+   "integrand": "r/sqrt(-a^2+2*exp(1)*r^2)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "r*x/sqrt(-a^2+2*exp(1)*r^2)",
+   "params": [
+    "a",
+    "r"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 13,
+   "integrand": "cot(x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "ln(sin(x))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 41,
+   "integrand": "cos(5*x)*sin(3*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/4*cos(2*x)-1/16*cos(8*x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 59,
+   "integrand": "cos(x)^4",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "3/8*x+3/8*cos(x)*sin(x)+1/4*cos(x)^3*sin(x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 77,
+   "integrand": "cos(x)^2*tan(x)^3",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/2*cos(x)^2-ln(cos(x))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 95,
+   "integrand": "sec(x)^2/cot(x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*sec(x)^2",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 113,
+   "integrand": "sin(x)^2*tan(x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/2*cos(x)^2-ln(cos(x))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 131,
+   "integrand": "1/(x^3*sqrt(-16+x^2))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/128*atan(1/4*sqrt(-16+x^2))+1/32*sqrt(-16+x^2)/x^2",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 151,
+   "integrand": "1/sqrt(a^2+x^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "atanh(x/sqrt(a^2+x^2))",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 169,
+   "integrand": "(1+x^2+x^4)/((1+x^2)*(4+x^2)^2)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-13/24*x/(4+x^2)+25/144*atan(1/2*x)+1/9*atan(x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 187,
+   "integrand": "1/((-1+x)^2*(4+x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/5/(1-x)-1/25*ln(1-x)+1/25*ln(4+x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 205,
+   "integrand": "x^4/(-1+x^4)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "x-1/2*atan(x)-1/2*atanh(x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 223,
+   "integrand": "sqrt(x)/(1+x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-2*atan(sqrt(x))+2*sqrt(x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 241,
+   "integrand": "sqrt(1-exp(1)^x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-2*atanh(sqrt(1-exp(1)^x))+2*sqrt(1-exp(1)^x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 259,
+   "integrand": "(5+2*x)/(-3+x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "2*x+11*ln(3-x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 277,
+   "integrand": "cos(x)/(1+sin(x)^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "atan(sin(x))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 295,
+   "integrand": "x/(1-x^2+sqrt(1-x^2))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-ln(1+sqrt(1-x^2))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 313,
+   "integrand": "cot(2*x)^3*csc(2*x)^3",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/6*csc(2*x)^3-1/10*csc(2*x)^5",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 333,
+   "integrand": "1/(-exp(1)^x+exp(1)^(3*x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/exp(1)^x-atanh(exp(1)^x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 351,
+   "integrand": "x^2*cos(3*x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2/9*x*cos(3*x)-2/27*sin(3*x)+1/3*x^2*sin(3*x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Stewart Problems.mac",
+   "index": 370,
+   "integrand": "cos(x)^3*sin(x)^3",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/4*sin(x)^4-1/6*sin(x)^6",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 12,
+   "integrand": "cos(x)/(a^2-b^2*sin(x)^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "atanh(b*sin(x)/a)/(a*b)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 32,
+   "integrand": "cos(x)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*x+1/2*cos(x)*sin(x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 50,
+   "integrand": "1/(x*sqrt(-a^2+x^2))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "atan(sqrt(-a^2+x^2)/a)/a",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 71,
+   "integrand": "ln(x)/x^5",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "(-1/16)/x^4-1/4*ln(x)/x^4",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 91,
+   "integrand": "1/(2-7*x+3*x^2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/5*ln(1-3*x)+1/5*ln(2-x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 110,
+   "integrand": "x/((1+x)*(1+2*x)^2*(1+x^2))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "2/5/(1+2*x)+1/50*atan(x)-1/2*ln(1+x)+16/25*ln(1+2*x)-7/100*ln(1+x^2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 129,
+   "integrand": "1/(x^2*(a^4-x^4))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "(-1)/(a^4*x)-1/2*atan(x/a)/a^5+1/2*atanh(x/a)/a^5",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 149,
+   "integrand": "(-41+55*x-27*x^2+5*x^3)/(5-4*x+x^2)^2",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "(1-x)/(5-4*x+x^2)-2*atan(2-x)+5/2*ln(5-4*x+x^2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 169,
+   "integrand": "x^5/(1+x^4)^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/8*x^2/(1+x^4)^2+1/16*x^2/(1+x^4)+1/16*atan(x^2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 189,
+   "integrand": "(b1+c1*x)*(a+2*b*x+c*x^2)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "a^2*b1*x+1/2*a*(4*b*b1+a*c1)*x^2+2/3*(2*b^2*b1+a*b1*c+2*a*b*c1)*x^3+1/2*(2*b*b1*c+2*b^2*c1+a*c*c1)*x^4+1/5*c*(b1*c+4*b*c1)*x^5+1/6*c^2*c1*x^6",
+   "params": [
+    "a",
+    "b",
+    "b1",
+    "c",
+    "c1"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 209,
+   "integrand": "1/(1+sqrt(1+x))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-2*ln(1+sqrt(1+x))+2*sqrt(1+x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 233,
+   "integrand": "1/(9+3*x-5*x^2+x^3)^(4/3)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "3/20*(3-x)*(1+x)/(9+3*x-5*x^2+x^3)^(4/3)+9/80*(3-x)^2*(1+x)/(9+3*x-5*x^2+x^3)^(4/3)-27/320*(3-x)^3*(1+x)/(9+3*x-5*x^2+x^3)^(4/3)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 252,
+   "integrand": "x/(1+x^2+a*sqrt(1+x^2))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "ln(a+sqrt(1+x^2))",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 270,
+   "integrand": "x^2*sqrt(1+x+x^2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-5/24*(1+x+x^2)^(3/2)+1/4*x*(1+x+x^2)^(3/2)+3/128*asinh((1+2*x)/sqrt(3))+1/64*(1+2*x)*sqrt(1+x+x^2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 288,
+   "integrand": "x^2/(1+2*x+2*sqrt(1+x+x^2))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-1/9*x^3-1/6*x^4-5/36*(1+x+x^2)^(3/2)+1/6*x*(1+x+x^2)^(3/2)+1/64*asinh((1+2*x)/sqrt(3))+1/96*(1+2*x)*sqrt(1+x+x^2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 307,
+   "integrand": "x^3/((-1+x^4)*sqrt(1+2*x^8))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/4*atanh((1+2*x^4)/(sqrt(3)*sqrt(1+2*x^8)))/sqrt(3)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 328,
+   "integrand": "1/((1+x^(2*n))*(-x^2+(1+x^(2*n))^(1/n))^(1/2))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "atan(x/sqrt(-x^2+(1+x^(2*n))^(1/n)))",
+   "params": [
+    "n"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 347,
+   "integrand": "cos(x)^2*sin(x)^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/8*x+1/8*cos(x)*sin(x)-1/4*cos(x)^3*sin(x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 367,
+   "integrand": "cos(x)*cos(4*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/6*sin(3*x)+1/10*sin(5*x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 389,
+   "integrand": "sqrt(1+sin(2*x))",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-cos(2*x)/sqrt(1+sin(2*x))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 408,
+   "integrand": "1/(cos(x)^3*sqrt(sin(2*x)))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "4/5*sec(x)*sqrt(sin(2*x))+1/5*sec(x)^3*sqrt(sin(2*x))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 436,
+   "integrand": "(-3+cos(2*x))/(cos(x)^4*sqrt(4-cot(x)^2))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-2/3*sqrt(4-cot(x)^2)*tan(x)-1/3*sqrt(4-cot(x)^2)*tan(x)^3",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 459,
+   "integrand": "1/(x*(-4+x^2)^4)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/24/(4-x^2)^3+1/64/(4-x^2)^2+1/128/(4-x^2)+1/256*ln(x)-1/512*ln(4-x^2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 478,
+   "integrand": "(1-2*x-2*x^2)^3",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "x-3*x^2+2*x^3+4*x^4-12/5*x^5-4*x^6-8/7*x^7",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 500,
+   "integrand": "(1/a^(4*x)-a^(2*x))^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "3*x+(-1/12)/(a^(12*x)*ln(a))+1/2/(a^(6*x)*ln(a))-1/6*a^(6*x)/ln(a)",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 523,
+   "integrand": "(-1+exp(1)^x)/(1+exp(1)^x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-x+2*ln(1+exp(1)^x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 544,
+   "integrand": "exp(1)^(m*x)*sin(x)^3",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-6*exp(1)^(m*x)*cos(x)/(9+10*m^2+m^4)+6*exp(1)^(m*x)*m*sin(x)/(9+10*m^2+m^4)-3*exp(1)^(m*x)*cos(x)*sin(x)^2/(9+m^2)+exp(1)^(m*x)*m*sin(x)^3/(9+m^2)",
+   "params": [
+    "m"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 573,
+   "integrand": "sech(x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "atan(sinh(x))",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 593,
+   "integrand": "sinh(x)^2*sinh(2*x)/(1-sinh(x)^2)^(3/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "2/sqrt(1-sinh(x)^2)+2*sqrt(1-sinh(x)^2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 612,
+   "integrand": "-1-8*ln(x)^2+3*ln(x)^3",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-35*x+34*x*ln(x)-17*x*ln(x)^2+3*x*ln(x)^3",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 633,
+   "integrand": "(1/exp(1)^ln(cos(x))+exp(1)^ln(cos(x)))*tan(x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-cos(x)+sec(x)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 651,
+   "integrand": "acos(x)*sqrt(1-x^2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/4*x^2-1/4*acos(x)^2+1/2*x*acos(x)*sqrt(1-x^2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Timofeev Problems.mac",
+   "index": 672,
+   "integrand": "x^2*atan(x)/(1+x^2)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(-1/4)/(1+x^2)-1/2*x*atan(x)/(1+x^2)+1/4*atan(x)^2",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Welz Problems.mac",
+   "index": 3,
+   "integrand": "1/((-4+3*x^2)^2*sqrt(-1+x^2))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "5/16*atanh(1/2*x/sqrt(-1+x^2))+3/8*x*sqrt(-1+x^2)/(4-3*x^2)",
+   "params": []
+  },
+  {
+   "source": "0 Independent test suites/Welz Problems.mac",
+   "index": 25,
+   "integrand": "sqrt(b*x+sqrt(a+b^2*x^2))/sqrt(a+b^2*x^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "2*sqrt(b*x+sqrt(a+b^2*x^2))/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Welz Problems.mac",
+   "index": 44,
+   "integrand": "(1-k*x)/((1+(-2+k)*x)*((1-x)*x*(1-k*x))^(2/3))",
+   "variable": "x",
+   "steps": -1,
+   "antiderivative": "ln(1-(2-k)*x)/(2^(2/3)*(1-k)^(1/3))+1/2*ln(1-k*x)/(2^(2/3)*(1-k)^(1/3))-3/2*ln(-1+k*x+2^(2/3)*(1-k)^(1/3)*((1-x)*x*(1-k*x))^(1/3))/(2^(2/3)*(1-k)^(1/3))-atan((1+2^(1/3)*(1-k*x)/((1-k)^(1/3)*((1-x)*x*(1-k*x))^(1/3)))/sqrt(3))*sqrt(3)/(2^(2/3)*(1-k)^(1/3))",
+   "params": [
+    "k"
+   ]
+  },
+  {
+   "source": "0 Independent test suites/Welz Problems.mac",
+   "index": 62,
+   "integrand": "sqrt(1-x^4)/(1+x^4)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/2*atan(x*(1+x^2)/sqrt(1-x^4))+1/2*atanh(x*(1-x^2)/sqrt(1-x^4))",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.2 (a+b x)^m (c+d x)^n.mac",
+   "index": 0,
+   "integrand": "0",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "0",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.2 (a+b x)^m (c+d x)^n.mac",
+   "index": 219,
+   "integrand": "1/(x^3*(a+b*x)^7)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(-1/2)/(a^7*x^2)+7*b/(a^8*x)+1/6*b^2/(a^3*(a+b*x)^6)+3/5*b^2/(a^4*(a+b*x)^5)+3/2*b^2/(a^5*(a+b*x)^4)+10/3*b^2/(a^6*(a+b*x)^3)+15/2*b^2/(a^7*(a+b*x)^2)+21*b^2/(a^8*(a+b*x))+28*b^2*ln(x)/a^9-28*b^2*ln(a+b*x)/a^9",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.2 (a+b x)^m (c+d x)^n.mac",
+   "index": 437,
+   "integrand": "(a+b*x)^2*sqrt(x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "2/3*a^2*x^(3/2)+4/5*a*b*x^(5/2)+2/7*b^2*x^(7/2)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.2 (a+b x)^m (c+d x)^n.mac",
+   "index": 655,
+   "integrand": "(a+b*x)/x^(4/3)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-3*a/x^(1/3)+3/2*b*x^(2/3)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.2 (a+b x)^m (c+d x)^n.mac",
+   "index": 915,
+   "integrand": "1/(x^2*(a+b*x)^2*sqrt(c*x^2))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2*b/(a^3*sqrt(c*x^2))+(-1/2)/(a^2*x*sqrt(c*x^2))+b^2*x/(a^3*(a+b*x)*sqrt(c*x^2))+3*b^2*x*ln(x)/(a^4*sqrt(c*x^2))-3*b^2*x*ln(a+b*x)/(a^4*sqrt(c*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.2 (a+b x)^m (c+d x)^n.mac",
+   "index": 1160,
+   "integrand": "(3-x)^(1/2)*(-2+x)^(1/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/8*asin(5-2*x)-1/2*(3-x)^(3/2)*sqrt(-2+x)+1/4*sqrt(3-x)*sqrt(-2+x)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.2 (a+b x)^m (c+d x)^n.mac",
+   "index": 1441,
+   "integrand": "1/((a+b*x)^3*(c+d*x)^(5/2))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "35/12*d^2/((b*c-a*d)^3*(c+d*x)^(3/2))+(-1/2)/((b*c-a*d)*(a+b*x)^2*(c+d*x)^(3/2))+7/4*d/((b*c-a*d)^2*(a+b*x)*(c+d*x)^(3/2))-35/4*b^(3/2)*d^2*atanh(sqrt(b)*sqrt(c+d*x)/sqrt(b*c-a*d))/(b*c-a*d)^(9/2)+35/4*b*d^2/((b*c-a*d)^4*sqrt(c+d*x))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.2 (a+b x)^m (c+d x)^n.mac",
+   "index": 1843,
+   "integrand": "(a+b*x)^m*(a+b*(2+m)*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "x*(a+b*x)^(1+m)",
+   "params": [
+    "a",
+    "b",
+    "m"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.3 (a+b x)^m (c+d x)^n (e+f x)^p.mac",
+   "index": 168,
+   "integrand": "(A+B*x)/(x^3*(a+b*x)^3)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/2*A/(a^3*x^2)+(3*A*b-a*B)/(a^4*x)+1/2*b*(A*b-a*B)/(a^3*(a+b*x)^2)+b*(3*A*b-2*a*B)/(a^4*(a+b*x))+3*b*(2*A*b-a*B)*ln(x)/a^5-3*b*(2*A*b-a*B)*ln(a+b*x)/a^5",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.3 (a+b x)^m (c+d x)^n (e+f x)^p.mac",
+   "index": 406,
+   "integrand": "(a+b*x)^(5/2)*(A+B*x)/x^5",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "5/96*b*(A*b-8*a*B)*(a+b*x)^(3/2)/(a*x^2)+1/24*(A*b-8*a*B)*(a+b*x)^(5/2)/(a*x^3)-1/4*A*(a+b*x)^(7/2)/(a*x^4)+5/64*b^3*(A*b-8*a*B)*atanh(sqrt(a+b*x)/sqrt(a))/a^(3/2)+5/64*b^2*(A*b-8*a*B)*sqrt(a+b*x)/(a*x)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.3 (a+b x)^m (c+d x)^n (e+f x)^p.mac",
+   "index": 625,
+   "integrand": "(a+b*x)^(3/2)/(x^2*(c+d*x)^(3/2))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-3*(b*c-a*d)*atanh(sqrt(c)*sqrt(a+b*x)/(sqrt(a)*sqrt(c+d*x)))*sqrt(a)/c^(5/2)-(a+b*x)^(3/2)/(c*x*sqrt(c+d*x))+3*(b*c-a*d)*sqrt(a+b*x)/(c^2*sqrt(c+d*x))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.3 (a+b x)^m (c+d x)^n (e+f x)^p.mac",
+   "index": 874,
+   "integrand": "(a+b*x)^(1/4)/(x*(c+d*x)^(1/4))",
+   "variable": "x",
+   "steps": 11,
+   "antiderivative": "-2*a^(1/4)*atan(c^(1/4)*(a+b*x)^(1/4)/(a^(1/4)*(c+d*x)^(1/4)))/c^(1/4)+2*b^(1/4)*atan(d^(1/4)*(a+b*x)^(1/4)/(b^(1/4)*(c+d*x)^(1/4)))/d^(1/4)-2*a^(1/4)*atanh(c^(1/4)*(a+b*x)^(1/4)/(a^(1/4)*(c+d*x)^(1/4)))/c^(1/4)+2*b^(1/4)*atanh(d^(1/4)*(a+b*x)^(1/4)/(b^(1/4)*(c+d*x)^(1/4)))/d^(1/4)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.3 (a+b x)^m (c+d x)^n (e+f x)^p.mac",
+   "index": 1176,
+   "integrand": "(1-2*x)*(3+5*x)^3/(2+3*x)^6",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "7/15*(3+5*x)^4/(2+3*x)^5+5/12*(3+5*x)^4/(2+3*x)^4",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.3 (a+b x)^m (c+d x)^n (e+f x)^p.mac",
+   "index": 1394,
+   "integrand": "(1-2*x)^3*(2+3*x)^2/(3+5*x)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1179/3125*x-427/625*x^2+164/125*x^3-18/25*x^4+(-1331/15625)/(3+5*x)+1452/3125*ln(3+5*x)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.3 (a+b x)^m (c+d x)^n (e+f x)^p.mac",
+   "index": 1612,
+   "integrand": "1/((1-2*x)^2*(3+5*x)^3)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "4/1331/(1-2*x)+(-5/242)/(3+5*x)^2+(-20/1331)/(3+5*x)-60/14641*ln(1-2*x)+60/14641*ln(3+5*x)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.3 (a+b x)^m (c+d x)^n (e+f x)^p.mac",
+   "index": 1831,
+   "integrand": "sqrt(1-2*x)/((2+3*x)*(3+5*x)^2)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-2*atanh(sqrt(3/7)*sqrt(1-2*x))*sqrt(21)+68*atanh(sqrt(5/11)*sqrt(1-2*x))/sqrt(55)-sqrt(1-2*x)/(3+5*x)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.3 (a+b x)^m (c+d x)^n (e+f x)^p.mac",
+   "index": 2049,
+   "integrand": "(2+3*x)^2/((3+5*x)^3*sqrt(1-2*x))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-2313/3025*atanh(sqrt(5/11)*sqrt(1-2*x))/sqrt(55)-1/550*sqrt(1-2*x)/(3+5*x)^2-27/1210*sqrt(1-2*x)/(3+5*x)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.3 (a+b x)^m (c+d x)^n (e+f x)^p.mac",
+   "index": 2267,
+   "integrand": "(3+5*x)^(3/2)*sqrt(1-2*x)/(2+3*x)^2",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "41/27*asin(sqrt(2/11)*sqrt(3+5*x))*sqrt(5/2)+107/27*atan(sqrt(1-2*x)/(sqrt(7)*sqrt(3+5*x)))/sqrt(7)-1/3*(3+5*x)^(3/2)*sqrt(1-2*x)/(2+3*x)+10/9*sqrt(1-2*x)*sqrt(3+5*x)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.3 (a+b x)^m (c+d x)^n (e+f x)^p.mac",
+   "index": 2485,
+   "integrand": "(2+3*x)^4/((3+5*x)^(3/2)*sqrt(1-2*x))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "143283/8000*asin(sqrt(2/11)*sqrt(3+5*x))/sqrt(10)-2/55*(2+3*x)^3*sqrt(1-2*x)/sqrt(3+5*x)-21/550*(2+3*x)^2*sqrt(1-2*x)*sqrt(3+5*x)-21/88000*(8987+3660*x)*sqrt(1-2*x)*sqrt(3+5*x)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.1 Linear/1.1.1.4 (a+b x)^m (c+d x)^n (e+f x)^p (g+h x)^q.mac",
+   "index": 22,
+   "integrand": "x^2*(1+a*x)/(sqrt(a*x)*sqrt(1-a*x))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-11/16*asin(1-2*a*x)/a^3-11/12*(a*x)^(3/2)*sqrt(1-a*x)/a^3-1/3*(a*x)^(5/2)*sqrt(1-a*x)/a^3-11/8*sqrt(a*x)*sqrt(1-a*x)/a^3",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.2 Quadratic/1.1.2.2 (c x)^m (a+b x^2)^p.mac",
+   "index": 117,
+   "integrand": "(a+b*x^2)^8/x^10",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/9*a^8/x^9-8/7*a^7*b/x^7-28/5*a^6*b^2/x^5-56/3*a^5*b^3/x^3-70*a^4*b^4/x+56*a^3*b^5*x+28/3*a^2*b^6*x^3+8/5*a*b^7*x^5+1/7*b^8*x^7",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.2 Quadratic/1.1.2.2 (c x)^m (a+b x^2)^p.mac",
+   "index": 335,
+   "integrand": "1/(x^(7/2)*(1+x^2)^3)",
+   "variable": "x",
+   "steps": 14,
+   "antiderivative": "(-117/80)/x^(5/2)+1/4/(x^(5/2)*(1+x^2)^2)+13/16/(x^(5/2)*(1+x^2))-117/32*atan(1-sqrt(2)*sqrt(x))/sqrt(2)+117/32*atan(1+sqrt(2)*sqrt(x))/sqrt(2)+117/64*ln(1+x-sqrt(2)*sqrt(x))/sqrt(2)-117/64*ln(1+x+sqrt(2)*sqrt(x))/sqrt(2)+117/16/sqrt(x)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.2 Quadratic/1.1.2.2 (c x)^m (a+b x^2)^p.mac",
+   "index": 563,
+   "integrand": "1/(x^5*sqrt(-9+4*x^2))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "2/81*atan(1/3*sqrt(-9+4*x^2))+1/36*sqrt(-9+4*x^2)/x^4+1/54*sqrt(-9+4*x^2)/x^2",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.2 Quadratic/1.1.2.3 (a+b x^2)^p (c+d x^2)^q.mac",
+   "index": 76,
+   "integrand": "1/(a+b*x^2)^(1/2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "atanh(x*sqrt(b)/sqrt(a+b*x^2))/sqrt(b)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.2 Quadratic/1.1.2.4 (e x)^m (a+b x^2)^p (c+d x^2)^q.mac",
+   "index": 140,
+   "integrand": "x^4*(a+b*x^2)^2*(c+d*x^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/5*a^2*c*x^5+1/7*a*(2*b*c+a*d)*x^7+1/9*b*(b*c+2*a*d)*x^9+1/11*b^2*d*x^11",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.2 Quadratic/1.1.2.4 (e x)^m (a+b x^2)^p (c+d x^2)^q.mac",
+   "index": 376,
+   "integrand": "x^(3/2)*(A+B*x^2)/(a+b*x^2)^2",
+   "variable": "x",
+   "steps": 12,
+   "antiderivative": "1/2*(A*b-a*B)*x^(5/2)/(a*b*(a+b*x^2))-1/4*(A*b-5*a*B)*atan(1-b^(1/4)*sqrt(2)*sqrt(x)/a^(1/4))/(a^(3/4)*b^(9/4)*sqrt(2))+1/4*(A*b-5*a*B)*atan(1+b^(1/4)*sqrt(2)*sqrt(x)/a^(1/4))/(a^(3/4)*b^(9/4)*sqrt(2))-1/8*(A*b-5*a*B)*ln(sqrt(a)+x*sqrt(b)-a^(1/4)*b^(1/4)*sqrt(2)*sqrt(x))/(a^(3/4)*b^(9/4)*sqrt(2))+1/8*(A*b-5*a*B)*ln(sqrt(a)+x*sqrt(b)+a^(1/4)*b^(1/4)*sqrt(2)*sqrt(x))/(a^(3/4)*b^(9/4)*sqrt(2))-1/2*(A*b-5*a*B)*sqrt(x)/(a*b^2)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.2 Quadratic/1.1.2.4 (e x)^m (a+b x^2)^p (c+d x^2)^q.mac",
+   "index": 594,
+   "integrand": "(A+B*x^2)/(x^4*(a+b*x^2)^(5/2))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/3*A/(a*x^3*(a+b*x^2)^(3/2))+(2*A*b-a*B)/(a^2*x*(a+b*x^2)^(3/2))+4/3*b*(2*A*b-a*B)*x/(a^3*(a+b*x^2)^(3/2))+8/3*b*(2*A*b-a*B)*x/(a^4*sqrt(a+b*x^2))",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.2 Quadratic/1.1.2.4 (e x)^m (a+b x^2)^p (c+d x^2)^q.mac",
+   "index": 981,
+   "integrand": "x/((a+b*x^2)^(3/2)*sqrt(c+d*x^2))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-sqrt(c+d*x^2)/((b*c-a*d)*sqrt(a+b*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.2 Quadratic/1.1.2.8 P(x) (c x)^m (a+b x^2)^p.mac",
+   "index": 88,
+   "integrand": "x*(A+B*x+C*x^2+D*x^3)/(a+b*x^2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "(b*B-a*D)*x/b^2+1/2*C*x^2/b+1/3*D*x^3/b+1/2*(A*b-a*C)*ln(a+b*x^2)/b^2-(b*B-a*D)*atan(x*sqrt(b)/sqrt(a))*sqrt(a)/b^(5/2)",
+   "params": [
+    "A",
+    "B",
+    "C",
+    "D",
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.2 (c x)^m (a+b x^n)^p.mac",
+   "index": 134,
+   "integrand": "sqrt(b*x^n)/x^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-2*sqrt(b*x^n)/((2-n)*x)",
+   "params": [
+    "b",
+    "n"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.2 (c x)^m (a+b x^n)^p.mac",
+   "index": 355,
+   "integrand": "1/(x^4*(a-b*x^3))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "(-1/3)/(a*x^3)+b*ln(x)/a^2-1/3*b*ln(a-b*x^3)/a^2",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.2 (c x)^m (a+b x^n)^p.mac",
+   "index": 685,
+   "integrand": "x^7/(2+3*x^4)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/12*x^4-1/18*ln(2+3*x^4)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.2 (c x)^m (a+b x^n)^p.mac",
+   "index": 1034,
+   "integrand": "(a+b*x^4)^(3/4)/x^12",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/11*(a+b*x^4)^(7/4)/(a*x^11)+4/77*b*(a+b*x^4)^(7/4)/(a^2*x^7)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.2 (c x)^m (a+b x^n)^p.mac",
+   "index": 1369,
+   "integrand": "1/(x^3*(1+x^6))",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "(-1/2)/x^2+1/6*ln(1+x^2)-1/12*ln(1-x^2+x^4)+1/2*atan((1-2*x^2)/sqrt(3))/sqrt(3)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.2 (c x)^m (a+b x^n)^p.mac",
+   "index": 1635,
+   "integrand": "1/((a+b/x)^3*x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/2*b^2/(a^3*(b+a*x)^2)+2*b/(a^3*(b+a*x))+ln(b+a*x)/a^3",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.2 (c x)^m (a+b x^n)^p.mac",
+   "index": 1853,
+   "integrand": "1/((a+b/x^2)*x^7)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "(-1/4)/(b*x^4)+1/2*a/(b^2*x^2)+a^2*ln(x)/b^3-1/2*a^2*ln(b+a*x^2)/b^3",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.2 (c x)^m (a+b x^n)^p.mac",
+   "index": 2139,
+   "integrand": "x^3*(a+b*sqrt(x))^5",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/4*a^5*x^4+10/9*a^4*b*x^(9/2)+2*a^3*b^2*x^5+20/11*a^2*b^3*x^(11/2)+5/6*a*b^4*x^6+2/13*b^5*x^(13/2)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.2 (c x)^m (a+b x^n)^p.mac",
+   "index": 2365,
+   "integrand": "x^3/(a+b*x^(1/3))^3",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "3/2*a^11/(b^12*(a+b*x^(1/3))^2)-33*a^10/(b^12*(a+b*x^(1/3)))+135*a^8*x^(1/3)/b^11-54*a^7*x^(2/3)/b^10+28*a^6*x/b^9-63/4*a^5*x^(4/3)/b^8+9*a^4*x^(5/3)/b^7-5*a^3*x^2/b^6+18/7*a^2*x^(7/3)/b^5-9/8*a*x^(8/3)/b^4+1/3*x^3/b^3-165*a^9*ln(a+b*x^(1/3))/b^12",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.2 (c x)^m (a+b x^n)^p.mac",
+   "index": 2620,
+   "integrand": "1/(x*(a+b*x^n)^2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/(a*n*(a+b*x^n))+ln(x)/a^2-ln(a+b*x^n)/(a^2*n)",
+   "params": [
+    "a",
+    "b",
+    "n"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.2 (c x)^m (a+b x^n)^p.mac",
+   "index": 2887,
+   "integrand": "(c*ee+d*ee*x)^3/(a+b*(c+d*x)^3)^2",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-1/3*ee^3*(c+d*x)/(b*d*(a+b*(c+d*x)^3))+1/9*ee^3*ln(a^(1/3)+b^(1/3)*(c+d*x))/(a^(2/3)*b^(4/3)*d)-1/18*ee^3*ln(a^(2/3)-a^(1/3)*b^(1/3)*(c+d*x)+b^(2/3)*(c+d*x)^2)/(a^(2/3)*b^(4/3)*d)-1/3*ee^3*atan((a^(1/3)-2*b^(1/3)*(c+d*x))/(a^(1/3)*sqrt(3)))/(a^(2/3)*b^(4/3)*d*sqrt(3))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.3 (a+b x^n)^p (c+d x^n)^q.mac",
+   "index": 141,
+   "integrand": "(a+b/x)^(5/2)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-5/3*b*(a+b/x)^(3/2)+(a+b/x)^(5/2)*x+5*a^(3/2)*b*atanh(sqrt(a+b/x)/sqrt(a))-5*a*b*sqrt(a+b/x)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.4 (e x)^m (a+b x^n)^p (c+d x^n)^q.mac",
+   "index": 132,
+   "integrand": "x^(3/2)*(a+b*x^3)*(A+B*x^3)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "2/5*a*A*x^(5/2)+2/11*(A*b+a*B)*x^(11/2)+2/17*b*B*x^(17/2)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.4 (e x)^m (a+b x^n)^p (c+d x^n)^q.mac",
+   "index": 569,
+   "integrand": "x^5/((1-x^3)^(1/3)*(1+x^3))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-1/2*(1-x^3)^(2/3)+1/6*ln(1+x^3)/2^(1/3)-1/2*ln(2^(1/3)-(1-x^3)^(1/3))/2^(1/3)-atan((1+2^(2/3)*(1-x^3)^(1/3))/sqrt(3))/(2^(1/3)*sqrt(3))",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.4 (e x)^m (a+b x^n)^p (c+d x^n)^q.mac",
+   "index": 901,
+   "integrand": "x^(-1+2*n)/((a+b*x^n)^(3/2)*sqrt(c+d*x^n))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "2*atanh(sqrt(d)*sqrt(a+b*x^n)/(sqrt(b)*sqrt(c+d*x^n)))/(b^(3/2)*n*sqrt(d))+2*a*sqrt(c+d*x^n)/(b*(b*c-a*d)*n*sqrt(a+b*x^n))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "n"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.8 P(x) (c x)^m (a+b x^n)^p.mac",
+   "index": 247,
+   "integrand": "(c+d*x^3+ee*x^6+f*x^9)/(x^14*(a+b*x^3))",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-1/13*c/(a*x^13)+1/10*(b*c-a*d)/(a^2*x^10)+1/7*(-b^2*c+a*b*d-a^2*ee)/(a^3*x^7)+1/4*(b^3*c-a*b^2*d+a^2*b*ee-a^3*f)/(a^4*x^4)-b*(b^3*c-a*b^2*d+a^2*b*ee-a^3*f)/(a^5*x)+1/3*b^(4/3)*(b^3*c-a*b^2*d+a^2*b*ee-a^3*f)*ln(a^(1/3)+b^(1/3)*x)/a^(16/3)-1/6*b^(4/3)*(b^3*c-a*b^2*d+a^2*b*ee-a^3*f)*ln(a^(2/3)-a^(1/3)*b^(1/3)*x+b^(2/3)*x^2)/a^(16/3)+b^(4/3)*(b^3*c-a*b^2*d+a^2*b*ee-a^3*f)*atan((a^(1/3)-2*b^(1/3)*x)/(a^(1/3)*sqrt(3)))/(a^(16/3)*sqrt(3))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.3 General/1.1.3.8 P(x) (c x)^m (a+b x^n)^p.mac",
+   "index": 571,
+   "integrand": "(9+6*x+4*x^2)/(729-64*x^6)^2",
+   "variable": "x",
+   "steps": 14,
+   "antiderivative": "1/157464/(3-2*x)+(-1/472392)/(3+2*x)+1/236196*(-3+4*x)/(9-6*x+4*x^2)-1/118098*ln(3-2*x)+1/354294*ln(3+2*x)+5/2834352*ln(9-6*x+4*x^2)+1/944784*ln(9+6*x+4*x^2)-1/52488*atan(1/3*(3-4*x)/sqrt(3))/sqrt(3)+1/472392*atan(1/3*(3+4*x)/sqrt(3))/sqrt(3)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.4 Improper/1.1.4.2 (c x)^m (a x^j+b x^n)^p.mac",
+   "index": 285,
+   "integrand": "x^3/sqrt(a*x^2+b*x^5)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "2/3*sqrt(a*x^2+b*x^5)/(b*x)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.1 Binomial products/1.1.4 Improper/1.1.4.3 (e x)^m (a x^j+b x^k)^p (c+d x^n)^q.mac",
+   "index": 81,
+   "integrand": "x^5*(A+B*x^2)/(b*x^2+c*x^4)^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/4*(-b*B+A*c)/(b*c*(b+c*x^2)^2)+1/2*A/(b^2*(b+c*x^2))+A*ln(x)/b^3-1/2*A*ln(b+c*x^2)/b^3",
+   "params": [
+    "A",
+    "B",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.1 (a+b x+c x^2)^p.mac",
+   "index": 101,
+   "integrand": "1/(1+x^2+2*x*cos(1/7*pi))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "atan(cot(1/7*pi)+x*csc(1/7*pi))*csc(1/7*pi)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.2 (d+e x)^m (a+b x+c x^2)^p.mac",
+   "index": 210,
+   "integrand": "x/(9+12*x+4*x^2)^(1/2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-3/4*(3+2*x)*ln(3+2*x)/sqrt(9+12*x+4*x^2)+1/4*sqrt(9+12*x+4*x^2)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.2 (d+e x)^m (a+b x+c x^2)^p.mac",
+   "index": 486,
+   "integrand": "(a+c*x^2)^3/(d+ee*x)^10",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/9*(c*d^2+a*ee^2)^3/(ee^7*(d+ee*x)^9)+3/4*c*d*(c*d^2+a*ee^2)^2/(ee^7*(d+ee*x)^8)-3/7*c*(c*d^2+a*ee^2)*(5*c*d^2+a*ee^2)/(ee^7*(d+ee*x)^7)+2/3*c^2*d*(5*c*d^2+3*a*ee^2)/(ee^7*(d+ee*x)^6)-3/5*c^2*(5*c*d^2+a*ee^2)/(ee^7*(d+ee*x)^5)+3/2*c^3*d/(ee^7*(d+ee*x)^4)-1/3*c^3/(ee^7*(d+ee*x)^3)",
+   "params": [
+    "a",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.2 (d+e x)^m (a+b x+c x^2)^p.mac",
+   "index": 784,
+   "integrand": "sqrt(a^2-b^2*x^2)/(a+b*x)^5",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/7*(a^2-b^2*x^2)^(3/2)/(a*b*(a+b*x)^5)-2/35*(a^2-b^2*x^2)^(3/2)/(a^2*b*(a+b*x)^4)-2/105*(a^2-b^2*x^2)^(3/2)/(a^3*b*(a+b*x)^3)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.2 (d+e x)^m (a+b x+c x^2)^p.mac",
+   "index": 1032,
+   "integrand": "sqrt(c*d^2+2*c*d*ee*x+c*ee^2*x^2)/(d+ee*x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "sqrt(c*d^2+2*c*d*ee*x+c*ee^2*x^2)/ee",
+   "params": [
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.2 (d+e x)^m (a+b x+c x^2)^p.mac",
+   "index": 1250,
+   "integrand": "(b*d+2*c*d*x)^5/(a+b*x+c*x^2)^(5/2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-2/3*d^5*(b+2*c*x)^4/(a+b*x+c*x^2)^(3/2)-32/3*c*d^5*(b+2*c*x)^2/sqrt(a+b*x+c*x^2)+256/3*c^2*d^5*sqrt(a+b*x+c*x^2)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.2 (d+e x)^m (a+b x+c x^2)^p.mac",
+   "index": 1580,
+   "integrand": "(a^2+2*a*b*x+b^2*x^2)^(5/2)/(d+ee*x)^7",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/6*(a+b*x)^5*sqrt(a^2+2*a*b*x+b^2*x^2)/((b*d-a*ee)*(d+ee*x)^6)",
+   "params": [
+    "a",
+    "b",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.2 (d+e x)^m (a+b x+c x^2)^p.mac",
+   "index": 1814,
+   "integrand": "(a+b*x)/(a*c+(b*c+a*d)*x+b*d*x^2)^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/((b*c-a*d)*(c+d*x))+b*ln(a+b*x)/(b*c-a*d)^2-b*ln(c+d*x)/(b*c-a*d)^2",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.2 (d+e x)^m (a+b x+c x^2)^p.mac",
+   "index": 2034,
+   "integrand": "(a*d*ee+(c*d^2+a*ee^2)*x+c*d*ee*x^2)^(1/2)/(d+ee*x)^(9/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/8*c^3*d^3*atan(sqrt(ee)*sqrt(a*d*ee+(c*d^2+a*ee^2)*x+c*d*ee*x^2)/(sqrt(c*d^2-a*ee^2)*sqrt(d+ee*x)))/(ee^(3/2)*(c*d^2-a*ee^2)^(5/2))-1/3*sqrt(a*d*ee+(c*d^2+a*ee^2)*x+c*d*ee*x^2)/(ee*(d+ee*x)^(7/2))+1/12*c*d*sqrt(a*d*ee+(c*d^2+a*ee^2)*x+c*d*ee*x^2)/(ee*(c*d^2-a*ee^2)*(d+ee*x)^(5/2))+1/8*c^2*d^2*sqrt(a*d*ee+(c*d^2+a*ee^2)*x+c*d*ee*x^2)/(ee*(c*d^2-a*ee^2)^2*(d+ee*x)^(3/2))",
+   "params": [
+    "a",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.2 (d+e x)^m (a+b x+c x^2)^p.mac",
+   "index": 2268,
+   "integrand": "(d+ee*x)^(3/2)*(a+b*x+c*x^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "2/5*(c*d^2-b*d*ee+a*ee^2)*(d+ee*x)^(5/2)/ee^3-2/7*(2*c*d-b*ee)*(d+ee*x)^(7/2)/ee^3+2/9*c*(d+ee*x)^(9/2)/ee^3",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.3 (d+e x)^m (f+g x) (a+b x+c x^2)^p.mac",
+   "index": 43,
+   "integrand": "x^3*(d+ee*x)/(b*x+c*x^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-b*(c*d-b*ee)*x/c^3+1/2*(c*d-b*ee)*x^2/c^2+1/3*ee*x^3/c+b^2*(c*d-b*ee)*ln(b+c*x)/c^4",
+   "params": [
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.3 (d+e x)^m (f+g x) (a+b x+c x^2)^p.mac",
+   "index": 261,
+   "integrand": "(A+B*x)*(a+c*x^2)^2/x",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "a^2*B*x+a*A*c*x^2+2/3*a*B*c*x^3+1/4*A*c^2*x^4+1/5*B*c^2*x^5+a^2*A*ln(x)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.3 (d+e x)^m (f+g x) (a+b x+c x^2)^p.mac",
+   "index": 552,
+   "integrand": "(A+B*x)*(a^2+2*a*b*x+b^2*x^2)^3/x^9",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/8*A*(a+b*x)^7/(a*x^8)+1/56*(A*b-8*a*B)*(a+b*x)^7/(a^2*x^7)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.3 (d+e x)^m (f+g x) (a+b x+c x^2)^p.mac",
+   "index": 770,
+   "integrand": "(A+B*x)/(x^(3/2)*(a^2+2*a*b*x+b^2*x^2)^2)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-5/8*(7*A*b-a*B)*atan(sqrt(b)*sqrt(x)/sqrt(a))/(a^(9/2)*sqrt(b))-5/8*(7*A*b-a*B)/(a^4*b*sqrt(x))+1/3*(A*b-a*B)/(a*b*(a+b*x)^3*sqrt(x))+1/12*(7*A*b-a*B)/(a^2*b*(a+b*x)^2*sqrt(x))+5/24*(7*A*b-a*B)/(a^3*b*(a+b*x)*sqrt(x))",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.3 (d+e x)^m (f+g x) (a+b x+c x^2)^p.mac",
+   "index": 990,
+   "integrand": "x^(5/2)*(A+B*x)*(a+b*x+c*x^2)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "2/7*a^2*A*x^(7/2)+2/9*a*(2*A*b+a*B)*x^(9/2)+2/11*(2*a*b*B+A*(b^2+2*a*c))*x^(11/2)+2/13*(b^2*B+2*A*b*c+2*a*B*c)*x^(13/2)+2/15*c*(2*b*B+A*c)*x^(15/2)+2/17*B*c^2*x^(17/2)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.3 (d+e x)^m (f+g x) (a+b x+c x^2)^p.mac",
+   "index": 1307,
+   "integrand": "(A+B*x)*(a+c*x^2)^2/(d+ee*x)^6",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/5*(B*d-A*ee)*(c*d^2+a*ee^2)^2/(ee^6*(d+ee*x)^5)-1/4*(c*d^2+a*ee^2)*(5*B*c*d^2-4*A*c*d*ee+a*B*ee^2)/(ee^6*(d+ee*x)^4)+2/3*c*(5*B*c*d^3-3*A*c*d^2*ee+3*a*B*d*ee^2-a*A*ee^3)/(ee^6*(d+ee*x)^3)-c*(5*B*c*d^2-2*A*c*d*ee+a*B*ee^2)/(ee^6*(d+ee*x)^2)+c^2*(5*B*d-A*ee)/(ee^6*(d+ee*x))+B*c^2*ln(d+ee*x)/ee^6",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.3 (d+e x)^m (f+g x) (a+b x+c x^2)^p.mac",
+   "index": 1544,
+   "integrand": "(b+2*c*x)/((d+ee*x)*(a+b*x+c*x^2)^3)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "1/2*(-(b^2-4*a*c)*(c*d-b*ee)+c*(b^2-4*a*c)*ee*x)/((b^2-4*a*c)*(c*d^2-b*d*ee+a*ee^2)*(a+b*x+c*x^2)^2)-1/2*ee*(3*b^2*c*d*ee-8*a*c^2*d*ee-2*b^3*ee^2-b*c*(c*d^2-7*a*ee^2)-2*c*(c^2*d^2+b^2*ee^2-c*ee*(b*d+3*a*ee))*x)/((b^2-4*a*c)*(c*d^2-b*d*ee+a*ee^2)^2*(a+b*x+c*x^2))-ee*(2*c^4*d^4-b^4*ee^4-4*c^3*d^2*ee*(b*d-3*a*ee)-6*a*c^2*ee^3*(2*b*d+a*ee)+2*b^2*c*ee^3*(b*d+3*a*ee))*atanh((b+2*c*x)/sqrt(b^2-4*a*c))/((b^2-4*a*c)^(3/2)*(c*d^2-b*d*ee+a*ee^2)^3)-ee^4*(2*c*d-b*ee)*ln(d+ee*x)/(c*d^2-b*d*ee+a*ee^2)^3+1/2*ee^4*(2*c*d-b*ee)*ln(a+b*x+c*x^2)/(c*d^2-b*d*ee+a*ee^2)^3",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.3 (d+e x)^m (f+g x) (a+b x+c x^2)^p.mac",
+   "index": 1790,
+   "integrand": "(A+B*x)*(a^2+2*a*b*x+b^2*x^2)/(d+ee*x)^(7/2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2/5*(b*d-a*ee)^2*(B*d-A*ee)/(ee^4*(d+ee*x)^(5/2))-2/3*(b*d-a*ee)*(3*b*B*d-2*A*b*ee-a*B*ee)/(ee^4*(d+ee*x)^(3/2))+2*b*(3*b*B*d-A*b*ee-2*a*B*ee)/(ee^4*sqrt(d+ee*x))+2*b^2*B*sqrt(d+ee*x)/ee^4",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.3 (d+e x)^m (f+g x) (a+b x+c x^2)^p.mac",
+   "index": 2013,
+   "integrand": "(a+b*x)*(a^2+2*a*b*x+b^2*x^2)^(5/2)/(d+ee*x)^17",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/16*(b*d-a*ee)^6*sqrt(a^2+2*a*b*x+b^2*x^2)/(ee^7*(a+b*x)*(d+ee*x)^16)+2/5*b*(b*d-a*ee)^5*sqrt(a^2+2*a*b*x+b^2*x^2)/(ee^7*(a+b*x)*(d+ee*x)^15)-15/14*b^2*(b*d-a*ee)^4*sqrt(a^2+2*a*b*x+b^2*x^2)/(ee^7*(a+b*x)*(d+ee*x)^14)+20/13*b^3*(b*d-a*ee)^3*sqrt(a^2+2*a*b*x+b^2*x^2)/(ee^7*(a+b*x)*(d+ee*x)^13)-5/4*b^4*(b*d-a*ee)^2*sqrt(a^2+2*a*b*x+b^2*x^2)/(ee^7*(a+b*x)*(d+ee*x)^12)+6/11*b^5*(b*d-a*ee)*sqrt(a^2+2*a*b*x+b^2*x^2)/(ee^7*(a+b*x)*(d+ee*x)^11)-1/10*b^6*sqrt(a^2+2*a*b*x+b^2*x^2)/(ee^7*(a+b*x)*(d+ee*x)^10)",
+   "params": [
+    "a",
+    "b",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.3 (d+e x)^m (f+g x) (a+b x+c x^2)^p.mac",
+   "index": 2237,
+   "integrand": "(f+g*x)*sqrt(c*d^2-b*d*ee-b*ee^2*x-c*ee^2*x^2)/(d+ee*x)^(9/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/3*(ee*f-d*g)*(d*(c*d-b*ee)-b*ee^2*x-c*ee^2*x^2)^(3/2)/(ee^2*(2*c*d-b*ee)*(d+ee*x)^(9/2))+1/8*c^2*(c*ee*f+3*c*d*g-2*b*ee*g)*atanh(sqrt(d*(c*d-b*ee)-b*ee^2*x-c*ee^2*x^2)/(sqrt(2*c*d-b*ee)*sqrt(d+ee*x)))/(ee^2*(2*c*d-b*ee)^(5/2))-1/4*(c*ee*f+3*c*d*g-2*b*ee*g)*sqrt(d*(c*d-b*ee)-b*ee^2*x-c*ee^2*x^2)/(ee^2*(2*c*d-b*ee)*(d+ee*x)^(5/2))+1/8*c*(c*ee*f+3*c*d*g-2*b*ee*g)*sqrt(d*(c*d-b*ee)-b*ee^2*x-c*ee^2*x^2)/(ee^2*(2*c*d-b*ee)^2*(d+ee*x)^(3/2))",
+   "params": [
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.3 (d+e x)^m (f+g x) (a+b x+c x^2)^p.mac",
+   "index": 2466,
+   "integrand": "(A+B*x)*(d+ee*x)/sqrt(a+b*x+c*x^2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/8*(3*b^2*B*ee-4*b*c*(B*d+A*ee)+4*c*(2*A*c*d-a*B*ee))*atanh(1/2*(b+2*c*x)/(sqrt(c)*sqrt(a+b*x+c*x^2)))/c^(5/2)-1/4*(3*b*B*ee-4*c*(B*d+A*ee)-2*B*c*ee*x)*sqrt(a+b*x+c*x^2)/c^2",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.4 (d+e x)^m (f+g x)^n (a+b x+c x^2)^p.mac",
+   "index": 107,
+   "integrand": "(d^2-ee^2*x^2)^(5/2)/(x*(d+ee*x))",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "1/12*(4*d-3*ee*x)*(d^2-ee^2*x^2)^(3/2)-3/8*d^4*atan(ee*x/sqrt(d^2-ee^2*x^2))-d^4*atanh(sqrt(d^2-ee^2*x^2)/d)+1/8*d^2*(8*d-3*ee*x)*sqrt(d^2-ee^2*x^2)",
+   "params": [
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.4 (d+e x)^m (f+g x)^n (a+b x+c x^2)^p.mac",
+   "index": 506,
+   "integrand": "1/(x*sqrt(1+x)*sqrt(1-x+x^2))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-2/3*atanh(sqrt(1+x^3))*sqrt(1+x^3)/(sqrt(1+x)*sqrt(1-x+x^2))",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.4 (d+e x)^m (f+g x)^n (a+b x+c x^2)^p.mac",
+   "index": 796,
+   "integrand": "(a+b*x+c*x^2)^3/((1-d*x)^(3/2)*(1+d*x)^(3/2))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-3/8*(5*c^3+12*b^2*c*d^2+12*a*c^2*d^2+8*a*b^2*d^4+8*a^2*c*d^4)*asin(d*x)/d^7+(b*(3*a^2+3*c^2/d^4+b^2/d^2+6*a*c/d^2)*d^4+(c+a*d^2)*(c^2+3*b^2*d^2+2*a*c*d^2+a^2*d^4)*x)/(d^6*sqrt(1-d^2*x^2))+b*(5*c^2+b^2*d^2+6*a*c*d^2)*sqrt(1-d^2*x^2)/d^6+1/8*c*(7*c^2+12*b^2*d^2+12*a*c*d^2)*x*sqrt(1-d^2*x^2)/d^6+b*c^2*x^2*sqrt(1-d^2*x^2)/d^4+1/4*c^3*x^3*sqrt(1-d^2*x^2)/d^4",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.6 (g+h x)^m (a+b x+c x^2)^p (d+e x+f x^2)^q.mac",
+   "index": 15,
+   "integrand": "(A+B*x)/((a+b*x+c*x^2)^2*(d+ee*x+f*x^2))",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "(-A*c*(2*a*c*ee-b*(c*d+a*f))-(A*b-a*B)*(2*c^2*d+b^2*f-c*(b*ee+2*a*f))-c*(A*b^2*f+2*c*(A*c*d+a*B*ee-a*A*f)-b*(B*c*d+A*c*ee+a*B*f))*x)/((b^2-4*a*c)*((c*d-a*f)^2-(b*d-a*ee)*(c*ee-b*f))*(a+b*x+c*x^2))-(b^5*(B*d-A*ee)*f^2-2*b^4*f*(B*c*d*ee-A*(c*ee^2-c*d*f+a*f^2))-4*c^2*(A*(c^3*d^3-3*a^3*f^3-a^2*c*f*(ee^2-7*d*f)+a*c^2*d*(3*ee^2-5*d*f))-a*B*ee*(c^2*d^2-3*a^2*f^2-a*c*(ee^2-2*d*f)))-4*b^2*c*(B*c^2*d^2*ee+A*f*(2*c^2*d^2+3*a^2*f^2+3*a*c*(ee^2-d*f)))+2*b*c*(B*(c^3*d^3+3*a^3*f^3+a*c^2*d*(ee^2-7*d*f)+3*a^2*c*f*(ee^2+d*f))+A*c*ee*(3*c^2*d^2+3*a^2*f^2+a*c*(3*ee^2+2*d*f)))-b^3*(A*c*ee*(c*ee^2-2*c*d*f-4*a*f^2)+B*(4*a*c*d*f^2+a^2*f^3-c^2*d*(ee^2+5*d*f))))*atanh((b+2*c*x)/sqrt(b^2-4*a*c))/((b^2-4*a*c)^(3/2)*(c^2*d^2+f*(b^2*d-a*b*ee+a^2*f)-c*(b*d*ee-a*(ee^2-2*d*f)))^2)+1/2*(A*(c*ee-b*f)*(f*(b*ee-2*a*f)-c*(ee^2-2*d*f))-B*(2*c*d*f*(b*ee-a*f)-f^2*(b^2*d-a^2*f)-c^2*d*(ee^2-d*f)))*ln(a+b*x+c*x^2)/(c^2*d^2+f*(b^2*d-a*b*ee+a^2*f)-c*(b*d*ee-a*(ee^2-2*d*f)))^2-1/2*(A*(c*ee-b*f)*(f*(b*ee-2*a*f)-c*(ee^2-2*d*f))-B*(2*c*d*f*(b*ee-a*f)-f^2*(b^2*d-a^2*f)-c^2*d*(ee^2-d*f)))*ln(d+ee*x+f*x^2)/(c^2*d^2+f*(b^2*d-a*b*ee+a^2*f)-c*(b*d*ee-a*(ee^2-2*d*f)))^2+(B*(c^2*d*ee*(ee^2-3*d*f)-2*c*d*f*(b*ee^2-2*b*d*f-a*ee*f)+f^2*(b^2*d*ee-4*a*b*d*f+a^2*ee*f))-A*(c^2*(ee^4-4*d*ee^2*f+2*d^2*f^2)-f^2*(2*a*b*ee*f-2*a^2*f^2-b^2*(ee^2-2*d*f))+2*c*f*(a*f*(ee^2-2*d*f)-b*(ee^3-3*d*ee*f))))*atanh((ee+2*f*x)/sqrt(ee^2-4*d*f))/((c^2*d^2+f*(b^2*d-a*b*ee+a^2*f)-c*(b*d*ee-a*(ee^2-2*d*f)))^2*sqrt(ee^2-4*d*f))",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.9 P(x) (d+e x)^m (a+b x+c x^2)^p.mac",
+   "index": 94,
+   "integrand": "(a+c*x^2)^(3/2)*(d+ee*x+f*x^2)/(g+h*x)^4",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-1/6*(c*g*(4*ee*g-10*f*g^2/h-d*h)-3*a*h*(3*f*g-ee*h)-(3*a*f*h^2+c*(5*f*g^2-2*h*(ee*g-d*h)))*x)*(a+c*x^2)^(3/2)/(h^2*(c*g^2+a*h^2)*(g+h*x)^2)-1/3*(f*g^2-ee*g*h+d*h^2)*(a+c*x^2)^(5/2)/(h*(c*g^2+a*h^2)*(g+h*x)^3)+1/2*c*(3*a^2*h^4*(4*f*g-ee*h)+2*c^2*g^3*(10*f*g^2-h*(4*ee*g-d*h))+3*a*c*g*h^2*(11*f*g^2-h*(4*ee*g-d*h)))*atanh((a*h-c*g*x)/(sqrt(c*g^2+a*h^2)*sqrt(a+c*x^2)))/(h^6*(c*g^2+a*h^2)^(3/2))+1/2*(3*a*f*h^2+2*c*(10*f*g^2-h*(4*ee*g-d*h)))*atanh(x*sqrt(c)/sqrt(a+c*x^2))*sqrt(c)/h^6-1/2*((c*g^2+a*h^2)*(3*a*f*h^2+2*c*(10*f*g^2-h*(4*ee*g-d*h)))+c*h*(3*a*h^2*(3*f*g-ee*h)+c*g*(10*f*g^2-h*(4*ee*g-d*h)))*x)*sqrt(a+c*x^2)/(h^5*(c*g^2+a*h^2)*(g+h*x))",
+   "params": [
+    "a",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g",
+    "h"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.1 Quadratic/1.2.1.9 P(x) (d+e x)^m (a+b x+c x^2)^p.mac",
+   "index": 332,
+   "integrand": "(2+x+3*x^2-x^3+5*x^4)*sqrt(3-x+2*x^2)/(5+2*x)^8",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-3667/4032*(3-x+2*x^2)^(3/2)/(5+2*x)^7+948341/1741824*(3-x+2*x^2)^(3/2)/(5+2*x)^6-1464037/13934592*(3-x+2*x^2)^(3/2)/(5+2*x)^5+19414831/4013162496*(3-x+2*x^2)^(3/2)/(5+2*x)^4+246159769/866843099136*(3-x+2*x^2)^(3/2)/(5+2*x)^3-289071245/285315214344192*atanh(1/12*(17-22*x)/(sqrt(2)*sqrt(3-x+2*x^2)))/sqrt(2)-12568315/23776267862016*(17-22*x)*sqrt(3-x+2*x^2)/(5+2*x)^2",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.2 Quartic/1.2.2.2 (d x)^m (a+b x^2+c x^4)^p.mac",
+   "index": 276,
+   "integrand": "x/(b*x^2+c*x^4)^(3/2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(-b-2*c*x^2)/(b^2*sqrt(b*x^2+c*x^4))",
+   "params": [
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.2 Quartic/1.2.2.2 (d x)^m (a+b x^2+c x^4)^p.mac",
+   "index": 548,
+   "integrand": "sqrt(a^2+2*a*b*x^2+b^2*x^4)/x^11",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/10*a*sqrt(a^2+2*a*b*x^2+b^2*x^4)/(x^10*(a+b*x^2))-1/8*b*sqrt(a^2+2*a*b*x^2+b^2*x^4)/(x^8*(a+b*x^2))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.2 Quartic/1.2.2.2 (d x)^m (a+b x^2+c x^4)^p.mac",
+   "index": 774,
+   "integrand": "(d*x)^(11/2)/(a^2+2*a*b*x^2+b^2*x^4)^(5/2)",
+   "variable": "x",
+   "steps": 15,
+   "antiderivative": "-1/8*d*(d*x)^(9/2)/(b*(a+b*x^2)^3*sqrt(a^2+2*a*b*x^2+b^2*x^4))-3/32*d^3*(d*x)^(5/2)/(b^2*(a+b*x^2)^2*sqrt(a^2+2*a*b*x^2+b^2*x^4))-45/2048*d^(11/2)*(a+b*x^2)*atan(1-b^(1/4)*sqrt(2)*sqrt(d*x)/(a^(1/4)*sqrt(d)))/(a^(7/4)*b^(13/4)*sqrt(2)*sqrt(a^2+2*a*b*x^2+b^2*x^4))+45/2048*d^(11/2)*(a+b*x^2)*atan(1+b^(1/4)*sqrt(2)*sqrt(d*x)/(a^(1/4)*sqrt(d)))/(a^(7/4)*b^(13/4)*sqrt(2)*sqrt(a^2+2*a*b*x^2+b^2*x^4))-45/4096*d^(11/2)*(a+b*x^2)*ln(sqrt(a)*sqrt(d)+x*sqrt(b)*sqrt(d)-a^(1/4)*b^(1/4)*sqrt(2)*sqrt(d*x))/(a^(7/4)*b^(13/4)*sqrt(2)*sqrt(a^2+2*a*b*x^2+b^2*x^4))+45/4096*d^(11/2)*(a+b*x^2)*ln(sqrt(a)*sqrt(d)+x*sqrt(b)*sqrt(d)+a^(1/4)*b^(1/4)*sqrt(2)*sqrt(d*x))/(a^(7/4)*b^(13/4)*sqrt(2)*sqrt(a^2+2*a*b*x^2+b^2*x^4))+15/1024*d^5*sqrt(d*x)/(a*b^3*sqrt(a^2+2*a*b*x^2+b^2*x^4))-15/256*d^5*sqrt(d*x)/(b^3*(a+b*x^2)*sqrt(a^2+2*a*b*x^2+b^2*x^4))",
+   "params": [
+    "a",
+    "b",
+    "d"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.2 Quartic/1.2.2.2 (d x)^m (a+b x^2+c x^4)^p.mac",
+   "index": 1047,
+   "integrand": "x^(5/2)*(a+b*x^2+c*x^4)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "2/7*a^2*x^(7/2)+4/11*a*b*x^(11/2)+2/15*(b^2+2*a*c)*x^(15/2)+4/19*b*c*x^(19/2)+2/23*c^2*x^(23/2)",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.2 Quartic/1.2.2.3 (d+e x^2)^m (a+b x^2+c x^4)^p.mac",
+   "index": 253,
+   "integrand": "(d+ee*x^2)*(a+b*x^2+c*x^4)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "a^2*d*x+1/3*a*(2*b*d+a*ee)*x^3+1/5*(b^2*d+2*a*c*d+2*a*b*ee)*x^5+1/7*(2*b*c*d+b^2*ee+2*a*c*ee)*x^7+1/9*c*(c*d+2*b*ee)*x^9+1/11*c^2*ee*x^11",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.2 Quartic/1.2.2.4 (f x)^m (d+e x^2)^q (a+b x^2+c x^4)^p.mac",
+   "index": 252,
+   "integrand": "x^6/((d+ee*x^2)*(a+c*x^4)^2)",
+   "variable": "x",
+   "steps": 23,
+   "antiderivative": "-1/4*x*(a*ee+c*d*x^2)/(c*(c*d^2+a*ee^2)*(a+c*x^4))+1/8*atan(1-c^(1/4)*x*sqrt(2)/a^(1/4))*(-ee*sqrt(a)+d*sqrt(c))/(a^(1/4)*c^(5/4)*(c*d^2+a*ee^2)*sqrt(2))-1/8*atan(1+c^(1/4)*x*sqrt(2)/a^(1/4))*(-ee*sqrt(a)+d*sqrt(c))/(a^(1/4)*c^(5/4)*(c*d^2+a*ee^2)*sqrt(2))+1/4*d^2*ln(-a^(1/4)*c^(1/4)*x*sqrt(2)+sqrt(a)+x^2*sqrt(c))*(-ee*sqrt(a)+d*sqrt(c))/(a^(1/4)*c^(1/4)*(c*d^2+a*ee^2)^2*sqrt(2))-1/4*d^2*ln(a^(1/4)*c^(1/4)*x*sqrt(2)+sqrt(a)+x^2*sqrt(c))*(-ee*sqrt(a)+d*sqrt(c))/(a^(1/4)*c^(1/4)*(c*d^2+a*ee^2)^2*sqrt(2))-1/2*d^2*atan(1-c^(1/4)*x*sqrt(2)/a^(1/4))*(ee*sqrt(a)+d*sqrt(c))/(a^(1/4)*c^(1/4)*(c*d^2+a*ee^2)^2*sqrt(2))+1/2*d^2*atan(1+c^(1/4)*x*sqrt(2)/a^(1/4))*(ee*sqrt(a)+d*sqrt(c))/(a^(1/4)*c^(1/4)*(c*d^2+a*ee^2)^2*sqrt(2))-1/16*ln(-a^(1/4)*c^(1/4)*x*sqrt(2)+sqrt(a)+x^2*sqrt(c))*(ee*sqrt(a)+d*sqrt(c))/(a^(1/4)*c^(5/4)*(c*d^2+a*ee^2)*sqrt(2))+1/16*ln(a^(1/4)*c^(1/4)*x*sqrt(2)+sqrt(a)+x^2*sqrt(c))*(ee*sqrt(a)+d*sqrt(c))/(a^(1/4)*c^(5/4)*(c*d^2+a*ee^2)*sqrt(2))-d^(5/2)*atan(x*sqrt(ee)/sqrt(d))*sqrt(ee)/(c*d^2+a*ee^2)^2",
+   "params": [
+    "a",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.2 Quartic/1.2.2.5 P(x) (a+b x^2+c x^4)^p.mac",
+   "index": 109,
+   "integrand": "(a*g+f*x^3-c*g*x^4)/(a+b*x^2+c*x^4)^(3/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "g*x/sqrt(a+b*x^2+c*x^4)+f*(2*a+b*x^2)/((b^2-4*a*c)*sqrt(a+b*x^2+c*x^4))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "f",
+    "g"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.3 General/1.2.3.2 (d x)^m (a+b x^n+c x^(2 n))^p.mac",
+   "index": 74,
+   "integrand": "(a^2+2*a*b*x^3+b^2*x^6)^(5/2)/x^12",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/11*a^5*sqrt(a^2+2*a*b*x^3+b^2*x^6)/(x^11*(a+b*x^3))-5/8*a^4*b*sqrt(a^2+2*a*b*x^3+b^2*x^6)/(x^8*(a+b*x^3))-2*a^3*b^2*sqrt(a^2+2*a*b*x^3+b^2*x^6)/(x^5*(a+b*x^3))-5*a^2*b^3*sqrt(a^2+2*a*b*x^3+b^2*x^6)/(x^2*(a+b*x^3))+5*a*b^4*x*sqrt(a^2+2*a*b*x^3+b^2*x^6)/(a+b*x^3)+1/4*b^5*x^4*sqrt(a^2+2*a*b*x^3+b^2*x^6)/(a+b*x^3)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.3 General/1.2.3.2 (d x)^m (a+b x^n+c x^(2 n))^p.mac",
+   "index": 362,
+   "integrand": "1/(x^2*(1-x^4+x^8))",
+   "variable": "x",
+   "steps": 22,
+   "antiderivative": "(-1)/x+1/8*ln(1+x^2-x*sqrt(2-sqrt(3)))*sqrt(1/3*(2-sqrt(3)))-1/8*ln(1+x^2+x*sqrt(2-sqrt(3)))*sqrt(1/3*(2-sqrt(3)))+1/4*atan((-2*x+sqrt(2-sqrt(3)))/sqrt(2+sqrt(3)))/sqrt(3*(2-sqrt(3)))-1/4*atan((2*x+sqrt(2-sqrt(3)))/sqrt(2+sqrt(3)))/sqrt(3*(2-sqrt(3)))-1/8*ln(1+x^2-x*sqrt(2+sqrt(3)))*sqrt(1/3*(2+sqrt(3)))+1/8*ln(1+x^2+x*sqrt(2+sqrt(3)))*sqrt(1/3*(2+sqrt(3)))-1/4*atan((-2*x+sqrt(2+sqrt(3)))/sqrt(2-sqrt(3)))/sqrt(3*(2+sqrt(3)))+1/4*atan((2*x+sqrt(2+sqrt(3)))/sqrt(2-sqrt(3)))/sqrt(3*(2+sqrt(3)))",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.3 General/1.2.3.2 (d x)^m (a+b x^n+c x^(2 n))^p.mac",
+   "index": 637,
+   "integrand": "(d*f+ee*f*x)^4/(a+b*(d+ee*x)^2+c*(d+ee*x)^4)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "f^4*x/c-f^4*atan((d+ee*x)*sqrt(2)*sqrt(c)/sqrt(b-sqrt(b^2-4*a*c)))*(b+(-b^2+2*a*c)/sqrt(b^2-4*a*c))/(c^(3/2)*ee*sqrt(2)*sqrt(b-sqrt(b^2-4*a*c)))-f^4*atan((d+ee*x)*sqrt(2)*sqrt(c)/sqrt(b+sqrt(b^2-4*a*c)))*(b+(b^2-2*a*c)/sqrt(b^2-4*a*c))/(c^(3/2)*ee*sqrt(2)*sqrt(b+sqrt(b^2-4*a*c)))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.2 Trinomial products/1.2.4 Improper/1.2.4.2 (d x)^m (a x^q+b x^n+c x^(2 n-q))^p.mac",
+   "index": 31,
+   "integrand": "sqrt(a*x^2+b*x^3+c*x^4)/x",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/8*(b^2-4*a*c)*x*atanh(1/2*(b+2*c*x)/(sqrt(c)*sqrt(a+b*x+c*x^2)))*sqrt(a+b*x+c*x^2)/(c^(3/2)*sqrt(a*x^2+b*x^3+c*x^4))+1/4*(b+2*c*x)*sqrt(a*x^2+b*x^3+c*x^4)/(c*x)",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.3 Miscellaneous/1.3.1 Rational functions.mac",
+   "index": 126,
+   "integrand": "x/(a+8*x-8*x^2+4*x^3-x^4)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "1/2*atanh((1+(-1+x)^2)/sqrt(4+a))/sqrt(4+a)-1/2*atan((-1+x)/sqrt(1-sqrt(4+a)))/(sqrt(4+a)*sqrt(1-sqrt(4+a)))+1/2*atan((-1+x)/sqrt(1+sqrt(4+a)))/(sqrt(4+a)*sqrt(1+sqrt(4+a)))",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "1 Algebraic functions/1.3 Miscellaneous/1.3.1 Rational functions.mac",
+   "index": 370,
+   "integrand": "(1+x^3)/(-x^2+x^3)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/x+x+2*ln(1-x)-ln(x)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.3 Miscellaneous/1.3.2 Algebraic functions.mac",
+   "index": 256,
+   "integrand": "x^3*(sqrt(1-x)+sqrt(1+x))^2",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/2*x^4-2/3*(1-x^2)^(3/2)+2/5*(1-x^2)^(5/2)",
+   "params": []
+  },
+  {
+   "source": "1 Algebraic functions/1.3 Miscellaneous/1.3.2 Algebraic functions.mac",
+   "index": 512,
+   "integrand": "(-1+x^2)^3*sqrt(-1+1/x^2)/x",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-35/48*(-1+1/x^2)^(3/2)*x^2-7/24*(-1+1/x^2)^(5/2)*x^4-1/6*(-1+1/x^2)^(7/2)*x^6-35/16*atan(sqrt(-1+1/x^2))+35/16*sqrt(-1+1/x^2)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.1 u (F^(c (a+b x)))^n.mac",
+   "index": 1,
+   "integrand": "F^(c*(a+b*x))*(d+ee*x)^4",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "24*ee^4*F^(c*(a+b*x))/(b^5*c^5*ln(F)^5)-24*ee^3*F^(c*(a+b*x))*(d+ee*x)/(b^4*c^4*ln(F)^4)+12*ee^2*F^(c*(a+b*x))*(d+ee*x)^2/(b^3*c^3*ln(F)^3)-4*ee*F^(c*(a+b*x))*(d+ee*x)^3/(b^2*c^2*ln(F)^2)+F^(c*(a+b*x))*(d+ee*x)^4/(b*c*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.1 u (F^(c (a+b x)))^n.mac",
+   "index": 5,
+   "integrand": "F^(c*(a+b*x))",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "F^(c*(a+b*x))/(b*c*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.1 u (F^(c (a+b x)))^n.mac",
+   "index": 26,
+   "integrand": "F^(2+5*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/5*F^(2+5*x)/ln(F)",
+   "params": [
+    "F"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.1 u (F^(c (a+b x)))^n.mac",
+   "index": 50,
+   "integrand": "F^(c*(a+b*x))*(d+ee*x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-ee*F^(c*(a+b*x))/(b^2*c^2*ln(F)^2)+F^(c*(a+b*x))*(d+ee*x)/(b*c*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.1 u (F^(c (a+b x)))^n.mac",
+   "index": 55,
+   "integrand": "exp(1)^(-a-b*x)*x^3*(a+b*x)^3",
+   "variable": "x",
+   "steps": 24,
+   "antiderivative": "-720*exp(1)^(-a-b*x)/b^4-360*exp(1)^(-a-b*x)*a/b^4-72*exp(1)^(-a-b*x)*a^2/b^4-6*exp(1)^(-a-b*x)*a^3/b^4-720*exp(1)^(-a-b*x)*x/b^3-360*exp(1)^(-a-b*x)*a*x/b^3-72*exp(1)^(-a-b*x)*a^2*x/b^3-6*exp(1)^(-a-b*x)*a^3*x/b^3-360*exp(1)^(-a-b*x)*x^2/b^2-180*exp(1)^(-a-b*x)*a*x^2/b^2-36*exp(1)^(-a-b*x)*a^2*x^2/b^2-3*exp(1)^(-a-b*x)*a^3*x^2/b^2-120*exp(1)^(-a-b*x)*x^3/b-60*exp(1)^(-a-b*x)*a*x^3/b-12*exp(1)^(-a-b*x)*a^2*x^3/b-exp(1)^(-a-b*x)*a^3*x^3/b-30*exp(1)^(-a-b*x)*x^4-15*exp(1)^(-a-b*x)*a*x^4-3*exp(1)^(-a-b*x)*a^2*x^4-6*exp(1)^(-a-b*x)*b*x^5-3*exp(1)^(-a-b*x)*a*b*x^5-exp(1)^(-a-b*x)*b^2*x^6",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.1 u (F^(c (a+b x)))^n.mac",
+   "index": 64,
+   "integrand": "F^(a+b*(c+d*x))*x^3*(ee+f*x)^2",
+   "variable": "x",
+   "steps": 17,
+   "antiderivative": "-120*f^2*F^(a+b*c+b*d*x)/(b^6*d^6*ln(F)^6)+48*ee*f*F^(a+b*c+b*d*x)/(b^5*d^5*ln(F)^5)+120*f^2*F^(a+b*c+b*d*x)*x/(b^5*d^5*ln(F)^5)-6*ee^2*F^(a+b*c+b*d*x)/(b^4*d^4*ln(F)^4)-48*ee*f*F^(a+b*c+b*d*x)*x/(b^4*d^4*ln(F)^4)-60*f^2*F^(a+b*c+b*d*x)*x^2/(b^4*d^4*ln(F)^4)+6*ee^2*F^(a+b*c+b*d*x)*x/(b^3*d^3*ln(F)^3)+24*ee*f*F^(a+b*c+b*d*x)*x^2/(b^3*d^3*ln(F)^3)+20*f^2*F^(a+b*c+b*d*x)*x^3/(b^3*d^3*ln(F)^3)-3*ee^2*F^(a+b*c+b*d*x)*x^2/(b^2*d^2*ln(F)^2)-8*ee*f*F^(a+b*c+b*d*x)*x^3/(b^2*d^2*ln(F)^2)-5*f^2*F^(a+b*c+b*d*x)*x^4/(b^2*d^2*ln(F)^2)+ee^2*F^(a+b*c+b*d*x)*x^3/(b*d*ln(F))+2*ee*f*F^(a+b*c+b*d*x)*x^4/(b*d*ln(F))+f^2*F^(a+b*c+b*d*x)*x^5/(b*d*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.1 u (F^(c (a+b x)))^n.mac",
+   "index": 73,
+   "integrand": "exp(1)^(-a-b*x)*(a+b*x)^4*(c+d*x)^3",
+   "variable": "x",
+   "steps": 28,
+   "antiderivative": "-5040*exp(1)^(-a-b*x)*d^3/b^4-2160*exp(1)^(-a-b*x)*d^2*(b*c-a*d)/b^4-360*exp(1)^(-a-b*x)*d*(b*c-a*d)^2/b^4-24*exp(1)^(-a-b*x)*(b*c-a*d)^3/b^4-5040*exp(1)^(-a-b*x)*d^3*(a+b*x)/b^4-2160*exp(1)^(-a-b*x)*d^2*(b*c-a*d)*(a+b*x)/b^4-360*exp(1)^(-a-b*x)*d*(b*c-a*d)^2*(a+b*x)/b^4-24*exp(1)^(-a-b*x)*(b*c-a*d)^3*(a+b*x)/b^4-2520*exp(1)^(-a-b*x)*d^3*(a+b*x)^2/b^4-1080*exp(1)^(-a-b*x)*d^2*(b*c-a*d)*(a+b*x)^2/b^4-180*exp(1)^(-a-b*x)*d*(b*c-a*d)^2*(a+b*x)^2/b^4-12*exp(1)^(-a-b*x)*(b*c-a*d)^3*(a+b*x)^2/b^4-840*exp(1)^(-a-b*x)*d^3*(a+b*x)^3/b^4-360*exp(1)^(-a-b*x)*d^2*(b*c-a*d)*(a+b*x)^3/b^4-60*exp(1)^(-a-b*x)*d*(b*c-a*d)^2*(a+b*x)^3/b^4-4*exp(1)^(-a-b*x)*(b*c-a*d)^3*(a+b*x)^3/b^4-210*exp(1)^(-a-b*x)*d^3*(a+b*x)^4/b^4-90*exp(1)^(-a-b*x)*d^2*(b*c-a*d)*(a+b*x)^4/b^4-15*exp(1)^(-a-b*x)*d*(b*c-a*d)^2*(a+b*x)^4/b^4-exp(1)^(-a-b*x)*(b*c-a*d)^3*(a+b*x)^4/b^4-42*exp(1)^(-a-b*x)*d^3*(a+b*x)^5/b^4-18*exp(1)^(-a-b*x)*d^2*(b*c-a*d)*(a+b*x)^5/b^4-3*exp(1)^(-a-b*x)*d*(b*c-a*d)^2*(a+b*x)^5/b^4-7*exp(1)^(-a-b*x)*d^3*(a+b*x)^6/b^4-3*exp(1)^(-a-b*x)*d^2*(b*c-a*d)*(a+b*x)^6/b^4-exp(1)^(-a-b*x)*d^3*(a+b*x)^7/b^4",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.1 u (F^(c (a+b x)))^n.mac",
+   "index": 82,
+   "integrand": "F^(c*(a+b*x))*x^m*ln(d*x)^n*(ee+ee*n+ee*(1+m+b*c*x*ln(F))*ln(d*x))",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "ee*F^(c*(a+b*x))*x^(1+m)*ln(d*x)^(1+n)",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "m",
+    "n"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.1 u (F^(c (a+b x)))^n.mac",
+   "index": 86,
+   "integrand": "F^(c*(a+b*x))*ln(d*x)^n*(ee+ee*n+b*c*ee*x*ln(F)*ln(d*x))/x",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "ee*F^(c*(a+b*x))*ln(d*x)^(1+n)",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.1 u (F^(c (a+b x)))^n.mac",
+   "index": 90,
+   "integrand": "x^3*sqrt(exp(1)^(a+b*x))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-96*sqrt(exp(1)^(a+b*x))/b^4+48*x*sqrt(exp(1)^(a+b*x))/b^3-12*x^2*sqrt(exp(1)^(a+b*x))/b^2+2*x^3*sqrt(exp(1)^(a+b*x))/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.2 (c+d x)^m (F^(g (e+f x)))^n (a+b (F^(g (e+f x)))^n)^p.mac",
+   "index": 3,
+   "integrand": "1/(a+exp(1)^(c+d*x)*b)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "x/a-ln(a+exp(1)^(c+d*x)*b)/(a*d)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.2 (c+d x)^m (F^(g (e+f x)))^n (a+b (F^(g (e+f x)))^n)^p.mac",
+   "index": 14,
+   "integrand": "1/(a+exp(1)^(c-d*x)*b)^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "(-1)/(a*(a+exp(1)^(c-d*x)*b)*d)+x/a^2+ln(a+exp(1)^(c-d*x)*b)/(a^2*d)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.2 (c+d x)^m (F^(g (e+f x)))^n (a+b (F^(g (e+f x)))^n)^p.mac",
+   "index": 23,
+   "integrand": "1/(a+exp(1)^(-c-d*x)*b)^3",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "(-1/2)/(a*(a+exp(1)^(-c-d*x)*b)^2*d)+(-1)/(a^2*(a+exp(1)^(-c-d*x)*b)*d)+x/a^3+ln(a+exp(1)^(-c-d*x)*b)/(a^3*d)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.2 (c+d x)^m (F^(g (e+f x)))^n (a+b (F^(g (e+f x)))^n)^p.mac",
+   "index": 27,
+   "integrand": "a+b*(F^(g*(ee+f*x)))^n",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "a*x+b*(F^(g*(ee+f*x)))^n/(f*g*n*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "ee",
+    "f",
+    "g",
+    "n"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.2 (c+d x)^m (F^(g (e+f x)))^n (a+b (F^(g (e+f x)))^n)^p.mac",
+   "index": 34,
+   "integrand": "(a+b*(F^(g*(ee+f*x)))^n)^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "a^2*x+2*a*b*(F^(g*(ee+f*x)))^n/(f*g*n*ln(F))+1/2*b^2*(F^(g*(ee+f*x)))^(2*n)/(f*g*n*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "ee",
+    "f",
+    "g",
+    "n"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.2 (c+d x)^m (F^(g (e+f x)))^n (a+b (F^(g (e+f x)))^n)^p.mac",
+   "index": 41,
+   "integrand": "(a+b*(F^(g*(ee+f*x)))^n)^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "a^3*x+3*a^2*b*(F^(g*(ee+f*x)))^n/(f*g*n*ln(F))+3/2*a*b^2*(F^(g*(ee+f*x)))^(2*n)/(f*g*n*ln(F))+1/3*b^3*(F^(g*(ee+f*x)))^(3*n)/(f*g*n*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "ee",
+    "f",
+    "g",
+    "n"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.2 (c+d x)^m (F^(g (e+f x)))^n (a+b (F^(g (e+f x)))^n)^p.mac",
+   "index": 78,
+   "integrand": "F^(c+d*x)/(a+b*F^(c+d*x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "ln(a+b*F^(c+d*x))/(b*d*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.2 (c+d x)^m (F^(g (e+f x)))^n (a+b (F^(g (e+f x)))^n)^p.mac",
+   "index": 90,
+   "integrand": "F^(c+d*x)/(a+b*F^(c+d*x))^3",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(-1/2)/(b*d*(a+b*F^(c+d*x))^2*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 3,
+   "integrand": "exp(1)^(c+d*x)/(a+exp(1)^(c+d*x)*b)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "ln(a+exp(1)^(c+d*x)*b)/(b*d)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 7,
+   "integrand": "F^x/(a+b*F^x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "ln(a+b*F^x)/(b*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 11,
+   "integrand": "F^(d*x)*(a+b*F^(c+d*x))^n",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "(a+b*F^(c+d*x))^(1+n)/(b*d*F^c*(1+n)*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d",
+    "n"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 15,
+   "integrand": "(F^(ee*(c+d*x)))^n*(a+b*(F^(ee*(c+d*x)))^n)^p",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(a+b*(F^(ee*(c+d*x)))^n)^(1+p)/(b*d*ee*n*(1+p)*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n",
+    "p"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 19,
+   "integrand": "exp(1)^(2*x)/(a+exp(1)^x*b)^3",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*exp(1)^(2*x)/(a*(a+exp(1)^x*b)^2)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 23,
+   "integrand": "exp(1)^(4*x)/(a+exp(1)^(2*x)*b)^3",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/4*exp(1)^(4*x)/(a*(a+exp(1)^(2*x)*b)^2)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 27,
+   "integrand": "(a+exp(1)^(n*x)*b)^2/exp(1)^(n*x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-a^2/(exp(1)^(n*x)*n)+exp(1)^(n*x)*b^2/n+2*a*b*x",
+   "params": [
+    "a",
+    "b",
+    "n"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 31,
+   "integrand": "1/(exp(1)^(n*x)*(a+exp(1)^(n*x)*b)^3)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "(-1)/(exp(1)^(n*x)*a^3*n)-1/2*b/(a^2*(a+exp(1)^(n*x)*b)^2*n)-2*b/(a^3*(a+exp(1)^(n*x)*b)*n)-3*b*x/a^4+3*b*ln(a+exp(1)^(n*x)*b)/(a^4*n)",
+   "params": [
+    "a",
+    "b",
+    "n"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 35,
+   "integrand": "f^(a+4*b*x)/(c+d*f^(ee+2*b*x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/2*f^(a-ee+2*b*x)/(b*d*ln(f))-1/2*c*f^(a-2*ee)*ln(c+d*f^(ee+2*b*x))/(b*d^2*ln(f))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 42,
+   "integrand": "f^x/(a+b*f^(2*x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "atan(f^x*sqrt(b)/sqrt(a))/(ln(f)*sqrt(a)*sqrt(b))",
+   "params": [
+    "a",
+    "b",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 57,
+   "integrand": "1/(b/f^x+a*f^x)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(-1/2)/(a*(b+a*f^(2*x))*ln(f))",
+   "params": [
+    "a",
+    "b",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 70,
+   "integrand": "f^(a+b*x^2)*x^9",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/2*f^(a+b*x^2)*(24-24*b*x^2*ln(f)+12*b^2*x^4*ln(f)^2-4*b^3*x^6*ln(f)^3+b^4*x^8*ln(f)^4)/(b^5*ln(f)^5)",
+   "params": [
+    "a",
+    "b",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 74,
+   "integrand": "f^(a+b*x^2)*x",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/2*f^(a+b*x^2)/(b*ln(f))",
+   "params": [
+    "a",
+    "b",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 98,
+   "integrand": "f^(a+b*x^3)*x^8",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2/3*f^(a+b*x^3)/(b^3*ln(f)^3)-2/3*f^(a+b*x^3)*x^3/(b^2*ln(f)^2)+1/3*f^(a+b*x^3)*x^6/(b*ln(f))",
+   "params": [
+    "a",
+    "b",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 121,
+   "integrand": "f^(a+b/x)/x^2",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-f^(a+b/x)/(b*ln(f))",
+   "params": [
+    "a",
+    "b",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 125,
+   "integrand": "f^(a+b/x)/x^6",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-f^(a+b/x)*(24*x^4-24*b*x^3*ln(f)+12*b^2*x^2*ln(f)^2-4*b^3*x*ln(f)^3+b^4*ln(f)^4)/(b^5*x^4*ln(f)^5)",
+   "params": [
+    "a",
+    "b",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 136,
+   "integrand": "f^(a+b/x^2)/x^7",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-f^(a+b/x^2)/(b^3*ln(f)^3)+f^(a+b/x^2)/(b^2*x^2*ln(f)^2)-1/2*f^(a+b/x^2)/(b*x^4*ln(f))",
+   "params": [
+    "a",
+    "b",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 160,
+   "integrand": "f^(a+b/x^3)/x^4",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-1/3*f^(a+b/x^3)/(b*ln(f))",
+   "params": [
+    "a",
+    "b",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 164,
+   "integrand": "f^(a+b/x^3)/x^16",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-1/3*f^(a+b/x^3)*(24*x^12-24*b*x^9*ln(f)+12*b^2*x^6*ln(f)^2-4*b^3*x^3*ln(f)^3+b^4*ln(f)^4)/(b^5*x^12*ln(f)^5)",
+   "params": [
+    "a",
+    "b",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 184,
+   "integrand": "f^(a+b*x^n)*x^(-1+n)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "f^(a+b*x^n)/(b*n*ln(f))",
+   "params": [
+    "a",
+    "b",
+    "f",
+    "n"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 255,
+   "integrand": "F^(a+b*(c+d*x)^2)*(c+d*x)^9",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/2*F^(a+b*(c+d*x)^2)*(24-24*b*(c+d*x)^2*ln(F)+12*b^2*(c+d*x)^4*ln(F)^2-4*b^3*(c+d*x)^6*ln(F)^3+b^4*(c+d*x)^8*ln(F)^4)/(b^5*d*ln(F)^5)",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 259,
+   "integrand": "F^(a+b*(c+d*x)^2)*(c+d*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/2*F^(a+b*(c+d*x)^2)/(b*d*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 283,
+   "integrand": "F^(a+b*(c+d*x)^3)*(c+d*x)^8",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2/3*F^(a+b*(c+d*x)^3)/(b^3*d*ln(F)^3)-2/3*F^(a+b*(c+d*x)^3)*(c+d*x)^3/(b^2*d*ln(F)^2)+1/3*F^(a+b*(c+d*x)^3)*(c+d*x)^6/(b*d*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 299,
+   "integrand": "f^(a+b*(c+d*x)^(1/3))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "6*f^(a+b*(c+d*x)^(1/3))/(b^3*d*ln(f)^3)-6*f^(a+b*(c+d*x)^(1/3))*(c+d*x)^(1/3)/(b^2*d*ln(f)^2)+3*f^(a+b*(c+d*x)^(1/3))*(c+d*x)^(2/3)/(b*d*ln(f))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 310,
+   "integrand": "F^(a+b/(c+d*x))/(c+d*x)^5",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "6*F^(a+b/(c+d*x))/(b^4*d*ln(F)^4)-6*F^(a+b/(c+d*x))/(b^3*d*(c+d*x)*ln(F)^3)+3*F^(a+b/(c+d*x))/(b^2*d*(c+d*x)^2*ln(F)^2)-F^(a+b/(c+d*x))/(b*d*(c+d*x)^3*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 321,
+   "integrand": "F^(a+b/(c+d*x)^2)/(c+d*x)^5",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*F^(a+b/(c+d*x)^2)/(b^2*d*ln(F)^2)-1/2*F^(a+b/(c+d*x)^2)/(b*d*(c+d*x)^2*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 325,
+   "integrand": "F^(a+b/(c+d*x)^2)/(c+d*x)^13",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/2*F^(a+b/(c+d*x)^2)*(120*(c+d*x)^10-120*b*(c+d*x)^8*ln(F)+60*b^2*(c+d*x)^6*ln(F)^2-20*b^3*(c+d*x)^4*ln(F)^3+5*b^4*(c+d*x)^2*ln(F)^4-b^5*ln(F)^5)/(b^6*d*(c+d*x)^10*ln(F)^6)",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 349,
+   "integrand": "F^(a+b/(c+d*x)^3)/(c+d*x)^13",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "2*F^(a+b/(c+d*x)^3)/(b^4*d*ln(F)^4)-2*F^(a+b/(c+d*x)^3)/(b^3*d*(c+d*x)^3*ln(F)^3)+F^(a+b/(c+d*x)^3)/(b^2*d*(c+d*x)^6*ln(F)^2)-1/3*F^(a+b/(c+d*x)^3)/(b*d*(c+d*x)^9*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 368,
+   "integrand": "F^(a+b*(c+d*x)^n)*(c+d*x)^(-1+5*n)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "F^(a+b*(c+d*x)^n)*(24-24*b*(c+d*x)^n*ln(F)+12*b^2*(c+d*x)^(2*n)*ln(F)^2-4*b^3*(c+d*x)^(3*n)*ln(F)^3+b^4*(c+d*x)^(4*n)*ln(F)^4)/(b^5*d*n*ln(F)^5)",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d",
+    "n"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 372,
+   "integrand": "F^(a+b*(c+d*x)^n)*(c+d*x)^(-1+n)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "F^(a+b*(c+d*x)^n)/(b*d*n*ln(F))",
+   "params": [
+    "F",
+    "a",
+    "b",
+    "c",
+    "d",
+    "n"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 433,
+   "integrand": "exp(1)^(a+b*x-c*x^2)*x",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/2*exp(1)^(a+b*x-c*x^2)/c-1/4*exp(1)^(a+1/4*b^2/c)*b*erf(1/2*(b-2*c*x)/sqrt(c))*sqrt(pi)/c^(3/2)",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 455,
+   "integrand": "f^(b*x+c*x^2)*(b+2*c*x)^3",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-4*c*f^(b*x+c*x^2)/ln(f)^2+f^(b*x+c*x^2)*(b+2*c*x)^2/ln(f)",
+   "params": [
+    "b",
+    "c",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 474,
+   "integrand": "4^x/(a-2^x*b)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-2^x/(b*ln(2))-a*ln(a-2^x*b)/(b^2*ln(2))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 478,
+   "integrand": "4^x/(a-b/2^x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "b^2*x/a^3+2^(-1+2*x)/(a*ln(2))+2^x*b/(a^2*ln(2))+b^2*ln(a-b/2^x)/(a^3*ln(2))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 482,
+   "integrand": "2^x/(a-4^x*b)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "atanh(2^x*sqrt(b)/sqrt(a))/(ln(2)*sqrt(a)*sqrt(b))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 486,
+   "integrand": "2^x/(a-b/4^x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "2^x/(a*ln(2))-atanh(2^x*sqrt(a)/sqrt(b))*sqrt(b)/(a^(3/2)*ln(2))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 490,
+   "integrand": "2^x/sqrt(a-4^x*b)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "atan(2^x*sqrt(b)/sqrt(a-4^x*b))/(ln(2)*sqrt(b))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 494,
+   "integrand": "2^x/sqrt(a-b/4^x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "2^x*sqrt(a-b/2^(2*x))/(a*ln(2))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 498,
+   "integrand": "4^x/sqrt(a-2^x*b)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2/3*(a-2^x*b)^(3/2)/(b^2*ln(2))-2*a*sqrt(a-2^x*b)/(b^2*ln(2))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 502,
+   "integrand": "4^x/sqrt(a-b/2^x)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "3/4*b^2*atanh(sqrt(a-b/2^x)/sqrt(a))/(a^(5/2)*ln(2))+2^(-1+2*x)*sqrt(a-b/2^x)/(a*ln(2))+3*2^(-2+x)*b*sqrt(a-b/2^x)/(a^2*ln(2))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 506,
+   "integrand": "1/(-1+exp(1)^x+exp(1)^(2*x))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-x+1/10*ln(1+2*exp(1)^x+sqrt(5))*(5-sqrt(5))+1/10*ln(1+2*exp(1)^x-sqrt(5))*(5+sqrt(5))",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 520,
+   "integrand": "1/(a+b*f^(c+d*x)+c*f^(2*c+2*d*x))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "x/a-1/2*ln(a+b*f^(c+d*x)+c*f^(2*c+2*d*x))/(a*d*ln(f))+b*atanh((b+2*c*f^(c+d*x))/sqrt(b^2-4*a*c))/(a*d*ln(f)*sqrt(b^2-4*a*c))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "f"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 528,
+   "integrand": "1/(2+1/exp(1)^x+exp(1)^x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(-1)/(1+exp(1)^x)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 534,
+   "integrand": "1/(2+1/3^x+3^x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(-1)/((1+3^x)*ln(3))",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 546,
+   "integrand": "1/(d*f+(ee*f+d*g)*x+ee*g*x^2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "ln(d+ee*x)/(ee*f-d*g)-ln(f+g*x)/(ee*f-d*g)",
+   "params": [
+    "d",
+    "ee",
+    "f",
+    "g"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 564,
+   "integrand": "a^x*b^x",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "a^x*b^x/(ln(a)+ln(b))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 574,
+   "integrand": "(d+exp(1)^(h+i*x)*ee)/(a+exp(1)^(h+i*x)*b+exp(1)^(2*h+2*i*x)*c)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "d*x/a-1/2*d*ln(a+exp(1)^(h+i*x)*b+exp(1)^(2*h+2*i*x)*c)/(a*i)+(b*d-2*a*ee)*atanh((b+2*exp(1)^(h+i*x)*c)/sqrt(b^2-4*a*c))/(a*i*sqrt(b^2-4*a*c))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "h",
+    "i"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 620,
+   "integrand": "exp(1)^(a+b*x+c*x^2)*(b+2*c*x)*(a+b*x+c*x^2)^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "2*exp(1)^(a+b*x+c*x^2)-2*exp(1)^(a+b*x+c*x^2)*(a+b*x+c*x^2)+exp(1)^(a+b*x+c*x^2)*(a+b*x+c*x^2)^2",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 636,
+   "integrand": "exp(1)^x/(4+exp(1)^(2*x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*atan(1/2*exp(1)^x)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 640,
+   "integrand": "exp(1)^(x^2)*x^3",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/2*exp(1)^(x^2)+1/2*exp(1)^(x^2)*x^2",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 644,
+   "integrand": "exp(1)^(2-x^2)*x",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-1/2*exp(1)^(2-x^2)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 648,
+   "integrand": "exp(1)^(2*x)/(1+exp(1)^(4*x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*atan(exp(1)^(2*x))",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 652,
+   "integrand": "exp(1)^x/(1+exp(1)^(2*x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "atan(exp(1)^x)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 658,
+   "integrand": "x/sqrt(-1+exp(1)^(2*x^2))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/2*atan(sqrt(-1+exp(1)^(2*x^2)))",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 662,
+   "integrand": "exp(1)^(x^(3/2))*x^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-2/3*exp(1)^(x^(3/2))+2/3*exp(1)^(x^(3/2))*x^(3/2)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 666,
+   "integrand": "exp(1)^(4*x)/sqrt(16+exp(1)^(8*x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/4*asinh(1/4*exp(1)^(4*x))",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 670,
+   "integrand": "exp(1)^sqrt(x)/sqrt(x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "2*exp(1)^sqrt(x)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 674,
+   "integrand": "(exp(1)^x+exp(1)^(2*x)+exp(1)^(3*x))/exp(1)^(4*x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "(-1/3)/exp(1)^(3*x)+(-1/2)/exp(1)^(2*x)+(-1)/exp(1)^x",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 678,
+   "integrand": "exp(1)^(2*x)/(1+exp(1)^x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "exp(1)^x-ln(1+exp(1)^x)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 682,
+   "integrand": "exp(1)^x*cos(4+3*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/10*exp(1)^x*cos(4+3*x)+3/10*exp(1)^x*sin(4+3*x)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 686,
+   "integrand": "exp(1)^(2*x)/(1+exp(1)^x)^(1/3)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-3/2*(1+exp(1)^x)^(2/3)+3/5*(1+exp(1)^x)^(5/3)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 690,
+   "integrand": "exp(1)^(3*x)*(-x+x^2)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "5/27*exp(1)^(3*x)-5/9*exp(1)^(3*x)*x+1/3*exp(1)^(3*x)*x^2",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 694,
+   "integrand": "(a+exp(1)^x*b)^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2*exp(1)^x*a*b+1/2*exp(1)^(2*x)*b^2+a^2*x",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 698,
+   "integrand": "1/sqrt(-a+exp(1)^(c+d*x)*b)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2*atan(sqrt(-a+exp(1)^(c+d*x)*b)/sqrt(a))/(d*sqrt(a))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 702,
+   "integrand": "exp(1)^(3*x)/(1+exp(1)^(2*x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "exp(1)^x-atan(exp(1)^x)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 706,
+   "integrand": "exp(1)^(7*x)*x^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-6/2401*exp(1)^(7*x)+6/343*exp(1)^(7*x)*x-3/49*exp(1)^(7*x)*x^2+1/7*exp(1)^(7*x)*x^3",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 710,
+   "integrand": "exp(1)^(6*x)/(9-exp(1)^x)^(5/2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "39366/(9-exp(1)^x)^(3/2)+540*(9-exp(1)^x)^(3/2)-18*(9-exp(1)^x)^(5/2)+2/7*(9-exp(1)^x)^(7/2)+(-65610)/sqrt(9-exp(1)^x)-14580*sqrt(9-exp(1)^x)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 714,
+   "integrand": "exp(1)^(exp(1)^x+x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "exp(1)^(exp(1)^x)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 718,
+   "integrand": "1/(1/exp(1)^x+exp(1)^x)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(-1/2)/(1+exp(1)^(2*x))",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 722,
+   "integrand": "exp(1)^x*((-1)/exp(1)^x+exp(1)^x)^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/2/exp(1)^(2*x)-3/2*exp(1)^(2*x)+1/4*exp(1)^(4*x)+3*x",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 727,
+   "integrand": "1/(-exp(1)^x+exp(1)^(3*x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/exp(1)^x-atanh(exp(1)^x)",
+   "params": []
+  },
+  {
+   "source": "2 Exponentials/2.3 Exponential functions.mac",
+   "index": 731,
+   "integrand": "(1+exp(1)^x)/sqrt(exp(1)^x+x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "2*sqrt(exp(1)^x+x)",
+   "params": []
+  },
+  {
+   "source": "3 Logarithms/3.1.2 (d x)^m (a+b log(c x^n))^p.mac",
+   "index": 0,
+   "integrand": "x^3*ln(c*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-1/16*x^4+1/4*x^4*ln(c*x)",
+   "params": [
+    "c"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.2 (d x)^m (a+b log(c x^n))^p.mac",
+   "index": 12,
+   "integrand": "ln(c*x)^2/x^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(-2)/x-2*ln(c*x)/x-ln(c*x)^2/x",
+   "params": [
+    "c"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.2 (d x)^m (a+b log(c x^n))^p.mac",
+   "index": 42,
+   "integrand": "x^3*(a+b*ln(c*x^n))",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-1/16*b*n*x^4+1/4*x^4*(a+b*ln(c*x^n))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.2 (d x)^m (a+b log(c x^n))^p.mac",
+   "index": 54,
+   "integrand": "(a+b*ln(c*x^n))^2/x^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-2*b^2*n^2/x-2*b*n*(a+b*ln(c*x^n))/x-(a+b*ln(c*x^n))^2/x",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.2 (d x)^m (a+b log(c x^n))^p.mac",
+   "index": 84,
+   "integrand": "1/(x*(a+b*ln(c*x^n))^3)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(-1/2)/(b*n*(a+b*ln(c*x^n))^2)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.2 (d x)^m (a+b log(c x^n))^p.mac",
+   "index": 99,
+   "integrand": "(a+b*ln(c*x^n))^2/(d*x)^(5/2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-16/27*b^2*n^2/(d*(d*x)^(3/2))-8/9*b*n*(a+b*ln(c*x^n))/(d*(d*x)^(3/2))-2/3*(a+b*ln(c*x^n))^2/(d*(d*x)^(3/2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.2 (d x)^m (a+b log(c x^n))^p.mac",
+   "index": 140,
+   "integrand": "1/(x^3*ln(a*x^n)^(3/2))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-2*(a*x^n)^(2/n)*erf(sqrt(2)*sqrt(ln(a*x^n))/sqrt(n))*sqrt(2*pi)/(n^(3/2)*x^2)+(-2)/(n*x^2*sqrt(ln(a*x^n)))",
+   "params": [
+    "a",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.2 (d x)^m (a+b log(c x^n))^p.mac",
+   "index": 178,
+   "integrand": "(a+b*ln(c*x))^p/x",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(a+b*ln(c*x))^(1+p)/(b*(1+p))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 11,
+   "integrand": "(d+ee*x)^2*(a+b*ln(c*x^n))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-b*d^2*n*x-1/2*b*d*ee*n*x^2-1/9*b*ee^2*n*x^3-1/3*b*d^3*n*ln(x)/ee+1/3*(d+ee*x)^3*(a+b*ln(c*x^n))/ee",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 23,
+   "integrand": "(d+ee*x)^3*(a+b*ln(c*x^n))/x^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-b*d^3*n/x-3*b*d*ee^2*n*x-1/4*b*ee^3*n*x^2-3/2*b*d^2*ee*n*ln(x)^2-d^3*(a+b*ln(c*x^n))/x+3*d*ee^2*x*(a+b*ln(c*x^n))+1/2*ee^3*x^2*(a+b*ln(c*x^n))+3*d^2*ee*ln(x)*(a+b*ln(c*x^n))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 57,
+   "integrand": "(a+b*ln(c*x^n))/(d+ee*x)^4",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/6*b*n/(d*ee*(d+ee*x)^2)+1/3*b*n/(d^2*ee*(d+ee*x))+1/3*b*n*ln(x)/(d^3*ee)+1/3*(-a-b*ln(c*x^n))/(ee*(d+ee*x)^3)-1/3*b*n*ln(d+ee*x)/(d^3*ee)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 80,
+   "integrand": "(d+ee*x)*(a+b*ln(c*x^n))^2/x^3",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-1/4*b^2*d*n^2/x^2-2*b^2*ee*n^2/x-1/2*b*d*n*(a+b*ln(c*x^n))/x^2-2*b*ee*n*(a+b*ln(c*x^n))/x-1/2*d*(a+b*ln(c*x^n))^2/x^2-ee*(a+b*ln(c*x^n))^2/x",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 130,
+   "integrand": "x^2*(a+b*ln(c*x^n))*sqrt(d+ee*x)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-32/315*b*d^2*n*(d+ee*x)^(3/2)/ee^3+36/175*b*d*n*(d+ee*x)^(5/2)/ee^3-4/49*b*n*(d+ee*x)^(7/2)/ee^3+32/105*b*d^(7/2)*n*atanh(sqrt(d+ee*x)/sqrt(d))/ee^3+2/3*d^2*(d+ee*x)^(3/2)*(a+b*ln(c*x^n))/ee^3-4/5*d*(d+ee*x)^(5/2)*(a+b*ln(c*x^n))/ee^3+2/7*(d+ee*x)^(7/2)*(a+b*ln(c*x^n))/ee^3-32/105*b*d^3*n*sqrt(d+ee*x)/ee^3",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 151,
+   "integrand": "x^2*(a+b*ln(c*x^n))/(d+ee*x)^(3/2)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-4/9*b*n*(d+ee*x)^(3/2)/ee^3-32/3*b*d^(3/2)*n*atanh(sqrt(d+ee*x)/sqrt(d))/ee^3+2/3*(d+ee*x)^(3/2)*(a+b*ln(c*x^n))/ee^3-2*d^2*(a+b*ln(c*x^n))/(ee^3*sqrt(d+ee*x))+20/3*b*d*n*sqrt(d+ee*x)/ee^3-4*d*(a+b*ln(c*x^n))*sqrt(d+ee*x)/ee^3",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 176,
+   "integrand": "x^4*(d+ee*x^2)*(a+b*ln(c*x^n))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/25*b*d*n*x^5-1/49*b*ee*n*x^7+1/35*(7*d*x^5+5*ee*x^7)*(a+b*ln(c*x^n))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 188,
+   "integrand": "x^4*(d+ee*x^2)^2*(a+b*ln(c*x^n))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/25*b*d^2*n*x^5-2/49*b*d*ee*n*x^7-1/81*b*ee^2*n*x^9+1/315*(63*d^2*x^5+90*d*ee*x^7+35*ee^2*x^9)*(a+b*ln(c*x^n))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 200,
+   "integrand": "(d+ee*x^2)^3*(a+b*ln(c*x^n))/x^5",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-1/16*b*d^3*n/x^4-3/4*b*d^2*ee*n/x^2-1/4*b*ee^3*n*x^2-3/2*b*d*ee^2*n*ln(x)^2-1/4*d^3*(a+b*ln(c*x^n))/x^4-3/2*d^2*ee*(a+b*ln(c*x^n))/x^2+1/2*ee^3*x^2*(a+b*ln(c*x^n))+3*d*ee^2*ln(x)*(a+b*ln(c*x^n))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 250,
+   "integrand": "x^5*(a+b*ln(c*x^n))*sqrt(d+ee*x^2)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-8/315*b*d^2*n*(d+ee*x^2)^(3/2)/ee^3+9/175*b*d*n*(d+ee*x^2)^(5/2)/ee^3-1/49*b*n*(d+ee*x^2)^(7/2)/ee^3+8/105*b*d^(7/2)*n*atanh(sqrt(d+ee*x^2)/sqrt(d))/ee^3+1/3*d^2*(d+ee*x^2)^(3/2)*(a+b*ln(c*x^n))/ee^3-2/5*d*(d+ee*x^2)^(5/2)*(a+b*ln(c*x^n))/ee^3+1/7*(d+ee*x^2)^(7/2)*(a+b*ln(c*x^n))/ee^3-8/105*b*d^3*n*sqrt(d+ee*x^2)/ee^3",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 274,
+   "integrand": "x*ln(x)*sqrt(4+x^2)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-1/9*(4+x^2)^(3/2)+8/3*atanh(1/2*sqrt(4+x^2))+1/3*(4+x^2)^(3/2)*ln(x)-4/3*sqrt(4+x^2)",
+   "params": []
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 293,
+   "integrand": "(a+b*ln(c*x^n))/(x^2*(d+ee*x^2)^(3/2))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "2*b*n*atanh(x*sqrt(ee)/sqrt(d+ee*x^2))*sqrt(ee)/d^2+(-a-b*ln(c*x^n))/(d*x*sqrt(d+ee*x^2))-2*ee*x*(a+b*ln(c*x^n))/(d^2*sqrt(d+ee*x^2))-b*n*sqrt(d+ee*x^2)/(d^2*x)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 309,
+   "integrand": "x*(a+b*ln(c*x^n))/(sqrt(d-ee*x)*sqrt(d+ee*x))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "b*n*(d^2-ee^2*x^2)/(ee^2*sqrt(d-ee*x)*sqrt(d+ee*x))-(d^2-ee^2*x^2)*(a+b*ln(c*x^n))/(ee^2*sqrt(d-ee*x)*sqrt(d+ee*x))-b*d^2*n*atanh(sqrt(1-ee^2*x^2/d^2))*sqrt(1-ee^2*x^2/d^2)/(ee^2*sqrt(d-ee*x)*sqrt(d+ee*x))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 356,
+   "integrand": "(f*x)^(-1+m)*(a+b*ln(c*x^n))/(d+ee*x^m)^3",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/2*b*n*x^(1-m)*(f*x)^(-1+m)/(d*ee*m^2*(d+ee*x^m))+1/2*b*n*x^(1-m)*(f*x)^(-1+m)*ln(x)/(d^2*ee*m)-1/2*x^(1-m)*(f*x)^(-1+m)*(a+b*ln(c*x^n))/(ee*m*(d+ee*x^m)^2)-1/2*b*n*x^(1-m)*(f*x)^(-1+m)*ln(d+ee*x^m)/(d^2*ee*m^2)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "m",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 372,
+   "integrand": "x^4*(d+ee*x^r)*(a+b*ln(c*x^n))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/25*b*d*n*x^5-b*ee*n*x^(5+r)/(5+r)^2+1/5*(d*x^5+5*ee*x^(5+r)/(5+r))*(a+b*ln(c*x^n))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n",
+    "r"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 384,
+   "integrand": "x^4*(d+ee*x^r)^2*(a+b*ln(c*x^n))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/25*b*d^2*n*x^5-2*b*d*ee*n*x^(5+r)/(5+r)^2-b*ee^2*n*x^(5+2*r)/(5+2*r)^2+1/5*(d^2*x^5+10*d*ee*x^(5+r)/(5+r)+5*ee^2*x^(5+2*r)/(5+2*r))*(a+b*ln(c*x^n))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n",
+    "r"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 396,
+   "integrand": "(d+ee*x^r)^3*(a+b*ln(c*x^n))/x^5",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/16*b*d^3*n/x^4-3/4*b*d*ee^2*n/((2-r)^2*x^(2*(2-r)))-3*b*d^2*ee*n*x^(-4+r)/(4-r)^2-b*ee^3*n*x^(-4+3*r)/(4-3*r)^2-1/4*d^3*(a+b*ln(c*x^n))/x^4-3/2*d*ee^2*(a+b*ln(c*x^n))/((2-r)*x^(2*(2-r)))-3*d^2*ee*x^(-4+r)*(a+b*ln(c*x^n))/(4-r)-ee^3*x^(-4+3*r)*(a+b*ln(c*x^n))/(4-3*r)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n",
+    "r"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.4 (f x)^m (d+e x^r)^q (a+b log(c x^n))^p.mac",
+   "index": 426,
+   "integrand": "(d+ee*x^r)^3*(a+b*ln(c*x^n))^2/x",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "6*b^2*d^2*ee*n^2*x^r/r^3+3/4*b^2*d*ee^2*n^2*x^(2*r)/r^3+2/27*b^2*ee^3*n^2*x^(3*r)/r^3-6*b*d^2*ee*n*x^r*(a+b*ln(c*x^n))/r^2-3/2*b*d*ee^2*n*x^(2*r)*(a+b*ln(c*x^n))/r^2-2/9*b*ee^3*n*x^(3*r)*(a+b*ln(c*x^n))/r^2+3*d^2*ee*x^r*(a+b*ln(c*x^n))^2/r+3/2*d*ee^2*x^(2*r)*(a+b*ln(c*x^n))^2/r+1/3*ee^3*x^(3*r)*(a+b*ln(c*x^n))^2/r+1/3*d^3*(a+b*ln(c*x^n))^3/(b*n)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n",
+    "r"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.5 u (a+b log(c x^n))^p.mac",
+   "index": 159,
+   "integrand": "(a+b*ln(c*x^n))*(d+ee*ln(f*x^r))/x^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-b*ee*n*r/x-ee*r*(a+b*n+b*ln(c*x^n))/x-b*n*(d+ee*ln(f*x^r))/x-(a+b*ln(c*x^n))*(d+ee*ln(f*x^r))/x",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "n",
+    "r"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.5 u (a+b log(c x^n))^p.mac",
+   "index": 181,
+   "integrand": "(a+b*ln(c*x^n))^p*(d+ee*ln(f*x^r))/x",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-ee*r*(a+b*ln(c*x^n))^(2+p)/(b^2*n^2*(1+p)*(2+p))+(a+b*ln(c*x^n))^(1+p)*(d+ee*ln(f*x^r))/(b*n*(1+p))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "n",
+    "p",
+    "r"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.1.5 u (a+b log(c x^n))^p.mac",
+   "index": 229,
+   "integrand": "x^2*ln(c*(b*x^n)^p)^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2/27*n^2*p^2*x^3-2/9*n*p*x^3*ln(c*(b*x^n)^p)+1/3*x^3*ln(c*(b*x^n)^p)^2",
+   "params": [
+    "b",
+    "c",
+    "n",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.1 (f+g x)^m (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 1,
+   "integrand": "(a*g+b*g*x)^3*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/4*B*(b*c-a*d)^3*g^3*n*x/d^3+1/8*B*(b*c-a*d)^2*g^3*n*(a+b*x)^2/(b*d^2)-1/12*B*(b*c-a*d)*g^3*n*(a+b*x)^3/(b*d)+1/4*g^3*(a+b*x)^4*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))/b+1/4*B*(b*c-a*d)^4*g^3*n*ln(c+d*x)/(b*d^4)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.1 (f+g x)^m (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 30,
+   "integrand": "(c*g+d*g*x)^2*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/3*B*(b*c-a*d)^2*g^2*n*x/b^2-1/6*B*(b*c-a*d)*g^2*n*(c+d*x)^2/(b*d)-1/3*B*(b*c-a*d)^3*g^2*n*ln(a+b*x)/(b^3*d)+1/3*g^2*(c+d*x)^3*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))/d",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.1 (f+g x)^m (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 58,
+   "integrand": "(f+g*x)^2*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/3*B*(b*c-a*d)*g*(3*b*d*f-b*c*g-a*d*g)*n*x/(b^2*d^2)-1/6*B*(b*c-a*d)*g^2*n*x^2/(b*d)-1/3*B*(b*f-a*g)^3*n*ln(a+b*x)/(b^3*g)+1/3*(f+g*x)^3*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))/g+1/3*B*(d*f-c*g)^3*n*ln(c+d*x)/(d^3*g)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.1 (f+g x)^m (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 94,
+   "integrand": "(A+B*ln(ee*(a+b*x)/(c+d*x)))/(a*g+b*g*x)^4",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/9*B/(b*g^4*(a+b*x)^3)+1/6*B*d/(b*(b*c-a*d)*g^4*(a+b*x)^2)-1/3*B*d^2/(b*(b*c-a*d)^2*g^4*(a+b*x))-1/3*B*d^3*ln(a+b*x)/(b*(b*c-a*d)^3*g^4)+1/3*(-A-B*ln(ee*(a+b*x)/(c+d*x)))/(b*g^4*(a+b*x)^3)+1/3*B*d^3*ln(c+d*x)/(b*(b*c-a*d)^3*g^4)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.1 (f+g x)^m (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 126,
+   "integrand": "(A+B*ln(ee*(a+b*x)^2/(c+d*x)^2))/(a*g+b*g*x)^5",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/8*B/(b*g^5*(a+b*x)^4)+1/6*B*d/(b*(b*c-a*d)*g^5*(a+b*x)^3)-1/4*B*d^2/(b*(b*c-a*d)^2*g^5*(a+b*x)^2)+1/2*B*d^3/(b*(b*c-a*d)^3*g^5*(a+b*x))+1/2*B*d^4*ln(a+b*x)/(b*(b*c-a*d)^4*g^5)+1/4*(-A-B*ln(ee*(a+b*x)^2/(c+d*x)^2))/(b*g^5*(a+b*x)^4)-1/2*B*d^4*ln(c+d*x)/(b*(b*c-a*d)^4*g^5)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.1 (f+g x)^m (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 154,
+   "integrand": "(A+B*ln(ee*(a+b*x)^n/(c+d*x)^n))/(a+b*x)^5",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/16*B*n/(b*(a+b*x)^4)+1/12*B*d*n/(b*(b*c-a*d)*(a+b*x)^3)-1/8*B*d^2*n/(b*(b*c-a*d)^2*(a+b*x)^2)+1/4*B*d^3*n/(b*(b*c-a*d)^3*(a+b*x))+1/4*B*d^4*n*ln(a+b*x)/(b*(b*c-a*d)^4)-1/4*B*d^4*n*ln(c+d*x)/(b*(b*c-a*d)^4)+1/4*(-A-B*ln(ee*(a+b*x)^n/(c+d*x)^n))/(b*(a+b*x)^4)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.1 (f+g x)^m (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 175,
+   "integrand": "(a*g+b*g*x)*(A+B*ln(ee*(c+d*x)/(a+b*x)))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/2*B*(b*c-a*d)*g*x/d-1/2*B*(b*c-a*d)^2*g*ln(c+d*x)/(b*d^2)+1/2*g*(a+b*x)^2*(A+B*ln(ee*(c+d*x)/(a+b*x)))/b",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.1 (f+g x)^m (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 205,
+   "integrand": "(A+B*ln(ee*(c+d*x)^2/(a+b*x)^2))/(a*g+b*g*x)^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-A*(c+d*x)/((b*c-a*d)*g^2*(a+b*x))+2*B*(c+d*x)/((b*c-a*d)*g^2*(a+b*x))-B*(c+d*x)*ln(ee*(c+d*x)^2/(a+b*x)^2)/((b*c-a*d)*g^2*(a+b*x))",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.1 (f+g x)^m (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 233,
+   "integrand": "A+B*ln(ee*(a+b*x)/(c+d*x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "A*x+B*(a+b*x)*ln(ee*(a+b*x)/(c+d*x))/b-B*(b*c-a*d)*ln(c+d*x)/(b*d)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.1 (f+g x)^m (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 268,
+   "integrand": "(A+B*ln(ee*(a+b*x)^2/(c+d*x)^2))/(f+g*x)^3",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-B*(b*c-a*d)/((b*f-a*g)*(d*f-c*g)*(f+g*x))+b^2*B*ln(a+b*x)/(g*(b*f-a*g)^2)+1/2*(-A-B*ln(ee*(a+b*x)^2/(c+d*x)^2))/(g*(f+g*x)^2)-B*d^2*ln(c+d*x)/(g*(d*f-c*g)^2)+B*(b*c-a*d)*(2*b*d*f-b*c*g-a*d*g)*ln(f+g*x)/((b*f-a*g)^2*(d*f-c*g)^2)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.2 (f+g x)^m (h+i x)^q (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 0,
+   "integrand": "(a*g+b*g*x)^3*(c*i+d*i*x)*(A+B*ln(ee*(a+b*x)/(c+d*x)))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/20*B*(b*c-a*d)^4*g^3*i*x/(b*d^3)+1/40*B*(b*c-a*d)^3*g^3*i*(a+b*x)^2/(b^2*d^2)-1/60*B*(b*c-a*d)^2*g^3*i*(a+b*x)^3/(b^2*d)+1/5*g^3*i*(a+b*x)^4*(c+d*x)*(A+B*ln(ee*(a+b*x)/(c+d*x)))/b+1/20*(b*c-a*d)*g^3*i*(a+b*x)^4*(A-B+B*ln(ee*(a+b*x)/(c+d*x)))/b^2+1/20*B*(b*c-a*d)^5*g^3*i*ln(c+d*x)/(b^2*d^4)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g",
+    "i"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.2 (f+g x)^m (h+i x)^q (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 17,
+   "integrand": "(c*i+d*i*x)^2*(A+B*ln(ee*(a+b*x)/(c+d*x)))/(a*g+b*g*x)^5",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/9*B*d*i^2*(c+d*x)^3/((b*c-a*d)^2*g^5*(a+b*x)^3)-1/16*b*B*i^2*(c+d*x)^4/((b*c-a*d)^2*g^5*(a+b*x)^4)+1/3*d*i^2*(c+d*x)^3*(A+B*ln(ee*(a+b*x)/(c+d*x)))/((b*c-a*d)^2*g^5*(a+b*x)^3)-1/4*b*i^2*(c+d*x)^4*(A+B*ln(ee*(a+b*x)/(c+d*x)))/((b*c-a*d)^2*g^5*(a+b*x)^4)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g",
+    "i"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.2 (f+g x)^m (h+i x)^q (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 37,
+   "integrand": "(A+B*ln(ee*(a+b*x)/(c+d*x)))/((a*g+b*g*x)^4*(c*i+d*i*x))",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-3*b*B*d^2*(c+d*x)/((b*c-a*d)^4*g^4*i*(a+b*x))+3/4*b^2*B*d*(c+d*x)^2/((b*c-a*d)^4*g^4*i*(a+b*x)^2)-1/9*b^3*B*(c+d*x)^3/((b*c-a*d)^4*g^4*i*(a+b*x)^3)+1/2*B*d^3*ln((a+b*x)/(c+d*x))^2/((b*c-a*d)^4*g^4*i)-3*b*d^2*(c+d*x)*(A+B*ln(ee*(a+b*x)/(c+d*x)))/((b*c-a*d)^4*g^4*i*(a+b*x))+3/2*b^2*d*(c+d*x)^2*(A+B*ln(ee*(a+b*x)/(c+d*x)))/((b*c-a*d)^4*g^4*i*(a+b*x)^2)-1/3*b^3*(c+d*x)^3*(A+B*ln(ee*(a+b*x)/(c+d*x)))/((b*c-a*d)^4*g^4*i*(a+b*x)^3)-d^3*ln((a+b*x)/(c+d*x))*(A+B*ln(ee*(a+b*x)/(c+d*x)))/((b*c-a*d)^4*g^4*i)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g",
+    "i"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.2 (f+g x)^m (h+i x)^q (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 60,
+   "integrand": "(c*i+d*i*x)*(A+B*ln(ee*(a+b*x)/(c+d*x)))^2/(a*g+b*g*x)^3",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/4*B^2*i*(c+d*x)^2/((b*c-a*d)*g^3*(a+b*x)^2)-1/2*B*i*(c+d*x)^2*(A+B*ln(ee*(a+b*x)/(c+d*x)))/((b*c-a*d)*g^3*(a+b*x)^2)-1/2*i*(c+d*x)^2*(A+B*ln(ee*(a+b*x)/(c+d*x)))^2/((b*c-a*d)*g^3*(a+b*x)^2)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g",
+    "i"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.2 (f+g x)^m (h+i x)^q (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 90,
+   "integrand": "(A+B*ln(ee*(a+b*x)/(c+d*x)))^2/((a*g+b*g*x)^4*(c*i+d*i*x))",
+   "variable": "x",
+   "steps": 11,
+   "antiderivative": "-6*b*B^2*d^2*(c+d*x)/((b*c-a*d)^4*g^4*i*(a+b*x))+3/4*b^2*B^2*d*(c+d*x)^2/((b*c-a*d)^4*g^4*i*(a+b*x)^2)-2/27*b^3*B^2*(c+d*x)^3/((b*c-a*d)^4*g^4*i*(a+b*x)^3)-6*b*B*d^2*(c+d*x)*(A+B*ln(ee*(a+b*x)/(c+d*x)))/((b*c-a*d)^4*g^4*i*(a+b*x))+3/2*b^2*B*d*(c+d*x)^2*(A+B*ln(ee*(a+b*x)/(c+d*x)))/((b*c-a*d)^4*g^4*i*(a+b*x)^2)-2/9*b^3*B*(c+d*x)^3*(A+B*ln(ee*(a+b*x)/(c+d*x)))/((b*c-a*d)^4*g^4*i*(a+b*x)^3)-3*b*d^2*(c+d*x)*(A+B*ln(ee*(a+b*x)/(c+d*x)))^2/((b*c-a*d)^4*g^4*i*(a+b*x))+3/2*b^2*d*(c+d*x)^2*(A+B*ln(ee*(a+b*x)/(c+d*x)))^2/((b*c-a*d)^4*g^4*i*(a+b*x)^2)-1/3*b^3*(c+d*x)^3*(A+B*ln(ee*(a+b*x)/(c+d*x)))^2/((b*c-a*d)^4*g^4*i*(a+b*x)^3)-1/3*d^3*(A+B*ln(ee*(a+b*x)/(c+d*x)))^3/(B*(b*c-a*d)^4*g^4*i)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g",
+    "i"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.2 (f+g x)^m (h+i x)^q (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 107,
+   "integrand": "(a*g+b*g*x)^3*(c*i+d*i*x)*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/20*B*(b*c-a*d)^4*g^3*i*n*x/(b*d^3)+1/40*B*(b*c-a*d)^3*g^3*i*n*(a+b*x)^2/(b^2*d^2)-1/60*B*(b*c-a*d)^2*g^3*i*n*(a+b*x)^3/(b^2*d)+1/5*g^3*i*(a+b*x)^4*(c+d*x)*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))/b+1/20*(b*c-a*d)*g^3*i*(a+b*x)^4*(A-B*n+B*ln(ee*((a+b*x)/(c+d*x))^n))/b^2+1/20*B*(b*c-a*d)^5*g^3*i*n*ln(c+d*x)/(b^2*d^4)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g",
+    "i",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.2 (f+g x)^m (h+i x)^q (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 124,
+   "integrand": "(c*i+d*i*x)^2*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))/(a*g+b*g*x)^5",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/9*B*d*i^2*n*(c+d*x)^3/((b*c-a*d)^2*g^5*(a+b*x)^3)-1/16*b*B*i^2*n*(c+d*x)^4/((b*c-a*d)^2*g^5*(a+b*x)^4)+1/3*d*i^2*(c+d*x)^3*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))/((b*c-a*d)^2*g^5*(a+b*x)^3)-1/4*b*i^2*(c+d*x)^4*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))/((b*c-a*d)^2*g^5*(a+b*x)^4)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g",
+    "i",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.2 (f+g x)^m (h+i x)^q (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 147,
+   "integrand": "(A+B*ln(ee*((a+b*x)/(c+d*x))^n))/((a*g+b*g*x)^2*(c*i+d*i*x)^2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-B*d^2*n*(a+b*x)/((b*c-a*d)^3*g^2*i^2*(c+d*x))-b^2*B*n*(c+d*x)/((b*c-a*d)^3*g^2*i^2*(a+b*x))+d^2*(a+b*x)*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))/((b*c-a*d)^3*g^2*i^2*(c+d*x))-b^2*(c+d*x)*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))/((b*c-a*d)^3*g^2*i^2*(a+b*x))-2*b*d*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))*ln((a+b*x)/(c+d*x))/((b*c-a*d)^3*g^2*i^2)+b*B*d*n*ln((a+b*x)/(c+d*x))^2/((b*c-a*d)^3*g^2*i^2)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g",
+    "i",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.2 (f+g x)^m (h+i x)^q (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 174,
+   "integrand": "(c*i+d*i*x)^2*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))^2/(a*g+b*g*x)^4",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-2/27*B^2*i^2*n^2*(c+d*x)^3/((b*c-a*d)*g^4*(a+b*x)^3)-2/9*B*i^2*n*(c+d*x)^3*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))/((b*c-a*d)*g^4*(a+b*x)^3)-1/3*i^2*(c+d*x)^3*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))^2/((b*c-a*d)*g^4*(a+b*x)^3)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g",
+    "i",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.2 (f+g x)^m (h+i x)^q (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 203,
+   "integrand": "(a*g+b*g*x)*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))^2/(c*i+d*i*x)^3",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/4*B^2*g*n^2*(a+b*x)^2/((b*c-a*d)*i^3*(c+d*x)^2)-1/2*B*g*n*(a+b*x)^2*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))/((b*c-a*d)*i^3*(c+d*x)^2)+1/2*g*(a+b*x)^2*(A+B*ln(ee*((a+b*x)/(c+d*x))^n))^2/((b*c-a*d)*i^3*(c+d*x)^2)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "g",
+    "i",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.2 (f+g x)^m (h+i x)^q (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 223,
+   "integrand": "ln(ee*((a+b*x)/(c+d*x))^n)^p/((a+b*x)*(c+d*x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "ln(ee*((a+b*x)/(c+d*x))^n)^(1+p)/((b*c-a*d)*n*(1+p))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.2 (f+g x)^m (h+i x)^q (A+B log(e ((a+b x) over (c+d x))^n))^p.mac",
+   "index": 237,
+   "integrand": "1/((a*f+b*f*x)*(c*g+d*g*x)*(A+B*ln(ee*(a+b*x)^n/(c+d*x)^n)))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "ln(A+B*ln(ee*(a+b*x)^n/(c+d*x)^n))/(B*(b*c-a*d)*f*g*n)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.3 u log(e (f (a+b x)^p (c+d x)^q)^r)^s.mac",
+   "index": 25,
+   "integrand": "(g+h*x)^3*ln(ee*(f*(a+b*x)^p*(c+d*x)^q)^r)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/4*(b*g-a*h)^3*p*r*x/b^3-1/4*(d*g-c*h)^3*q*r*x/d^3-1/8*(b*g-a*h)^2*p*r*(g+h*x)^2/(b^2*h)-1/8*(d*g-c*h)^2*q*r*(g+h*x)^2/(d^2*h)-1/12*(b*g-a*h)*p*r*(g+h*x)^3/(b*h)-1/12*(d*g-c*h)*q*r*(g+h*x)^3/(d*h)-1/16*p*r*(g+h*x)^4/h-1/16*q*r*(g+h*x)^4/h-1/4*(b*g-a*h)^4*p*r*ln(a+b*x)/(b^4*h)-1/4*(d*g-c*h)^4*q*r*ln(c+d*x)/(d^4*h)+1/4*(g+h*x)^4*ln(ee*(f*(a+b*x)^p*(c+d*x)^q)^r)/h",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g",
+    "h",
+    "p",
+    "q",
+    "r"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.2.3 u log(e (f (a+b x)^p (c+d x)^q)^r)^s.mac",
+   "index": 46,
+   "integrand": "1/((1-c^2*x^2)*(a+b*ln(sqrt(1-c*x)/sqrt(1+c*x))))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-ln(a+b*ln(sqrt(1-c*x)/sqrt(1+c*x)))/(b*c)",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.3 u (a+b log(c (d+e x)^n))^p.mac",
+   "index": 2,
+   "integrand": "ln(c*(d+ee*x))^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2*x-2*(d+ee*x)*ln(c*(d+ee*x))/ee+(d+ee*x)*ln(c*(d+ee*x))^2/ee",
+   "params": [
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.3 u (a+b log(c (d+e x)^n))^p.mac",
+   "index": 41,
+   "integrand": "(a+b*ln(c*(d+ee*x)^n))/(f+g*x)^3",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/2*b*ee*n/(g*(ee*f-d*g)*(f+g*x))+1/2*b*ee^2*n*ln(d+ee*x)/(g*(ee*f-d*g)^2)+1/2*(-a-b*ln(c*(d+ee*x)^n))/(g*(f+g*x)^2)-1/2*b*ee^2*n*ln(f+g*x)/(g*(ee*f-d*g)^2)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.3 u (a+b log(c (d+e x)^n))^p.mac",
+   "index": 63,
+   "integrand": "ln(a+b*x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-x+(a+b*x)*ln(a+b*x)/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.3 u (a+b log(c (d+e x)^n))^p.mac",
+   "index": 138,
+   "integrand": "(f+g*x)^(1/2)*(a+b*ln(c*(d+ee*x)^n))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-4/9*b*n*(f+g*x)^(3/2)/g+4/3*b*(ee*f-d*g)^(3/2)*n*atanh(sqrt(ee)*sqrt(f+g*x)/sqrt(ee*f-d*g))/(ee^(3/2)*g)+2/3*(f+g*x)^(3/2)*(a+b*ln(c*(d+ee*x)^n))/g-4/3*b*(ee*f-d*g)*n*sqrt(f+g*x)/(ee*g)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.3 u (a+b log(c (d+e x)^n))^p.mac",
+   "index": 183,
+   "integrand": "(h+i*x)^3*(a+b*ln(c*(ee+f*x)))^2/(d*ee+d*f*x)",
+   "variable": "x",
+   "steps": 24,
+   "antiderivative": "-4*a*b*i*(f*h-ee*i)^2*x/(d*f^3)+6*b^2*i*(f*h-ee*i)^2*x/(d*f^3)+3/4*b^2*i^2*(f*h-ee*i)*(ee+f*x)^2/(d*f^4)+2/27*b^2*i^3*(ee+f*x)^3/(d*f^4)+1/3*b^2*(f*h-ee*i)^3*ln(ee+f*x)^2/(d*f^4)-4*b^2*i*(f*h-ee*i)^2*(ee+f*x)*ln(c*(ee+f*x))/(d*f^4)-2*b*i*(f*h-ee*i)^2*(ee+f*x)*(a+b*ln(c*(ee+f*x)))/(d*f^4)-3/2*b*i^2*(f*h-ee*i)*(ee+f*x)^2*(a+b*ln(c*(ee+f*x)))/(d*f^4)-2/9*b*i^3*(ee+f*x)^3*(a+b*ln(c*(ee+f*x)))/(d*f^4)-2/3*b*(f*h-ee*i)^3*ln(ee+f*x)*(a+b*ln(c*(ee+f*x)))/(d*f^4)+2*i*(f*h-ee*i)^2*(ee+f*x)*(a+b*ln(c*(ee+f*x)))^2/(d*f^4)+1/2*i^2*(f*h-ee*i)*(ee+f*x)^2*(a+b*ln(c*(ee+f*x)))^2/(d*f^4)+1/3*(h+i*x)^3*(a+b*ln(c*(ee+f*x)))^2/(d*f)+1/3*(f*h-ee*i)^3*(a+b*ln(c*(ee+f*x)))^3/(b*d*f^4)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "h",
+    "i"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.3 u (a+b log(c (d+e x)^n))^p.mac",
+   "index": 307,
+   "integrand": "(a+b*ln(c*(d+ee*x)^n))/((f+g/x)^3*x^3)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/2*b*ee*n/(f*(d*f-ee*g)*(g+f*x))+1/2*b*ee^2*n*ln(d+ee*x)/(f*(d*f-ee*g)^2)+1/2*(-a-b*ln(c*(d+ee*x)^n))/(f*(g+f*x)^2)-1/2*b*ee^2*n*ln(g+f*x)/(f*(d*f-ee*g)^2)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.3 u (a+b log(c (d+e x)^n))^p.mac",
+   "index": 421,
+   "integrand": "(g+h*x)*(a+b*ln(c*(d*(ee+f*x)^p)^q))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/2*b*(f*g-ee*h)*p*q*x/f-1/4*b*p*q*(g+h*x)^2/h-1/2*b*(f*g-ee*h)^2*p*q*ln(ee+f*x)/(f^2*h)+1/2*(g+h*x)^2*(a+b*ln(c*(d*(ee+f*x)^p)^q))/h",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g",
+    "h",
+    "p",
+    "q"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.3 u (a+b log(c (d+e x)^n))^p.mac",
+   "index": 440,
+   "integrand": "(a+b*ln(c*(d*(ee+f*x)^p)^q))^4",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-24*a*b^3*p^3*q^3*x+24*b^4*p^4*q^4*x-24*b^4*p^3*q^3*(ee+f*x)*ln(c*(d*(ee+f*x)^p)^q)/f+12*b^2*p^2*q^2*(ee+f*x)*(a+b*ln(c*(d*(ee+f*x)^p)^q))^2/f-4*b*p*q*(ee+f*x)*(a+b*ln(c*(d*(ee+f*x)^p)^q))^3/f+(ee+f*x)*(a+b*ln(c*(d*(ee+f*x)^p)^q))^4/f",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "p",
+    "q"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 3,
+   "integrand": "x*ln(c*(a+b*x^2)^p)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/2*p*x^2+1/2*(a+b*x^2)*ln(c*(a+b*x^2)^p)/b",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 17,
+   "integrand": "ln(c*(a+b*x^3)^p)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-3*p*x+a^(1/3)*p*ln(a^(1/3)+b^(1/3)*x)/b^(1/3)-1/2*a^(1/3)*p*ln(a^(2/3)-a^(1/3)*b^(1/3)*x+b^(2/3)*x^2)/b^(1/3)+x*ln(c*(a+b*x^3)^p)-a^(1/3)*p*atan((a^(1/3)-2*b^(1/3)*x)/(a^(1/3)*sqrt(3)))*sqrt(3)/b^(1/3)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 31,
+   "integrand": "ln(c*(a+b/x)^p)/x^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "p/x-(a+b/x)*ln(c*(a+b/x)^p)/b",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 45,
+   "integrand": "x^3*ln(c*(a+b*sqrt(x))^p)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/8*a^6*p*x/b^6+1/12*a^5*p*x^(3/2)/b^5-1/16*a^4*p*x^2/b^4+1/20*a^3*p*x^(5/2)/b^3-1/24*a^2*p*x^3/b^2+1/28*a*p*x^(7/2)/b-1/32*p*x^4-1/4*a^8*p*ln(a+b*sqrt(x))/b^8+1/4*x^4*ln(c*(a+b*sqrt(x))^p)+1/4*a^7*p*sqrt(x)/b^7",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 68,
+   "integrand": "(f*x)^(-1-2*n)*ln(c*(d+ee*x^n)^p)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/2*ee*p*x^n/(d*f*n*(f*x)^(2*n))-1/2*ee^2*p*x^(2*n)*ln(x)/(d^2*f*(f*x)^(2*n))+1/2*ee^2*p*x^(2*n)*ln(d+ee*x^n)/(d^2*f*n*(f*x)^(2*n))-1/2*ln(c*(d+ee*x^n)^p)/(f*n*(f*x)^(2*n))",
+   "params": [
+    "c",
+    "d",
+    "ee",
+    "f",
+    "n",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 175,
+   "integrand": "(d+ee*x)^3*ln(c*(a+b*x)^p)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/4*(b*d-a*ee)^3*p*x/b^3-1/8*(b*d-a*ee)^2*p*(d+ee*x)^2/(b^2*ee)-1/12*(b*d-a*ee)*p*(d+ee*x)^3/(b*ee)-1/16*p*(d+ee*x)^4/ee-1/4*(b*d-a*ee)^4*p*ln(a+b*x)/(b^4*ee)+1/4*(d+ee*x)^4*ln(c*(a+b*x)^p)/ee",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 189,
+   "integrand": "ln(c*(a+b*x^2)^p)/(d+ee*x)^3",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "b*d*p/(ee*(b*d^2+a*ee^2)*(d+ee*x))-b*(b*d^2-a*ee^2)*p*ln(d+ee*x)/(ee*(b*d^2+a*ee^2)^2)+1/2*b*(b*d^2-a*ee^2)*p*ln(a+b*x^2)/(ee*(b*d^2+a*ee^2)^2)-1/2*ln(c*(a+b*x^2)^p)/(ee*(d+ee*x)^2)+2*b^(3/2)*d*p*atan(x*sqrt(b)/sqrt(a))*sqrt(a)/(b*d^2+a*ee^2)^2",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 203,
+   "integrand": "ln(c*(a+b/x)^p)/(d+ee*x)^4",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/6*b*p/(d*(a*d-b*ee)*(d+ee*x)^2)+1/3*b*(2*a*d-b*ee)*p/(d^2*(a*d-b*ee)^2*(d+ee*x))-1/3*ln(c*(a+b/x)^p)/(ee*(d+ee*x)^3)-1/3*p*ln(x)/(d^3*ee)+1/3*a^3*p*ln(b+a*x)/(ee*(a*d-b*ee)^3)-1/3*b*(3*a^2*d^2-3*a*b*d*ee+b^2*ee^2)*p*ln(d+ee*x)/(d^3*(a*d-b*ee)^3)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 316,
+   "integrand": "(f+g*x^2)*ln(c*(d+ee*x^2)^p)/x^9",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/24*ee*f*p/(d*x^6)+1/48*ee*(3*ee*f-4*d*g)*p/(d^2*x^4)-1/24*ee^2*(3*ee*f-4*d*g)*p/(d^3*x^2)-1/12*ee^3*(3*ee*f-4*d*g)*p*ln(x)/d^4+1/24*ee^3*(3*ee*f-4*d*g)*p*ln(d+ee*x^2)/d^4-1/8*f*ln(c*(d+ee*x^2)^p)/x^8-1/6*g*ln(c*(d+ee*x^2)^p)/x^6",
+   "params": [
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 332,
+   "integrand": "(f+g*x^2)^2*ln(c*(d+ee*x^2)^p)",
+   "variable": "x",
+   "steps": 13,
+   "antiderivative": "-2*f^2*p*x+4/3*d*f*g*p*x/ee-2/5*d^2*g^2*p*x/ee^2-4/9*f*g*p*x^3+2/15*d*g^2*p*x^3/ee-2/25*g^2*p*x^5-4/3*d^(3/2)*f*g*p*atan(x*sqrt(ee)/sqrt(d))/ee^(3/2)+2/5*d^(5/2)*g^2*p*atan(x*sqrt(ee)/sqrt(d))/ee^(5/2)+f^2*x*ln(c*(d+ee*x^2)^p)+2/3*f*g*x^3*ln(c*(d+ee*x^2)^p)+1/5*g^2*x^5*ln(c*(d+ee*x^2)^p)+2*f^2*p*atan(x*sqrt(ee)/sqrt(d))*sqrt(d)/sqrt(ee)",
+   "params": [
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 406,
+   "integrand": "(a+b*ln(c*(d+ee*sqrt(x))^n))/x^4",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/15*b*ee*n/(d*x^(5/2))+1/12*b*ee^2*n/(d^2*x^2)-1/9*b*ee^3*n/(d^3*x^(3/2))+1/6*b*ee^4*n/(d^4*x)-1/6*b*ee^6*n*ln(x)/d^6+1/3*b*ee^6*n*ln(d+ee*sqrt(x))/d^6+1/3*(-a-b*ln(c*(d+ee*sqrt(x))^n))/x^3-1/3*b*ee^5*n/(d^5*sqrt(x))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 426,
+   "integrand": "(a+b*ln(c*(d+ee/sqrt(x))^n))/x^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/8*b*n/x^2-1/6*b*d*n/(ee*x^(3/2))+1/4*b*d^2*n/(ee^2*x)+1/2*b*d^4*n*ln(d+ee/sqrt(x))/ee^4+1/2*(-a-b*ln(c*(d+ee/sqrt(x))^n))/x^2-1/2*b*d^3*n/(ee^3*sqrt(x))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 446,
+   "integrand": "(a+b*ln(c*(d+ee*x^(1/3))^n))/x^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/2*b*ee*n/(d*x^(2/3))+b*ee^2*n/(d^2*x^(1/3))-b*ee^3*n*ln(d+ee*x^(1/3))/d^3+(-a-b*ln(c*(d+ee*x^(1/3))^n))/x+1/3*b*ee^3*n*ln(x)/d^3",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 464,
+   "integrand": "x*(a+b*ln(c*(d+ee*x^(2/3))^n))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/2*b*d^2*n*x^(2/3)/ee^2+1/4*b*d*n*x^(4/3)/ee-1/6*b*n*x^2+1/2*b*d^3*n*ln(d+ee*x^(2/3))/ee^3+1/2*x^2*(a+b*ln(c*(d+ee*x^(2/3))^n))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 491,
+   "integrand": "a+b*ln(c*(d+ee/x^(1/3))^n)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-b*ee^2*n*x^(1/3)/d^2+1/2*b*ee*n*x^(2/3)/d+a*x+b*x*ln(c*(d+ee/x^(1/3))^n)+b*ee^3*n*ln(ee+d*x^(1/3))/d^3",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 512,
+   "integrand": "(a+b*ln(c*(d+ee/x^(2/3))^n))/x^2",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "2/3*b*n/x-2*b*d*n/(ee*x^(1/3))-2*b*d^(3/2)*n*atan(x^(1/3)*sqrt(d)/sqrt(ee))/ee^(3/2)+(-a-b*ln(c*(d+ee/x^(2/3))^n))/x",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.4 u (a+b log(c (d+e x^m)^n))^p.mac",
+   "index": 611,
+   "integrand": "(f+g*x)^2*(a+b*ln(c*(d+ee*x^2)^p))/(h*x)^(3/2)",
+   "variable": "x",
+   "steps": 36,
+   "antiderivative": "-8/9*b*g^2*p*(h*x)^(3/2)/h^3+2/3*g^2*(h*x)^(3/2)*(a+b*ln(c*(d+ee*x^2)^p))/h^3-2*b*ee^(1/4)*f^2*p*atan(1-ee^(1/4)*sqrt(2)*sqrt(h*x)/(d^(1/4)*sqrt(h)))*sqrt(2)/(d^(1/4)*h^(3/2))-4*b*d^(1/4)*f*g*p*atan(1-ee^(1/4)*sqrt(2)*sqrt(h*x)/(d^(1/4)*sqrt(h)))*sqrt(2)/(ee^(1/4)*h^(3/2))-2/3*b*d^(3/4)*g^2*p*atan(1-ee^(1/4)*sqrt(2)*sqrt(h*x)/(d^(1/4)*sqrt(h)))*sqrt(2)/(ee^(3/4)*h^(3/2))+2*b*ee^(1/4)*f^2*p*atan(1+ee^(1/4)*sqrt(2)*sqrt(h*x)/(d^(1/4)*sqrt(h)))*sqrt(2)/(d^(1/4)*h^(3/2))+4*b*d^(1/4)*f*g*p*atan(1+ee^(1/4)*sqrt(2)*sqrt(h*x)/(d^(1/4)*sqrt(h)))*sqrt(2)/(ee^(1/4)*h^(3/2))+2/3*b*d^(3/4)*g^2*p*atan(1+ee^(1/4)*sqrt(2)*sqrt(h*x)/(d^(1/4)*sqrt(h)))*sqrt(2)/(ee^(3/4)*h^(3/2))+b*ee^(1/4)*f^2*p*ln(sqrt(d)*sqrt(h)+x*sqrt(ee)*sqrt(h)-d^(1/4)*ee^(1/4)*sqrt(2)*sqrt(h*x))*sqrt(2)/(d^(1/4)*h^(3/2))-2*b*d^(1/4)*f*g*p*ln(sqrt(d)*sqrt(h)+x*sqrt(ee)*sqrt(h)-d^(1/4)*ee^(1/4)*sqrt(2)*sqrt(h*x))*sqrt(2)/(ee^(1/4)*h^(3/2))+1/3*b*d^(3/4)*g^2*p*ln(sqrt(d)*sqrt(h)+x*sqrt(ee)*sqrt(h)-d^(1/4)*ee^(1/4)*sqrt(2)*sqrt(h*x))*sqrt(2)/(ee^(3/4)*h^(3/2))-b*ee^(1/4)*f^2*p*ln(sqrt(d)*sqrt(h)+x*sqrt(ee)*sqrt(h)+d^(1/4)*ee^(1/4)*sqrt(2)*sqrt(h*x))*sqrt(2)/(d^(1/4)*h^(3/2))+2*b*d^(1/4)*f*g*p*ln(sqrt(d)*sqrt(h)+x*sqrt(ee)*sqrt(h)+d^(1/4)*ee^(1/4)*sqrt(2)*sqrt(h*x))*sqrt(2)/(ee^(1/4)*h^(3/2))-1/3*b*d^(3/4)*g^2*p*ln(sqrt(d)*sqrt(h)+x*sqrt(ee)*sqrt(h)+d^(1/4)*ee^(1/4)*sqrt(2)*sqrt(h*x))*sqrt(2)/(ee^(3/4)*h^(3/2))-2*f^2*(a+b*ln(c*(d+ee*x^2)^p))/(h*sqrt(h*x))+4*a*f*g*sqrt(h*x)/h^2-16*b*f*g*p*sqrt(h*x)/h^2+4*b*f*g*ln(c*(d+ee*x^2)^p)*sqrt(h*x)/h^2",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g",
+    "h",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.5 Logarithm functions.mac",
+   "index": 8,
+   "integrand": "ln(c*x^n)*(a*x^m+b*ln(c*x^n)^2)^3/x",
+   "variable": "x",
+   "steps": 13,
+   "antiderivative": "-360*a*b^2*n^5*x^m/m^6-9/8*a^2*b*n^3*x^(2*m)/m^4-1/9*a^3*n*x^(3*m)/m^2+360*a*b^2*n^4*x^m*ln(c*x^n)/m^5+9/4*a^2*b*n^2*x^(2*m)*ln(c*x^n)/m^3+1/3*a^3*x^(3*m)*ln(c*x^n)/m-180*a*b^2*n^3*x^m*ln(c*x^n)^2/m^4-9/4*a^2*b*n*x^(2*m)*ln(c*x^n)^2/m^2+60*a*b^2*n^2*x^m*ln(c*x^n)^3/m^3+3/2*a^2*b*x^(2*m)*ln(c*x^n)^3/m-15*a*b^2*n*x^m*ln(c*x^n)^4/m^2+3*a*b^2*x^m*ln(c*x^n)^5/m+1/8*b^3*ln(c*x^n)^8/n",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "m",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.5 Logarithm functions.mac",
+   "index": 23,
+   "integrand": "(a/x+2*b*n*ln(c*x^n)/x^2)*(a*x^2+b*x*ln(c*x^n)^2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/2*(a*x+b*ln(c*x^n)^2)^2",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.5 Logarithm functions.mac",
+   "index": 60,
+   "integrand": "x^3*ln(d*(b*x+c*x^2)^n)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/4*b^3*n*x/c^3-1/8*b^2*n*x^2/c^2+1/12*b*n*x^3/c-1/8*n*x^4-1/4*b^4*n*ln(b+c*x)/c^4+1/4*x^4*ln(d*(b*x+c*x^2)^n)",
+   "params": [
+    "b",
+    "c",
+    "d",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.5 Logarithm functions.mac",
+   "index": 74,
+   "integrand": "ln(d*(a+b*x+c*x^2)^n)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-2*n*x+1/2*b*n*ln(a+b*x+c*x^2)/c+x*ln(d*(a+b*x+c*x^2)^n)+n*atanh((b+2*c*x)/sqrt(b^2-4*a*c))*sqrt(b^2-4*a*c)/c",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.5 Logarithm functions.mac",
+   "index": 88,
+   "integrand": "ln(d*(a+b*x+c*x^2)^n)/(d+ee*x)^3",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "1/2*(2*c*d-b*ee)*n/(ee*(c*d^2-b*d*ee+a*ee^2)*(d+ee*x))-1/2*(2*c^2*d^2+b^2*ee^2-2*c*ee*(b*d+a*ee))*n*ln(d+ee*x)/(ee*(c*d^2-b*d*ee+a*ee^2)^2)+1/4*(2*c^2*d^2+b^2*ee^2-2*c*ee*(b*d+a*ee))*n*ln(a+b*x+c*x^2)/(ee*(c*d^2-b*d*ee+a*ee^2)^2)-1/2*ln(d*(a+b*x+c*x^2)^n)/(ee*(d+ee*x)^2)+1/2*(2*c*d-b*ee)*n*atanh((b+2*c*x)/sqrt(b^2-4*a*c))*sqrt(b^2-4*a*c)/(c*d^2-b*d*ee+a*ee^2)^2",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "n"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.5 Logarithm functions.mac",
+   "index": 110,
+   "integrand": "ln(-1+4*x+4*sqrt((-1+x)*x))/x^(3/2)",
+   "variable": "x",
+   "steps": 15,
+   "antiderivative": "-8*atan(sqrt(x)/sqrt(-x+x^2))+4*atan(2*sqrt(2)*sqrt(x))*sqrt(2)-2*ln(-1+4*x+4*sqrt(-x+x^2))/sqrt(x)-4*atan(2/3*sqrt(2)*sqrt(-1+x))*sqrt(2)*sqrt(-x+x^2)/(sqrt(-1+x)*sqrt(x))",
+   "params": []
+  },
+  {
+   "source": "3 Logarithms/3.5 Logarithm functions.mac",
+   "index": 139,
+   "integrand": "sin(ln(x))^2/x",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/2*ln(x)-1/2*cos(ln(x))*sin(ln(x))",
+   "params": []
+  },
+  {
+   "source": "3 Logarithms/3.5 Logarithm functions.mac",
+   "index": 151,
+   "integrand": "(b*ln(a*x^n)^m)^p/x",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "ln(a*x^n)*(b*ln(a*x^n)^m)^p/(n*(1+m*p))",
+   "params": [
+    "a",
+    "b",
+    "m",
+    "n",
+    "p"
+   ]
+  },
+  {
+   "source": "3 Logarithms/3.5 Logarithm functions.mac",
+   "index": 188,
+   "integrand": "cos(x)*ln(cos(x))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "atanh(sin(x))-sin(x)+ln(cos(x))*sin(x)",
+   "params": []
+  },
+  {
+   "source": "3 Logarithms/3.5 Logarithm functions.mac",
+   "index": 228,
+   "integrand": "x*ln((1+3*x)^(1/3))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/18*x-1/12*x^2+1/2*x^2*ln((1+3*x)^(1/3))-1/54*ln(1+3*x)",
+   "params": []
+  },
+  {
+   "source": "3 Logarithms/3.5 Logarithm functions.mac",
+   "index": 240,
+   "integrand": "ln((-11+5*x)/(5+76*x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/5*(11-5*x)*ln((-11+5*x)/(5+76*x))-861/380*ln(5+76*x)",
+   "params": []
+  },
+  {
+   "source": "3 Logarithms/3.5 Logarithm functions.mac",
+   "index": 252,
+   "integrand": "1/(a*x+b*x*ln(c*x^n)^4)",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "-1/2*atan(1-b^(1/4)*ln(c*x^n)*sqrt(2)/a^(1/4))/(a^(3/4)*b^(1/4)*n*sqrt(2))+1/2*atan(1+b^(1/4)*ln(c*x^n)*sqrt(2)/a^(1/4))/(a^(3/4)*b^(1/4)*n*sqrt(2))-1/4*ln(-a^(1/4)*b^(1/4)*ln(c*x^n)*sqrt(2)+sqrt(a)+ln(c*x^n)^2*sqrt(b))/(a^(3/4)*b^(1/4)*n*sqrt(2))+1/4*ln(a^(1/4)*b^(1/4)*ln(c*x^n)*sqrt(2)+sqrt(a)+ln(c*x^n)^2*sqrt(b))/(a^(3/4)*b^(1/4)*n*sqrt(2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "n"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.0 (a sin)^m (b trg)^n.mac",
+   "index": 0,
+   "integrand": "sin(a+b*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-cos(a+b*x)/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.0 (a sin)^m (b trg)^n.mac",
+   "index": 160,
+   "integrand": "cos(a+b*x)^5/sin(a+b*x)^4",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2*csc(a+b*x)/b-1/3*csc(a+b*x)^3/b+sin(a+b*x)/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.0 (a sin)^m (b trg)^n.mac",
+   "index": 399,
+   "integrand": "(b*sec(ee+f*x))^(5/2)*sin(ee+f*x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "2/3*b*(b*sec(ee+f*x))^(3/2)/f",
+   "params": [
+    "b",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.1.2 (g cos)^p (a+b sin)^m.mac",
+   "index": 44,
+   "integrand": "cos(c+d*x)*(a+a*sin(c+d*x))^8",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/9*(a+a*sin(c+d*x))^9/(a*d)",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.1.2 (g cos)^p (a+b sin)^m.mac",
+   "index": 171,
+   "integrand": "cos(c+d*x)^4/(a+a*sin(c+d*x))^(3/2)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-2/5*a*cos(c+d*x)^5/(d*(a+a*sin(c+d*x))^(5/2))",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.1.2 (g cos)^p (a+b sin)^m.mac",
+   "index": 420,
+   "integrand": "sec(c+d*x)^4*(a+b*sin(c+d*x))^8",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "35/8*b^4*(16*a^4+16*a^2*b^2+b^4)*x+1/6*a*b*(8*a^6-104*a^4*b^2-803*a^2*b^4-256*b^6)*cos(c+d*x)/d+1/24*b^2*(16*a^6-200*a^4*b^2-866*a^2*b^4-105*b^6)*cos(c+d*x)*sin(c+d*x)/d+1/12*a*b*(8*a^4-88*a^2*b^2-151*b^4)*cos(c+d*x)*(a+b*sin(c+d*x))^2/d+1/12*b*(8*a^4-72*a^2*b^2-35*b^4)*cos(c+d*x)*(a+b*sin(c+d*x))^3/d+1/3*a*b*(2*a^2-13*b^2)*cos(c+d*x)*(a+b*sin(c+d*x))^4/d+1/3*b*(2*a^2-7*b^2)*cos(c+d*x)*(a+b*sin(c+d*x))^5/d+1/3*sec(c+d*x)^3*(b+a*sin(c+d*x))*(a+b*sin(c+d*x))^7/d-1/3*sec(c+d*x)*(a+b*sin(c+d*x))^6*(5*a*b-(2*a^2-7*b^2)*sin(c+d*x))/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.1.3 (g tan)^p (a+b sin)^m.mac",
+   "index": 35,
+   "integrand": "(a+a*sin(c+d*x))^4*tan(c+d*x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-8*a^4*ln(1-sin(c+d*x))/d-8*a^4*sin(c+d*x)/d-7/2*a^4*sin(c+d*x)^2/d-4/3*a^4*sin(c+d*x)^3/d-1/4*a^4*sin(c+d*x)^4/d",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.1.3 (g tan)^p (a+b sin)^m.mac",
+   "index": 194,
+   "integrand": "cot(c+d*x)/(a+b*sin(c+d*x))^3",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "ln(sin(c+d*x))/(a^3*d)-ln(a+b*sin(c+d*x))/(a^3*d)+1/2/(a*d*(a+b*sin(c+d*x))^2)+1/(a^2*d*(a+b*sin(c+d*x)))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.12 (e x)^m (a+b sin(c+d x^n))^p.mac",
+   "index": 107,
+   "integrand": "sin(a+b/x)/x^3",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "cos(a+b/x)/(b*x)-sin(a+b/x)/b^2",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.1 (a+b sin)^m (c+d sin)^n.mac",
+   "index": 82,
+   "integrand": "csc(c+d*x)^2/(a+a*sin(c+d*x))^(5/2)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "5*atanh(cos(c+d*x)*sqrt(a)/sqrt(a+a*sin(c+d*x)))/(a^(5/2)*d)+1/4*cot(c+d*x)/(d*(a+a*sin(c+d*x))^(5/2))+15/16*cot(c+d*x)/(a*d*(a+a*sin(c+d*x))^(3/2))-115/16*atanh(cos(c+d*x)*sqrt(a)/(sqrt(2)*sqrt(a+a*sin(c+d*x))))/(a^(5/2)*d*sqrt(2))-35/16*cot(c+d*x)/(a^2*d*sqrt(a+a*sin(c+d*x)))",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.1 (a+b sin)^m (c+d sin)^n.mac",
+   "index": 293,
+   "integrand": "(a+a*sin(ee+f*x))/(c-c*sin(ee+f*x))^(1/2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "2*a*atanh(cos(ee+f*x)*sqrt(c)/(sqrt(2)*sqrt(c-c*sin(ee+f*x))))*sqrt(2)/(f*sqrt(c))-2*a*cos(ee+f*x)/(f*sqrt(c-c*sin(ee+f*x)))",
+   "params": [
+    "a",
+    "c",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.1 (a+b sin)^m (c+d sin)^n.mac",
+   "index": 435,
+   "integrand": "(a+a*sin(ee+f*x))^2*(c+d*sin(ee+f*x))^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/8*a^2*(12*c^2+16*c*d+7*d^2)*x-1/6*a^2*(12*c^2+16*c*d+7*d^2)*cos(ee+f*x)/f-1/24*a^2*(12*c^2+16*c*d+7*d^2)*cos(ee+f*x)*sin(ee+f*x)/f-1/12*(8*c-d)*d*cos(ee+f*x)*(a+a*sin(ee+f*x))^2/f-1/4*d^2*cos(ee+f*x)*(a+a*sin(ee+f*x))^3/(a*f)",
+   "params": [
+    "a",
+    "c",
+    "d",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.1 (a+b sin)^m (c+d sin)^n.mac",
+   "index": 627,
+   "integrand": "(3-3*sin(ee+f*x))^(-1-m)*(1+sin(ee+f*x))^m",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "cos(ee+f*x)*(3-3*sin(ee+f*x))^(-1-m)*(1+sin(ee+f*x))^m/(f*(1+2*m))",
+   "params": [
+    "ee",
+    "f",
+    "m"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.2 (g cos)^p (a+b sin)^m (c+d sin)^n.mac",
+   "index": 81,
+   "integrand": "cos(ee+f*x)^2*(a+a*sin(ee+f*x))^m*(c-c*sin(ee+f*x))^(-4-m)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "cos(ee+f*x)*(a+a*sin(ee+f*x))^(1+m)*(c-c*sin(ee+f*x))^(-3-m)/(a*c*f*(5+2*m))+cos(ee+f*x)*(a+a*sin(ee+f*x))^(1+m)*(c-c*sin(ee+f*x))^(-2-m)/(a*c^2*f*(15+16*m+4*m^2))",
+   "params": [
+    "a",
+    "c",
+    "ee",
+    "f",
+    "m"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.2 (g cos)^p (a+b sin)^m (c+d sin)^n.mac",
+   "index": 311,
+   "integrand": "cos(c+d*x)^2*csc(c+d*x)^2/(a+a*sin(c+d*x))^2",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "2*atanh(cos(c+d*x))/(a^2*d)-3*cot(c+d*x)/(a^2*d)+2*cot(c+d*x)/(a^2*d*(1+sin(c+d*x)))",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.2 (g cos)^p (a+b sin)^m (c+d sin)^n.mac",
+   "index": 438,
+   "integrand": "cos(c+d*x)^4*csc(c+d*x)^5/(a+a*sin(c+d*x))^3",
+   "variable": "x",
+   "steps": 14,
+   "antiderivative": "-51/8*atanh(cos(c+d*x))/(a^3*d)+7*cot(c+d*x)/(a^3*d)+cot(c+d*x)^3/(a^3*d)-19/8*cot(c+d*x)*csc(c+d*x)/(a^3*d)-1/4*cot(c+d*x)*csc(c+d*x)^3/(a^3*d)+4*cos(c+d*x)/(a^3*d*(1+sin(c+d*x)))",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.2 (g cos)^p (a+b sin)^m (c+d sin)^n.mac",
+   "index": 572,
+   "integrand": "cos(c+d*x)^6*sin(c+d*x)^3*(a+a*sin(c+d*x))",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "3/256*a*x-1/7*a*cos(c+d*x)^7/d+1/9*a*cos(c+d*x)^9/d+3/256*a*cos(c+d*x)*sin(c+d*x)/d+1/128*a*cos(c+d*x)^3*sin(c+d*x)/d+1/160*a*cos(c+d*x)^5*sin(c+d*x)/d-3/80*a*cos(c+d*x)^7*sin(c+d*x)/d-1/10*a*cos(c+d*x)^7*sin(c+d*x)^3/d",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.2 (g cos)^p (a+b sin)^m (c+d sin)^n.mac",
+   "index": 705,
+   "integrand": "cos(c+d*x)^8*sin(c+d*x)^4/(a+a*sin(c+d*x))",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "3/256*x/a+1/7*cos(c+d*x)^7/(a*d)-2/9*cos(c+d*x)^9/(a*d)+1/11*cos(c+d*x)^11/(a*d)+3/256*cos(c+d*x)*sin(c+d*x)/(a*d)+1/128*cos(c+d*x)^3*sin(c+d*x)/(a*d)+1/160*cos(c+d*x)^5*sin(c+d*x)/(a*d)-3/80*cos(c+d*x)^7*sin(c+d*x)/(a*d)-1/10*cos(c+d*x)^7*sin(c+d*x)^3/(a*d)",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.2 (g cos)^p (a+b sin)^m (c+d sin)^n.mac",
+   "index": 833,
+   "integrand": "sec(c+d*x)^4*sin(c+d*x)^2/(a+a*sin(c+d*x))^2",
+   "variable": "x",
+   "steps": 12,
+   "antiderivative": "2/5*sec(c+d*x)^5/(a^2*d)-2/7*sec(c+d*x)^7/(a^2*d)+1/3*tan(c+d*x)^3/(a^2*d)+3/5*tan(c+d*x)^5/(a^2*d)+2/7*tan(c+d*x)^7/(a^2*d)",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.2 (g cos)^p (a+b sin)^m (c+d sin)^n.mac",
+   "index": 989,
+   "integrand": "sec(c+d*x)*(a+a*sin(c+d*x))^3*(A+B*sin(c+d*x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-4*a^3*(A+B)*ln(1-sin(c+d*x))/d-3*a^3*(A+B)*sin(c+d*x)/d-1/2*a^3*(A+B)*sin(c+d*x)^2/d-1/3*B*(a+a*sin(c+d*x))^3/d",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.2 (g cos)^p (a+b sin)^m (c+d sin)^n.mac",
+   "index": 1141,
+   "integrand": "cos(c+d*x)^4*csc(c+d*x)^5/(a+b*sin(c+d*x))^3",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "-3/8*(a^4-24*a^2*b^2+40*b^4)*atanh(cos(c+d*x))/(a^7*d)-1/2*b*(13*a^2-30*b^2)*cot(c+d*x)/(a^6*d)+3/8*(7*a^2-20*b^2)*cot(c+d*x)*csc(c+d*x)/(a^5*d)-1/2*(3*a^2-10*b^2)*cot(c+d*x)*csc(c+d*x)^2/(a^4*b*d)+1/4*(2*a^2-3*b^2)*cot(c+d*x)*csc(c+d*x)^2/(a^2*b*d*(a+b*sin(c+d*x))^2)-1/4*cot(c+d*x)*csc(c+d*x)^3/(a*d*(a+b*sin(c+d*x))^2)+1/4*(4*a^2-15*b^2)*cot(c+d*x)*csc(c+d*x)^2/(a^3*b*d*(a+b*sin(c+d*x)))-3*b*(2*a^4-11*a^2*b^2+10*b^4)*atan((b+a*tan(1/2*(c+d*x)))/sqrt(a^2-b^2))/(a^7*d*sqrt(a^2-b^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.2 (g cos)^p (a+b sin)^m (c+d sin)^n.mac",
+   "index": 1330,
+   "integrand": "cos(c+d*x)^6*csc(c+d*x)^9/(a+b*sin(c+d*x))",
+   "variable": "x",
+   "steps": 12,
+   "antiderivative": "2*b^3*(a^2-b^2)^(5/2)*atan((b+a*tan(1/2*(c+d*x)))/sqrt(a^2-b^2))/(a^9*d)+1/128*(5*a^8+40*a^6*b^2-240*a^4*b^4+320*a^2*b^6-128*b^8)*atanh(cos(c+d*x))/(a^9*d)-1/105*b*(15*a^6-161*a^4*b^2+245*a^2*b^4-105*b^6)*cot(c+d*x)/(a^8*d)+1/128*(5*a^6-88*a^4*b^2+144*a^2*b^4-64*b^6)*cot(c+d*x)*csc(c+d*x)/(a^7*d)+1/105*b*(45*a^4-77*a^2*b^2+35*b^4)*cot(c+d*x)*csc(c+d*x)^2/(a^6*d)-1/192*(59*a^4-104*a^2*b^2+48*b^4)*cot(c+d*x)*csc(c+d*x)^3/(a^5*d)-1/4*cot(c+d*x)*csc(c+d*x)^4/(b*d)+1/140*(35*a^4-60*a^2*b^2+28*b^4)*cot(c+d*x)*csc(c+d*x)^4/(a^4*b*d)+1/5*a*cot(c+d*x)*csc(c+d*x)^5/(b^2*d)-1/240*(48*a^4-85*a^2*b^2+40*b^4)*cot(c+d*x)*csc(c+d*x)^5/(a^3*b^2*d)+1/7*b*cot(c+d*x)*csc(c+d*x)^6/(a^2*d)-1/8*cot(c+d*x)*csc(c+d*x)^7/(a*d)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.2.2 (g cos)^p (a+b sin)^m (c+d sin)^n.mac",
+   "index": 1557,
+   "integrand": "sec(c+d*x)^5*(A+B*sin(c+d*x))/(a+b*sin(c+d*x))^2",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/16*(3*a^2*A+2*a*b*(6*A+B)+b^2*(15*A+8*B))*ln(1-sin(c+d*x))/((a+b)^4*d)+1/16*(3*a^2*A+b^2*(15*A-8*B)-2*a*b*(6*A-B))*ln(1+sin(c+d*x))/((a-b)^4*d)-b^4*(6*a*A*b-5*a^2*B-b^2*B)*ln(a+b*sin(c+d*x))/((a^2-b^2)^4*d)-1/8*b*(3*a^4*A-12*a^2*A*b^2-15*A*b^4+2*a^3*b*B+22*a*b^3*B)/((a^2-b^2)^3*d*(a+b*sin(c+d*x)))-1/4*sec(c+d*x)^4*(A*b-a*B-(a*A-b*B)*sin(c+d*x))/((a^2-b^2)*d*(a+b*sin(c+d*x)))+1/8*sec(c+d*x)^2*(b*(a^2*A+5*A*b^2-6*a*b*B)+(3*a^3*A-9*a*A*b^2+2*a^2*b*B+4*b^3*B)*sin(c+d*x))/((a^2-b^2)^2*d*(a+b*sin(c+d*x)))",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.3.1 (a+b sin)^m (c+d sin)^n (A+B sin).mac",
+   "index": 107,
+   "integrand": "(A+B*sin(ee+f*x))*(c-c*sin(ee+f*x))^(7/2)/(a+a*sin(ee+f*x))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-12/35*(7*A-9*B)*c^2*cos(ee+f*x)*(c-c*sin(ee+f*x))^(3/2)/(a*f)-1/7*(7*A-9*B)*c*cos(ee+f*x)*(c-c*sin(ee+f*x))^(5/2)/(a*f)-(A-B)*sec(ee+f*x)*(c-c*sin(ee+f*x))^(9/2)/(a*c*f)-128/35*(7*A-9*B)*c^4*cos(ee+f*x)/(a*f*sqrt(c-c*sin(ee+f*x)))-32/35*(7*A-9*B)*c^3*cos(ee+f*x)*sqrt(c-c*sin(ee+f*x))/(a*f)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "c",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.3.1 (a+b sin)^m (c+d sin)^n (A+B sin).mac",
+   "index": 252,
+   "integrand": "(a+a*sin(ee+f*x))^2*(A+B*sin(ee+f*x))*(c+d*sin(ee+f*x))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/8*a^2*(12*A*c+8*B*c+8*A*d+7*B*d)*x-1/6*a^2*(12*A*c+8*B*c+8*A*d+7*B*d)*cos(ee+f*x)/f-1/24*a^2*(12*A*c+8*B*c+8*A*d+7*B*d)*cos(ee+f*x)*sin(ee+f*x)/f-1/12*(4*B*c+4*A*d-B*d)*cos(ee+f*x)*(a+a*sin(ee+f*x))^2/f-1/4*B*d*cos(ee+f*x)*(a+a*sin(ee+f*x))^3/(a*f)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "c",
+    "d",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.7 (d trig)^m (a+b (c sin)^n)^p.mac",
+   "index": 46,
+   "integrand": "csc(c+d*x)^4/(a-a*sin(c+d*x)^2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-2*cot(c+d*x)/(a*d)-1/3*cot(c+d*x)^3/(a*d)+tan(c+d*x)/(a*d)",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.7 (d trig)^m (a+b (c sin)^n)^p.mac",
+   "index": 211,
+   "integrand": "sin(c+d*x)^9/(a-b*sin(c+d*x)^4)^2",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-cos(c+d*x)/(b^2*d)-1/4*a*cos(c+d*x)*(a+b-b*cos(c+d*x)^2)/((a-b)*b^2*d*(a-b+2*b*cos(c+d*x)^2-b*cos(c+d*x)^4))+1/8*atan(b^(1/4)*cos(c+d*x)/sqrt(sqrt(a)-sqrt(b)))*sqrt(a)*(5*sqrt(a)-6*sqrt(b))/(b^(9/4)*d*(sqrt(a)-sqrt(b))^(3/2))+1/8*atanh(b^(1/4)*cos(c+d*x)/sqrt(sqrt(a)+sqrt(b)))*sqrt(a)*(5*sqrt(a)+6*sqrt(b))/(b^(9/4)*d*(sqrt(a)+sqrt(b))^(3/2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.7 (d trig)^m (a+b (c sin)^n)^p.mac",
+   "index": 389,
+   "integrand": "1/(a+b*sin(c+d*x)^3)",
+   "variable": "x",
+   "steps": 11,
+   "antiderivative": "2/3*atan((b^(1/3)+a^(1/3)*tan(1/2*(c+d*x)))/sqrt(a^(2/3)-b^(2/3)))/(a^(2/3)*d*sqrt(a^(2/3)-b^(2/3)))+2/3*atan(((-1)^(2/3)*b^(1/3)+a^(1/3)*tan(1/2*(c+d*x)))/sqrt(a^(2/3)+(-1)^(1/3)*b^(2/3)))/(a^(2/3)*d*sqrt(a^(2/3)+(-1)^(1/3)*b^(2/3)))-2/3*atan((-1)^(1/3)*(b^(1/3)+(-1)^(2/3)*a^(1/3)*tan(1/2*(c+d*x)))/sqrt(a^(2/3)-(-1)^(2/3)*b^(2/3)))/(a^(2/3)*d*sqrt(a^(2/3)-(-1)^(2/3)*b^(2/3)))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.1 Sine/4.1.9 trig^m (a+b sin^n+c sin^(2 n))^p.mac",
+   "index": 6,
+   "integrand": "csc(x)^2/(a+b*sin(x)+c*sin(x)^2)",
+   "variable": "x",
+   "steps": 12,
+   "antiderivative": "b*atanh(cos(x))/a^2-cot(x)/a+b*c*atan((2*c+(b-sqrt(b^2-4*a*c))*tan(1/2*x))/(sqrt(2)*sqrt(b^2-2*c*(a+c)-b*sqrt(b^2-4*a*c))))*sqrt(2)*(1+(b^2-2*a*c)/(b*sqrt(b^2-4*a*c)))/(a^2*sqrt(b^2-2*c*(a+c)-b*sqrt(b^2-4*a*c)))+b*c*atan((2*c+(b+sqrt(b^2-4*a*c))*tan(1/2*x))/(sqrt(2)*sqrt(b^2-2*c*(a+c)+b*sqrt(b^2-4*a*c))))*sqrt(2)*(1+(-b^2+2*a*c)/(b*sqrt(b^2-4*a*c)))/(a^2*sqrt(b^2-2*c*(a+c)+b*sqrt(b^2-4*a*c)))",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.1.1 (a+b cos)^n.mac",
+   "index": 31,
+   "integrand": "1/(-5-3*cos(c+d*x))^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-59/2048*x+59/1024*atan(sin(c+d*x)/(3+cos(c+d*x)))/d+3/32*sin(c+d*x)/(d*(5+3*cos(c+d*x))^2)+45/512*sin(c+d*x)/(d*(5+3*cos(c+d*x)))",
+   "params": [
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.12 (e x)^m (a+b cos(c+d x^n))^p.mac",
+   "index": 38,
+   "integrand": "cos(a+b/x)/x^4",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-2*cos(a+b/x)/(b^2*x)+2*sin(a+b/x)/b^3-sin(a+b/x)/(b*x^2)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.2.1 (a+b cos)^m (c+d cos)^n.mac",
+   "index": 116,
+   "integrand": "(a+a*cos(c+d*x))^(5/2)*sec(c+d*x)^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "5*a^(5/2)*atanh(sin(c+d*x)*sqrt(a)/sqrt(a+a*cos(c+d*x)))/d+a^3*sin(c+d*x)/(d*sqrt(a+a*cos(c+d*x)))+a^2*sqrt(a+a*cos(c+d*x))*tan(c+d*x)/d",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.2.1 (a+b cos)^m (c+d cos)^n.mac",
+   "index": 346,
+   "integrand": "(a+a*cos(c+d*x))^(3/2)*sec(c+d*x)^(7/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "6/5*a^2*sec(c+d*x)^(3/2)*sin(c+d*x)/(d*sqrt(a+a*cos(c+d*x)))+2/5*a^2*sec(c+d*x)^(5/2)*sin(c+d*x)/(d*sqrt(a+a*cos(c+d*x)))+12/5*a^2*sin(c+d*x)*sqrt(sec(c+d*x))/(d*sqrt(a+a*cos(c+d*x)))",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.2.1 (a+b cos)^m (c+d cos)^n.mac",
+   "index": 484,
+   "integrand": "sec(c+d*x)^2/(a+b*cos(c+d*x))^4",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "b^2*(20*a^6-35*a^4*b^2+28*a^2*b^4-8*b^6)*atan(sqrt(a-b)*tan(1/2*(c+d*x))/sqrt(a+b))/(a^5*(a-b)^(7/2)*(a+b)^(7/2)*d)-4*b*atanh(sin(c+d*x))/(a^5*d)+1/6*(6*a^6-65*a^4*b^2+68*a^2*b^4-24*b^6)*tan(c+d*x)/(a^4*(a^2-b^2)^3*d)+1/3*b^2*tan(c+d*x)/(a*(a^2-b^2)*d*(a+b*cos(c+d*x))^3)+1/6*b^2*(9*a^2-4*b^2)*tan(c+d*x)/(a^2*(a^2-b^2)^2*d*(a+b*cos(c+d*x))^2)+1/2*b^2*(12*a^4-11*a^2*b^2+4*b^4)*tan(c+d*x)/(a^3*(a^2-b^2)^3*d*(a+b*cos(c+d*x)))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.3.1 (a+b cos)^m (c+d cos)^n (A+B cos).mac",
+   "index": 69,
+   "integrand": "(A+B*cos(c+d*x))/(a+a*cos(c+d*x))^4",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/7*(A-B)*sin(c+d*x)/(d*(a+a*cos(c+d*x))^4)+1/35*(3*A+4*B)*sin(c+d*x)/(a*d*(a+a*cos(c+d*x))^3)+2/105*(3*A+4*B)*sin(c+d*x)/(d*(a^2+a^2*cos(c+d*x))^2)+2/105*(3*A+4*B)*sin(c+d*x)/(d*(a^4+a^4*cos(c+d*x)))",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.3.1 (a+b cos)^m (c+d cos)^n (A+B cos).mac",
+   "index": 239,
+   "integrand": "cos(c+d*x)^2*(a+b*cos(c+d*x))^4*(A+B*cos(c+d*x))",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "1/16*(8*a^4*A+36*a^2*A*b^2+5*A*b^4+24*a^3*b*B+20*a*b^3*B)*x+1/35*(140*a^3*A*b+112*a*A*b^3+35*a^4*B+168*a^2*b^2*B+24*b^4*B)*sin(c+d*x)/d+1/16*(8*a^4*A+36*a^2*A*b^2+5*A*b^4+24*a^3*b*B+20*a*b^3*B)*cos(c+d*x)*sin(c+d*x)/d+1/168*b*(224*a^2*A*b+35*A*b^3+104*a^3*B+140*a*b^2*B)*cos(c+d*x)^3*sin(c+d*x)/d+1/105*b^2*(49*a*A*b+31*a^2*B+18*b^2*B)*cos(c+d*x)^4*sin(c+d*x)/d+1/42*b*(7*A*b+10*a*B)*cos(c+d*x)^3*(a+b*cos(c+d*x))^2*sin(c+d*x)/d+1/7*b*B*cos(c+d*x)^3*(a+b*cos(c+d*x))^3*sin(c+d*x)/d-1/105*(140*a^3*A*b+112*a*A*b^3+35*a^4*B+168*a^2*b^2*B+24*b^4*B)*sin(c+d*x)^3/d",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.4.1 (a+b cos)^m (A+B cos+C cos^2).mac",
+   "index": 14,
+   "integrand": "(A+C*cos(c+d*x)^2)*sec(c+d*x)^8",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/7*(6*A+7*C)*tan(c+d*x)/d+1/7*A*sec(c+d*x)^6*tan(c+d*x)/d+2/21*(6*A+7*C)*tan(c+d*x)^3/d+1/35*(6*A+7*C)*tan(c+d*x)^5/d",
+   "params": [
+    "A",
+    "C",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.4.2 (a+b cos)^m (c+d cos)^n (A+B cos+C cos^2).mac",
+   "index": 20,
+   "integrand": "(a+a*cos(c+d*x))^3*(A+C*cos(c+d*x)^2)*sec(c+d*x)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "1/8*a^3*(28*A+15*C)*x+a^3*A*atanh(sin(c+d*x))/d+5/8*a^3*(4*A+3*C)*sin(c+d*x)/d+1/4*C*(a+a*cos(c+d*x))^3*sin(c+d*x)/d+1/4*C*(a^2+a^2*cos(c+d*x))^2*sin(c+d*x)/(a*d)+1/8*(4*A+5*C)*(a^3+a^3*cos(c+d*x))*sin(c+d*x)/d",
+   "params": [
+    "A",
+    "C",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.4.2 (a+b cos)^m (c+d cos)^n (A+B cos+C cos^2).mac",
+   "index": 192,
+   "integrand": "(a+a*cos(c+d*x))^(5/2)*(A+C*cos(c+d*x)^2)/cos(c+d*x)^(7/2)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "5*a^(5/2)*C*asin(sin(c+d*x)*sqrt(a)/sqrt(a+a*cos(c+d*x)))/d+2/3*a*A*(a+a*cos(c+d*x))^(3/2)*sin(c+d*x)/(d*cos(c+d*x)^(3/2))+2/5*A*(a+a*cos(c+d*x))^(5/2)*sin(c+d*x)/(d*cos(c+d*x)^(5/2))-1/15*a^3*(64*A+15*C)*sin(c+d*x)*sqrt(cos(c+d*x))/(d*sqrt(a+a*cos(c+d*x)))+2/5*a^2*(8*A+5*C)*sin(c+d*x)*sqrt(a+a*cos(c+d*x))/(d*sqrt(cos(c+d*x)))",
+   "params": [
+    "A",
+    "C",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.4.2 (a+b cos)^m (c+d cos)^n (A+B cos+C cos^2).mac",
+   "index": 326,
+   "integrand": "(a+a*cos(c+d*x))^3*(A+B*cos(c+d*x)+C*cos(c+d*x)^2)*sec(c+d*x)^7",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "1/16*a^3*(23*A+26*B+30*C)*atanh(sin(c+d*x))/d+1/15*a^3*(34*A+38*B+45*C)*tan(c+d*x)/d+1/16*a^3*(23*A+26*B+30*C)*sec(c+d*x)*tan(c+d*x)/d+1/120*a^3*(73*A+86*B+90*C)*sec(c+d*x)^2*tan(c+d*x)/d+1/120*(31*A+42*B+30*C)*(a^3+a^3*cos(c+d*x))*sec(c+d*x)^3*tan(c+d*x)/d+1/10*(A+2*B)*(a^2+a^2*cos(c+d*x))^2*sec(c+d*x)^4*tan(c+d*x)/(a*d)+1/6*A*(a+a*cos(c+d*x))^3*sec(c+d*x)^5*tan(c+d*x)/d",
+   "params": [
+    "A",
+    "B",
+    "C",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.4.2 (a+b cos)^m (c+d cos)^n (A+B cos+C cos^2).mac",
+   "index": 504,
+   "integrand": "(A+B*cos(c+d*x)+C*cos(c+d*x)^2)/(cos(c+d*x)^(1/2)*sqrt(a+a*cos(c+d*x)))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "(2*B-C)*asin(sin(c+d*x)*sqrt(a)/sqrt(a+a*cos(c+d*x)))/(d*sqrt(a))+(A-B+C)*atan(sin(c+d*x)*sqrt(a)/(sqrt(2)*sqrt(cos(c+d*x))*sqrt(a+a*cos(c+d*x))))*sqrt(2)/(d*sqrt(a))+C*sin(c+d*x)*sqrt(cos(c+d*x))/(d*sqrt(a+a*cos(c+d*x)))",
+   "params": [
+    "A",
+    "B",
+    "C",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.4.2 (a+b cos)^m (c+d cos)^n (A+B cos+C cos^2).mac",
+   "index": 779,
+   "integrand": "(a+b*cos(c+d*x))^2*(B*cos(c+d*x)+C*cos(c+d*x)^2)*sec(c+d*x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/2*(2*a^2*B+b^2*B+2*a*b*C)*x+2/3*(3*a*b*B+a^2*C+b^2*C)*sin(c+d*x)/d+1/6*b*(3*b*B+2*a*C)*cos(c+d*x)*sin(c+d*x)/d+1/3*C*(a+b*cos(c+d*x))^2*sin(c+d*x)/d",
+   "params": [
+    "B",
+    "C",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.4.2 (a+b cos)^m (c+d cos)^n (A+B cos+C cos^2).mac",
+   "index": 1221,
+   "integrand": "(a+a*cos(c+d*x))^(5/2)*(A+C*cos(c+d*x)^2)*sec(c+d*x)^(13/2)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "10/99*a*A*(a+a*cos(c+d*x))^(3/2)*sec(c+d*x)^(9/2)*sin(c+d*x)/d+2/11*A*(a+a*cos(c+d*x))^(5/2)*sec(c+d*x)^(11/2)*sin(c+d*x)/d+2/693*a^3*(568*A+759*C)*sec(c+d*x)^(3/2)*sin(c+d*x)/(d*sqrt(a+a*cos(c+d*x)))+2/693*a^3*(232*A+297*C)*sec(c+d*x)^(5/2)*sin(c+d*x)/(d*sqrt(a+a*cos(c+d*x)))+2/231*a^2*(32*A+33*C)*sec(c+d*x)^(7/2)*sin(c+d*x)*sqrt(a+a*cos(c+d*x))/d+4/693*a^3*(568*A+759*C)*sin(c+d*x)*sqrt(sec(c+d*x))/(d*sqrt(a+a*cos(c+d*x)))",
+   "params": [
+    "A",
+    "C",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.2 Cosine/4.2.7 (d trig)^m (a+b (c cos)^n)^p.mac",
+   "index": 46,
+   "integrand": "sqrt(1-cos(x)^2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-cot(x)*sqrt(sin(x)^2)",
+   "params": []
+  },
+  {
+   "source": "4 Trig functions/4.3 Tangent/4.3.0 (a trg)^m (b tan)^n.mac",
+   "index": 73,
+   "integrand": "sin(a+b*x)^2*(d*tan(a+b*x))^(5/2)",
+   "variable": "x",
+   "steps": 13,
+   "antiderivative": "7/4*d^(5/2)*atan(1-sqrt(2)*sqrt(d*tan(a+b*x))/sqrt(d))/(b*sqrt(2))-7/4*d^(5/2)*atan(1+sqrt(2)*sqrt(d*tan(a+b*x))/sqrt(d))/(b*sqrt(2))-7/8*d^(5/2)*ln(sqrt(d)-sqrt(2)*sqrt(d*tan(a+b*x))+sqrt(d)*tan(a+b*x))/(b*sqrt(2))+7/8*d^(5/2)*ln(sqrt(d)+sqrt(2)*sqrt(d*tan(a+b*x))+sqrt(d)*tan(a+b*x))/(b*sqrt(2))+7/6*d*(d*tan(a+b*x))^(3/2)/b-1/2*cos(a+b*x)^2*(d*tan(a+b*x))^(7/2)/(b*d)",
+   "params": [
+    "a",
+    "b",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.3 Tangent/4.3.1.2 (d sec)^m (a+b tan)^n.mac",
+   "index": 510,
+   "integrand": "sec(c+d*x)^2*(a+b*tan(c+d*x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/2*b*sec(c+d*x)^2/d+a*tan(c+d*x)/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.3 Tangent/4.3.1.3 (d sin)^m (a+b tan)^n.mac",
+   "index": 76,
+   "integrand": "csc(c+d*x)^6/(a+b*tan(c+d*x))^4",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-(a^4+20*a^2*b^2+35*b^4)*cot(c+d*x)/(a^8*d)+2*b*(2*a^2+5*b^2)*cot(c+d*x)^2/(a^7*d)-2/3*(a^2+5*b^2)*cot(c+d*x)^3/(a^6*d)+b*cot(c+d*x)^4/(a^5*d)-1/5*cot(c+d*x)^5/(a^4*d)-4*b*(a^4+10*a^2*b^2+14*b^4)*ln(tan(c+d*x))/(a^9*d)+4*b*(a^4+10*a^2*b^2+14*b^4)*ln(a+b*tan(c+d*x))/(a^9*d)-1/3*b*(a^2+b^2)^2/(a^6*d*(a+b*tan(c+d*x))^3)-b*(a^2+b^2)*(a^2+3*b^2)/(a^7*d*(a+b*tan(c+d*x))^2)-b*(3*a^4+20*a^2*b^2+21*b^4)/(a^8*d*(a+b*tan(c+d*x)))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.3 Tangent/4.3.2.1 (a+b tan)^m (c+d tan)^n.mac",
+   "index": 454,
+   "integrand": "cot(c+d*x)^7*(a+b*tan(c+d*x))^4",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-4*a*b*(a^2-b^2)*x-4*a*b*(a^2-b^2)*cot(c+d*x)/d-1/2*(a^4-6*a^2*b^2+b^4)*cot(c+d*x)^2/d+4/3*a*b*(a^2-b^2)*cot(c+d*x)^3/d+1/12*a^2*(3*a^2-16*b^2)*cot(c+d*x)^4/d-7/15*a^3*b*cot(c+d*x)^5/d-(a^4-6*a^2*b^2+b^4)*ln(sin(c+d*x))/d-1/6*a^2*cot(c+d*x)^6*(a+b*tan(c+d*x))^2/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.3 Tangent/4.3.2.1 (a+b tan)^m (c+d tan)^n.mac",
+   "index": 805,
+   "integrand": "cot(c+d*x)^(7/2)*(a+b*tan(c+d*x))^2",
+   "variable": "x",
+   "steps": 14,
+   "antiderivative": "-4/3*a*b*cot(c+d*x)^(3/2)/d-2/5*a^2*cot(c+d*x)^(5/2)/d+(a^2-2*a*b-b^2)*atan(1-sqrt(2)*sqrt(cot(c+d*x)))/(d*sqrt(2))-(a^2-2*a*b-b^2)*atan(1+sqrt(2)*sqrt(cot(c+d*x)))/(d*sqrt(2))+1/2*(a^2+2*a*b-b^2)*ln(1+cot(c+d*x)-sqrt(2)*sqrt(cot(c+d*x)))/(d*sqrt(2))-1/2*(a^2+2*a*b-b^2)*ln(1+cot(c+d*x)+sqrt(2)*sqrt(cot(c+d*x)))/(d*sqrt(2))+2*(a^2-b^2)*sqrt(cot(c+d*x))/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.3 Tangent/4.3.3.1 (a+b tan)^m (c+d tan)^n (A+B tan).mac",
+   "index": 286,
+   "integrand": "cot(c+d*x)*(A+B*tan(c+d*x))/(a+b*tan(c+d*x))^3",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-(3*a^2*A*b-A*b^3-a^3*B+3*a*b^2*B)*x/(a^2+b^2)^3+A*ln(sin(c+d*x))/(a^3*d)-b*(6*a^4*A*b+3*a^2*A*b^3+A*b^5-3*a^5*B+a^3*b^2*B)*ln(a*cos(c+d*x)+b*sin(c+d*x))/(a^3*(a^2+b^2)^3*d)+1/2*b*(A*b-a*B)/(a*(a^2+b^2)*d*(a+b*tan(c+d*x))^2)+b*(3*a^2*A*b+A*b^3-2*a^3*B)/(a^2*(a^2+b^2)^2*d*(a+b*tan(c+d*x)))",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.3 Tangent/4.3.4.2 (a+b tan)^m (c+d tan)^n (A+B tan+C tan^2).mac",
+   "index": 3,
+   "integrand": "cot(c+d*x)^2*(a+b*tan(c+d*x))*(B*tan(c+d*x)+C*tan(c+d*x)^2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "(b*B+a*C)*x-b*C*ln(cos(c+d*x))/d+a*B*ln(sin(c+d*x))/d",
+   "params": [
+    "B",
+    "C",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.3 Tangent/4.3.7 (d trig)^m (a+b (c tan)^n)^p.mac",
+   "index": 56,
+   "integrand": "sin(ee+f*x)/(a+b*tan(ee+f*x)^2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-cos(ee+f*x)/((a-b)*f)-atan(sec(ee+f*x)*sqrt(b)/sqrt(a-b))*sqrt(b)/((a-b)^(3/2)*f)",
+   "params": [
+    "a",
+    "b",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.3 Tangent/4.3.7 (d trig)^m (a+b (c tan)^n)^p.mac",
+   "index": 207,
+   "integrand": "cot(ee+f*x)^2*(a+b*tan(ee+f*x)^2)^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-(a-b)^2*x-a^2*cot(ee+f*x)/f+b^2*tan(ee+f*x)/f",
+   "params": [
+    "a",
+    "b",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.3 Tangent/4.3.7 (d trig)^m (a+b (c tan)^n)^p.mac",
+   "index": 334,
+   "integrand": "tan(ee+f*x)/(a+b*tan(ee+f*x)^2)^(3/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-atanh(sqrt(a+b*tan(ee+f*x)^2)/sqrt(a-b))/((a-b)^(3/2)*f)+1/((a-b)*f*sqrt(a+b*tan(ee+f*x)^2))",
+   "params": [
+    "a",
+    "b",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.3 Tangent/4.3.9 trig^m (a+b tan^n+c tan^(2 n))^p.mac",
+   "index": 23,
+   "integrand": "cot(d+ee*x)/(a+b*tan(d+ee*x)+c*tan(d+ee*x)^2)^(3/2)",
+   "variable": "x",
+   "steps": 13,
+   "antiderivative": "-atanh(1/2*(2*a+b*tan(d+ee*x))/(sqrt(a)*sqrt(a+b*tan(d+ee*x)+c*tan(d+ee*x)^2)))/(a^(3/2)*ee)+atanh((b^2-(a-c)*(a-c-sqrt(a^2+b^2-2*a*c+c^2))-b*(2*a-2*c+sqrt(a^2+b^2-2*a*c+c^2))*tan(d+ee*x))/(sqrt(2)*sqrt(2*a-2*c+sqrt(a^2+b^2-2*a*c+c^2))*sqrt(a^2-b^2-2*a*c+c^2-(a-c)*sqrt(a^2+b^2-2*a*c+c^2))*sqrt(a+b*tan(d+ee*x)+c*tan(d+ee*x)^2)))*sqrt(2*a-2*c+sqrt(a^2+b^2-2*a*c+c^2))*sqrt(a^2-b^2-2*a*c+c^2-(a-c)*sqrt(a^2+b^2-2*a*c+c^2))/((a^2+b^2-2*a*c+c^2)^(3/2)*ee*sqrt(2))-atanh((b^2-(a-c)*(a-c+sqrt(a^2+b^2-2*a*c+c^2))-b*(2*a-2*c-sqrt(a^2+b^2-2*a*c+c^2))*tan(d+ee*x))/(sqrt(2)*sqrt(2*a-2*c-sqrt(a^2+b^2-2*a*c+c^2))*sqrt(a^2-b^2-2*a*c+c^2+(a-c)*sqrt(a^2+b^2-2*a*c+c^2))*sqrt(a+b*tan(d+ee*x)+c*tan(d+ee*x)^2)))*sqrt(2*a-2*c-sqrt(a^2+b^2-2*a*c+c^2))*sqrt(a^2-b^2-2*a*c+c^2+(a-c)*sqrt(a^2+b^2-2*a*c+c^2))/((a^2+b^2-2*a*c+c^2)^(3/2)*ee*sqrt(2))+2*(b^2-2*a*c+b*c*tan(d+ee*x))/(a*(b^2-4*a*c)*ee*sqrt(a+b*tan(d+ee*x)+c*tan(d+ee*x)^2))-2*(a*(b^2-2*(a-c)*c)+b*c*(a+c)*tan(d+ee*x))/((b^2+(a-c)^2)*(b^2-4*a*c)*ee*sqrt(a+b*tan(d+ee*x)+c*tan(d+ee*x)^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.4 Cotangent/4.4.2.1 (a+b cot)^m (c+d cot)^n.mac",
+   "index": 50,
+   "integrand": "(ee*cot(c+d*x))^(3/2)*(a+b*cot(c+d*x))",
+   "variable": "x",
+   "steps": 12,
+   "antiderivative": "-2/3*b*(ee*cot(c+d*x))^(3/2)/d-(a+b)*ee^(3/2)*atan(1-sqrt(2)*sqrt(ee*cot(c+d*x))/sqrt(ee))/(d*sqrt(2))+(a+b)*ee^(3/2)*atan(1+sqrt(2)*sqrt(ee*cot(c+d*x))/sqrt(ee))/(d*sqrt(2))-1/2*(a-b)*ee^(3/2)*ln(sqrt(ee)+cot(c+d*x)*sqrt(ee)-sqrt(2)*sqrt(ee*cot(c+d*x)))/(d*sqrt(2))+1/2*(a-b)*ee^(3/2)*ln(sqrt(ee)+cot(c+d*x)*sqrt(ee)+sqrt(2)*sqrt(ee*cot(c+d*x)))/(d*sqrt(2))-2*a*ee*sqrt(ee*cot(c+d*x))/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.4 Cotangent/4.4.9 trig^m (a+b cot^n+c cot^(2 n))^p.mac",
+   "index": 21,
+   "integrand": "cot(d+ee*x)^5*sqrt(a+b*cot(d+ee*x)^2+c*cot(d+ee*x)^4)",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "-1/32*(b^3+2*b^2*c-4*b*(a-2*c)*c-8*c^2*(a+2*c))*atanh(1/2*(b+2*c*cot(d+ee*x)^2)/(sqrt(c)*sqrt(a+b*cot(d+ee*x)^2+c*cot(d+ee*x)^4)))/(c^(5/2)*ee)-1/6*(a+b*cot(d+ee*x)^2+c*cot(d+ee*x)^4)^(3/2)/(c*ee)+1/2*atanh(1/2*(2*a-b+(b-2*c)*cot(d+ee*x)^2)/(sqrt(a-b+c)*sqrt(a+b*cot(d+ee*x)^2+c*cot(d+ee*x)^4)))*sqrt(a-b+c)/ee+1/16*((b-2*c)*(b+4*c)+2*c*(b+2*c)*cot(d+ee*x)^2)*sqrt(a+b*cot(d+ee*x)^2+c*cot(d+ee*x)^4)/(c^2*ee)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.0 (a sec)^m (b trg)^n.mac",
+   "index": 286,
+   "integrand": "cos(ee+f*x)*(b*csc(ee+f*x))^n",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "b*(b*csc(ee+f*x))^(-1+n)/(f*(1-n))",
+   "params": [
+    "b",
+    "ee",
+    "f",
+    "n"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.1.2 (d sec)^n (a+b sec)^m.mac",
+   "index": 124,
+   "integrand": "cos(c+d*x)^2/sqrt(a+a*sec(c+d*x))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "7/4*atan(sqrt(a)*tan(c+d*x)/sqrt(a+a*sec(c+d*x)))/(d*sqrt(a))-atan(sqrt(a)*tan(c+d*x)/(sqrt(2)*sqrt(a+a*sec(c+d*x))))*sqrt(2)/(d*sqrt(a))-1/4*sin(c+d*x)/(d*sqrt(a+a*sec(c+d*x)))+1/2*cos(c+d*x)*sin(c+d*x)/(d*sqrt(a+a*sec(c+d*x)))",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.1.2 (d sec)^n (a+b sec)^m.mac",
+   "index": 458,
+   "integrand": "sec(c+d*x)*(a+b*sec(c+d*x))^2",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/2*(2*a^2+b^2)*atanh(sin(c+d*x))/d+2*a*b*tan(c+d*x)/d+1/2*b^2*sec(c+d*x)*tan(c+d*x)/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.1.3 (d sin)^n (a+b sec)^m.mac",
+   "index": 55,
+   "integrand": "csc(c+d*x)^10*(a+a*sec(c+d*x))^3",
+   "variable": "x",
+   "steps": 17,
+   "antiderivative": "17/2*a^3*atanh(sin(c+d*x))/d-16*a^3*cot(c+d*x)/d-34/3*a^3*cot(c+d*x)^3/d-36/5*a^3*cot(c+d*x)^5/d-19/7*a^3*cot(c+d*x)^7/d-4/9*a^3*cot(c+d*x)^9/d-17/2*a^3*csc(c+d*x)/d-17/6*a^3*csc(c+d*x)^3/d-17/10*a^3*csc(c+d*x)^5/d-17/14*a^3*csc(c+d*x)^7/d-17/18*a^3*csc(c+d*x)^9/d+1/2*a^3*csc(c+d*x)^9*sec(c+d*x)^2/d+3*a^3*tan(c+d*x)/d",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.1.4 (d tan)^n (a+b sec)^m.mac",
+   "index": 2,
+   "integrand": "(a+a*sec(c+d*x))*tan(c+d*x)^5",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-a*ln(cos(c+d*x))/d+a*sec(c+d*x)/d-a*sec(c+d*x)^2/d-2/3*a*sec(c+d*x)^3/d+1/4*a*sec(c+d*x)^4/d+1/5*a*sec(c+d*x)^5/d",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.1.4 (d tan)^n (a+b sec)^m.mac",
+   "index": 163,
+   "integrand": "cot(c+d*x)^5*(a+a*sec(c+d*x))^(5/2)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "2*a^(5/2)*atanh(sqrt(a+a*sec(c+d*x))/sqrt(a))/d-43/16*a^(5/2)*atanh(sqrt(a+a*sec(c+d*x))/(sqrt(2)*sqrt(a)))/(d*sqrt(2))-1/4*a^2*sqrt(a+a*sec(c+d*x))/(d*(1-sec(c+d*x))^2)-11/16*a^2*sqrt(a+a*sec(c+d*x))/(d*(1-sec(c+d*x)))",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.2.1 (a+b sec)^m (c+d sec)^n.mac",
+   "index": 5,
+   "integrand": "(a+a*sec(ee+f*x))^2/(c-c*sec(ee+f*x))",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "a^2*x/c-a^2*atanh(sin(ee+f*x))/(c*f)-4*a^2*tan(ee+f*x)/(c*f*(1-sec(ee+f*x)))",
+   "params": [
+    "a",
+    "c",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.2.1 (a+b sec)^m (c+d sec)^n.mac",
+   "index": 152,
+   "integrand": "sqrt(a+a*sec(ee+f*x))/(c+d*sec(ee+f*x))^3",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-1/2*a*d*tan(ee+f*x)/(c*(c+d)*f*(c+d*sec(ee+f*x))^2*sqrt(a+a*sec(ee+f*x)))-1/4*a*d*(7*c+4*d)*tan(ee+f*x)/(c^2*(c+d)^2*f*(c+d*sec(ee+f*x))*sqrt(a+a*sec(ee+f*x)))+2*a^(3/2)*atanh(sqrt(a-a*sec(ee+f*x))/sqrt(a))*tan(ee+f*x)/(c^3*f*sqrt(a-a*sec(ee+f*x))*sqrt(a+a*sec(ee+f*x)))-1/4*a^(3/2)*(15*c^2+20*c*d+8*d^2)*atanh(sqrt(d)*sqrt(a-a*sec(ee+f*x))/(sqrt(a)*sqrt(c+d)))*sqrt(d)*tan(ee+f*x)/(c^3*(c+d)^(5/2)*f*sqrt(a-a*sec(ee+f*x))*sqrt(a+a*sec(ee+f*x)))",
+   "params": [
+    "a",
+    "c",
+    "d",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.2.3 (g sec)^p (a+b sec)^m (c+d sec)^n.mac",
+   "index": 85,
+   "integrand": "sec(ee+f*x)*(c-c*sec(ee+f*x))^(7/2)/(a+a*sec(ee+f*x))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "12/5*c^2*(c-c*sec(ee+f*x))^(3/2)*tan(ee+f*x)/(a*f)+2*c*(c-c*sec(ee+f*x))^(5/2)*tan(ee+f*x)/(f*(a+a*sec(ee+f*x)))+128/5*c^4*tan(ee+f*x)/(a*f*sqrt(c-c*sec(ee+f*x)))+32/5*c^3*sqrt(c-c*sec(ee+f*x))*tan(ee+f*x)/(a*f)",
+   "params": [
+    "a",
+    "c",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.3.1 (a+b sec)^m (d sec)^n (A+B sec).mac",
+   "index": 44,
+   "integrand": "sec(c+d*x)^2*(a+a*sec(c+d*x))*(A+B*sec(c+d*x))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "1/2*a*(A+B)*atanh(sin(c+d*x))/d+1/3*a*(3*A+2*B)*tan(c+d*x)/d+1/2*a*(A+B)*sec(c+d*x)*tan(c+d*x)/d+1/3*a*B*sec(c+d*x)^2*tan(c+d*x)/d",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.3.1 (a+b sec)^m (d sec)^n (A+B sec).mac",
+   "index": 172,
+   "integrand": "cos(c+d*x)^2*(A+A*sec(c+d*x))/(a-a*sec(c+d*x))^(3/2)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "31/4*A*atan(sqrt(a)*tan(c+d*x)/sqrt(a-a*sec(c+d*x)))/(a^(3/2)*d)-A*cos(c+d*x)*sin(c+d*x)/(d*(a-a*sec(c+d*x))^(3/2))-11*A*atan(sqrt(a)*tan(c+d*x)/(sqrt(2)*sqrt(a-a*sec(c+d*x))))/(a^(3/2)*d*sqrt(2))+13/4*A*sin(c+d*x)/(a*d*sqrt(a-a*sec(c+d*x)))+3/2*A*cos(c+d*x)*sin(c+d*x)/(a*d*sqrt(a-a*sec(c+d*x)))",
+   "params": [
+    "A",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.3.1 (a+b sec)^m (d sec)^n (A+B sec).mac",
+   "index": 522,
+   "integrand": "cos(c+d*x)^(11/2)*(a+a*sec(c+d*x))^(3/2)*(A+B*sec(c+d*x))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "4/1155*a^2*(168*A+187*B)*cos(c+d*x)^(3/2)*sin(c+d*x)/(d*sqrt(a+a*sec(c+d*x)))+2/693*a^2*(168*A+187*B)*cos(c+d*x)^(5/2)*sin(c+d*x)/(d*sqrt(a+a*sec(c+d*x)))+2/99*a^2*(12*A+11*B)*cos(c+d*x)^(7/2)*sin(c+d*x)/(d*sqrt(a+a*sec(c+d*x)))+32/3465*a^2*(168*A+187*B)*sin(c+d*x)/(d*sqrt(cos(c+d*x))*sqrt(a+a*sec(c+d*x)))+16/3465*a^2*(168*A+187*B)*sin(c+d*x)*sqrt(cos(c+d*x))/(d*sqrt(a+a*sec(c+d*x)))+2/11*a*A*cos(c+d*x)^(9/2)*sin(c+d*x)*sqrt(a+a*sec(c+d*x))/d",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.4.2 (a+b sec)^m (d sec)^n (A+B sec+C sec^2).mac",
+   "index": 122,
+   "integrand": "sec(c+d*x)^2*(A+C*sec(c+d*x)^2)/(a+a*sec(c+d*x))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "1/2*(2*A+3*C)*atanh(sin(c+d*x))/(a*d)-(A+2*C)*tan(c+d*x)/(a*d)+1/2*(2*A+3*C)*sec(c+d*x)*tan(c+d*x)/(a*d)-(A+C)*sec(c+d*x)^2*tan(c+d*x)/(d*(a+a*sec(c+d*x)))",
+   "params": [
+    "A",
+    "C",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.4.2 (a+b sec)^m (d sec)^n (A+B sec+C sec^2).mac",
+   "index": 293,
+   "integrand": "(A+C*sec(c+d*x)^2)/(sec(c+d*x)^(5/2)*(a+a*sec(c+d*x))^(5/2))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-1/4*(A+C)*sin(c+d*x)/(d*sec(c+d*x)^(3/2)*(a+a*sec(c+d*x))^(5/2))-1/16*(21*A+5*C)*sin(c+d*x)/(a*d*sec(c+d*x)^(3/2)*(a+a*sec(c+d*x))^(3/2))-1/16*(283*A+75*C)*atanh(sin(c+d*x)*sqrt(a)*sqrt(sec(c+d*x))/(sqrt(2)*sqrt(a+a*sec(c+d*x))))/(a^(5/2)*d*sqrt(2))+1/80*(157*A+45*C)*sin(c+d*x)/(a^2*d*sec(c+d*x)^(3/2)*sqrt(a+a*sec(c+d*x)))-1/240*(787*A+195*C)*sin(c+d*x)/(a^2*d*sqrt(sec(c+d*x))*sqrt(a+a*sec(c+d*x)))+1/240*(2671*A+735*C)*sin(c+d*x)*sqrt(sec(c+d*x))/(a^2*d*sqrt(a+a*sec(c+d*x)))",
+   "params": [
+    "A",
+    "C",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.4.2 (a+b sec)^m (d sec)^n (A+B sec+C sec^2).mac",
+   "index": 430,
+   "integrand": "cos(c+d*x)*(a+a*sec(c+d*x))^3*(A+B*sec(c+d*x)+C*sec(c+d*x)^2)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "a^3*(3*A+B)*x+1/2*a^3*(6*A+7*B+5*C)*atanh(sin(c+d*x))/d+A*(a+a*sec(c+d*x))^3*sin(c+d*x)/d+5/2*a^3*(B+C)*tan(c+d*x)/d-1/3*(3*A-C)*(a^2+a^2*sec(c+d*x))^2*tan(c+d*x)/(a*d)-1/6*(6*A-3*B-5*C)*(a^3+a^3*sec(c+d*x))*tan(c+d*x)/d",
+   "params": [
+    "A",
+    "B",
+    "C",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.4.2 (a+b sec)^m (d sec)^n (A+B sec+C sec^2).mac",
+   "index": 603,
+   "integrand": "(a+a*sec(c+d*x))^(5/2)*(A+B*sec(c+d*x)+C*sec(c+d*x)^2)/sec(c+d*x)^(13/2)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "2/143*a*(5*A+13*B)*(a+a*sec(c+d*x))^(3/2)*sin(c+d*x)/(d*sec(c+d*x)^(9/2))+2/13*A*(a+a*sec(c+d*x))^(5/2)*sin(c+d*x)/(d*sec(c+d*x)^(11/2))+2/9009*a^3*(2224*A+2522*B+2717*C)*sin(c+d*x)/(d*sec(c+d*x)^(5/2)*sqrt(a+a*sec(c+d*x)))+2/15015*a^3*(8368*A+9230*B+10439*C)*sin(c+d*x)/(d*sec(c+d*x)^(3/2)*sqrt(a+a*sec(c+d*x)))+8/45045*a^3*(8368*A+9230*B+10439*C)*sin(c+d*x)/(d*sqrt(sec(c+d*x))*sqrt(a+a*sec(c+d*x)))+16/45045*a^3*(8368*A+9230*B+10439*C)*sin(c+d*x)*sqrt(sec(c+d*x))/(d*sqrt(a+a*sec(c+d*x)))+2/1287*a^2*(136*A+182*B+143*C)*sin(c+d*x)*sqrt(a+a*sec(c+d*x))/(d*sec(c+d*x)^(7/2))",
+   "params": [
+    "A",
+    "B",
+    "C",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.4.2 (a+b sec)^m (d sec)^n (A+B sec+C sec^2).mac",
+   "index": 797,
+   "integrand": "cos(c+d*x)^2*(B*sec(c+d*x)+C*sec(c+d*x)^2)/(a+b*sec(c+d*x))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-(b*B-a*C)*x/a^2+B*sin(c+d*x)/(a*d)+2*b*(b*B-a*C)*atanh(sqrt(a-b)*tan(1/2*(c+d*x))/sqrt(a+b))/(a^2*d*sqrt(a-b)*sqrt(a+b))",
+   "params": [
+    "B",
+    "C",
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.4.2 (a+b sec)^m (d sec)^n (A+B sec+C sec^2).mac",
+   "index": 1164,
+   "integrand": "(A+C*sec(c+d*x)^2)/(cos(c+d*x)^(3/2)*(a+a*sec(c+d*x))^(3/2))",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-1/2*(A+C)*sin(c+d*x)/(d*cos(c+d*x)^(5/2)*(a+a*sec(c+d*x))^(3/2))-3*C*asinh(sqrt(a)*tan(c+d*x)/sqrt(a+a*sec(c+d*x)))*sqrt(cos(c+d*x))*sqrt(sec(c+d*x))/(a^(3/2)*d)+1/2*(A+9*C)*atanh(sin(c+d*x)*sqrt(a)*sqrt(sec(c+d*x))/(sqrt(2)*sqrt(a+a*sec(c+d*x))))*sqrt(cos(c+d*x))*sqrt(sec(c+d*x))/(a^(3/2)*d*sqrt(2))+1/2*(A+3*C)*sin(c+d*x)/(a*d*cos(c+d*x)^(3/2)*sqrt(a+a*sec(c+d*x)))",
+   "params": [
+    "A",
+    "C",
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.7 (d trig)^m (a+b (c sec)^n)^p.mac",
+   "index": 72,
+   "integrand": "sin(ee+f*x)^6*sqrt(a+b*sec(ee+f*x)^2)",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "1/16*(5*a^3-15*a^2*b-5*a*b^2-b^3)*atan(sqrt(a)*tan(ee+f*x)/sqrt(a+b+b*tan(ee+f*x)^2))/(a^(5/2)*f)+atanh(sqrt(b)*tan(ee+f*x)/sqrt(a+b+b*tan(ee+f*x)^2))*sqrt(b)/f-1/16*(a-b)*(5*a+b)*cos(ee+f*x)*sin(ee+f*x)*sqrt(a+b+b*tan(ee+f*x)^2)/(a^2*f)-1/24*(5*a-b)*cos(ee+f*x)*sin(ee+f*x)^3*sqrt(a+b+b*tan(ee+f*x)^2)/(a*f)-1/6*cos(ee+f*x)*sin(ee+f*x)^5*sqrt(a+b+b*tan(ee+f*x)^2)/f",
+   "params": [
+    "a",
+    "b",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.7 (d trig)^m (a+b (c sec)^n)^p.mac",
+   "index": 211,
+   "integrand": "sec(ee+f*x)^6/(a+b*sec(ee+f*x)^2)^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/8*(3*a^2+8*a*b+8*b^2)*atan(sqrt(b)*tan(ee+f*x)/sqrt(a+b))/(b^(5/2)*(a+b)^(5/2)*f)-1/4*a*sec(ee+f*x)^2*tan(ee+f*x)/(b*(a+b)*f*(a+b+b*tan(ee+f*x)^2)^2)-3/8*a*(a+2*b)*tan(ee+f*x)/(b^2*(a+b)^2*f*(a+b+b*tan(ee+f*x)^2))",
+   "params": [
+    "a",
+    "b",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.5 Secant/4.5.7 (d trig)^m (a+b (c sec)^n)^p.mac",
+   "index": 382,
+   "integrand": "sqrt(a+b*sec(ee+f*x)^2)*tan(ee+f*x)^6",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "1/16*(a^3+5*a^2*b+15*a*b^2-5*b^3)*atanh(sqrt(b)*tan(ee+f*x)/sqrt(a+b+b*tan(ee+f*x)^2))/(b^(5/2)*f)-atan(sqrt(a)*tan(ee+f*x)/sqrt(a+b+b*tan(ee+f*x)^2))*sqrt(a)/f-1/16*(a-b)*(a+5*b)*sqrt(a+b+b*tan(ee+f*x)^2)*tan(ee+f*x)/(b^2*f)+1/24*(a-5*b)*sqrt(a+b+b*tan(ee+f*x)^2)*tan(ee+f*x)^3/(b*f)+1/6*sqrt(a+b+b*tan(ee+f*x)^2)*tan(ee+f*x)^5/f",
+   "params": [
+    "a",
+    "b",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.6 Cosecant/4.6.1.2 (d csc)^n (a+b csc)^m.mac",
+   "index": 42,
+   "integrand": "csc(x)/(a+b*csc(x))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-2*atanh((a+b*tan(1/2*x))/sqrt(a^2-b^2))/sqrt(a^2-b^2)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.7 Miscellaneous/4.7.1 (c trig)^m (d trig)^n.mac",
+   "index": 15,
+   "integrand": "sin(a+b*x)^2*sin(2*a+2*b*x)^2",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/4*x-1/8*cos(2*a+2*b*x)*sin(2*a+2*b*x)/b-1/12*sin(2*a+2*b*x)^3/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.7 Miscellaneous/4.7.1 (c trig)^m (d trig)^n.mac",
+   "index": 166,
+   "integrand": "cos(a+b*x)/sin(2*a+2*b*x)^(7/2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/5*cos(a+b*x)/(b*sin(2*a+2*b*x)^(5/2))+4/15*sin(a+b*x)/(b*sin(2*a+2*b*x)^(3/2))-8/15*cos(a+b*x)/(b*sqrt(sin(2*a+2*b*x)))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.7 Miscellaneous/4.7.2 trig^m (a trig+b trig)^n.mac",
+   "index": 62,
+   "integrand": "sec(c+d*x)*(a*cos(c+d*x)+b*sin(c+d*x))^3",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "1/2*a*(a^2+3*b^2)*x-b^3*ln(sin(c+d*x))/d+b^3*ln(tan(c+d*x))/d+1/2*(b*(3*a^2-b^2)+a*(a^2-3*b^2)*cot(c+d*x))*sin(c+d*x)^2/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.7 Miscellaneous/4.7.2 trig^m (a trig+b trig)^n.mac",
+   "index": 228,
+   "integrand": "cos(c+d*x)^3*(a*sin(c+d*x)+b*tan(c+d*x))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-1/3*b*cos(c+d*x)^3/d-1/4*a*cos(c+d*x)^4/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.7 Miscellaneous/4.7.5 x^m trig(a+b log(c x^n))^p.mac",
+   "index": 13,
+   "integrand": "x*sin(a+b*ln(c*x^n))^3",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-6*b^3*n^3*x^2*cos(a+b*ln(c*x^n))/(16+40*b^2*n^2+9*b^4*n^4)+12*b^2*n^2*x^2*sin(a+b*ln(c*x^n))/(16+40*b^2*n^2+9*b^4*n^4)-3*b*n*x^2*cos(a+b*ln(c*x^n))*sin(a+b*ln(c*x^n))^2/(4+9*b^2*n^2)+2*x^2*sin(a+b*ln(c*x^n))^3/(4+9*b^2*n^2)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "n"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.7 Miscellaneous/4.7.6 f^(a+b x+c x^2) trig(d+e x+f x^2)^n.mac",
+   "index": 48,
+   "integrand": "exp(1)^x*x*cos(x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/2*exp(1)^x*x*cos(x)-1/2*exp(1)^x*sin(x)+1/2*exp(1)^x*x*sin(x)",
+   "params": []
+  },
+  {
+   "source": "4 Trig functions/4.7 Miscellaneous/4.7.7 Trig functions.mac",
+   "index": 129,
+   "integrand": "cos(2*x)*sin(6*x)^2",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/4*sin(2*x)-1/40*sin(10*x)-1/56*sin(14*x)",
+   "params": []
+  },
+  {
+   "source": "4 Trig functions/4.7 Miscellaneous/4.7.7 Trig functions.mac",
+   "index": 306,
+   "integrand": "1/(csc(x)-sin(x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "sec(x)",
+   "params": []
+  },
+  {
+   "source": "4 Trig functions/4.7 Miscellaneous/4.7.7 Trig functions.mac",
+   "index": 458,
+   "integrand": "csc(x)/(a+b*cot(x)+c*csc(x))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-2*atanh((a-(b-c)*tan(1/2*x))/sqrt(a^2+b^2-c^2))/sqrt(a^2+b^2-c^2)",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.7 Miscellaneous/4.7.7 Trig functions.mac",
+   "index": 639,
+   "integrand": "(b*sec(c+d*x)+a*sin(c+d*x))*(a*cos(c+d*x)+b*sec(c+d*x)*tan(c+d*x))",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/2*(b*sec(c+d*x)+a*sin(c+d*x))^2/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "4 Trig functions/4.7 Miscellaneous/4.7.7 Trig functions.mac",
+   "index": 780,
+   "integrand": "x*sin(1+x^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/2*cos(1+x^2)",
+   "params": []
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.2 (d x)^m (a+b arcsin(c x))^n.mac",
+   "index": 0,
+   "integrand": "x^4*asin(a*x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-2/15*(1-a^2*x^2)^(3/2)/a^5+1/25*(1-a^2*x^2)^(5/2)/a^5+1/5*x^5*asin(a*x)+1/5*sqrt(1-a^2*x^2)/a^5",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.2 (d x)^m (a+b arcsin(c x))^n.mac",
+   "index": 14,
+   "integrand": "x*asin(a*x)^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/4*x^2-1/4*asin(a*x)^2/a^2+1/2*x^2*asin(a*x)^2+1/2*x*asin(a*x)*sqrt(1-a^2*x^2)/a",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.2 (d x)^m (a+b arcsin(c x))^n.mac",
+   "index": 35,
+   "integrand": "x*asin(a*x)^4",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "3/4*x^2+3/4*asin(a*x)^2/a^2-3/2*x^2*asin(a*x)^2-1/4*asin(a*x)^4/a^2+1/2*x^2*asin(a*x)^4-3/2*x*asin(a*x)*sqrt(1-a^2*x^2)/a+x*asin(a*x)^3*sqrt(1-a^2*x^2)/a",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.2 (d x)^m (a+b arcsin(c x))^n.mac",
+   "index": 153,
+   "integrand": "x*(a+b*asin(c*x))^3",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "3/8*b^3*asin(c*x)/c^2-3/4*b^2*x^2*(a+b*asin(c*x))-1/4*(a+b*asin(c*x))^3/c^2+1/2*x^2*(a+b*asin(c*x))^3-3/8*b^3*x*sqrt(1-c^2*x^2)/c+3/4*b*x*(a+b*asin(c*x))^2*sqrt(1-c^2*x^2)/c",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 13,
+   "integrand": "(d-c^2*d*x^2)^2*(a+b*asin(c*x))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "4/45*b*d^2*(1-c^2*x^2)^(3/2)/c+1/25*b*d^2*(1-c^2*x^2)^(5/2)/c+d^2*x*(a+b*asin(c*x))-2/3*c^2*d^2*x^3*(a+b*asin(c*x))+1/5*c^4*d^2*x^5*(a+b*asin(c*x))+8/15*b*d^2*sqrt(1-c^2*x^2)/c",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 54,
+   "integrand": "x^4*(d-c^2*d*x^2)^(1/2)*(a+b*asin(c*x))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-1/16*x*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/c^4-1/24*x^3*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/c^2+1/6*x^5*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)+1/32*b*x^2*sqrt(d-c^2*d*x^2)/(c^3*sqrt(1-c^2*x^2))+1/96*b*x^4*sqrt(d-c^2*d*x^2)/(c*sqrt(1-c^2*x^2))-1/36*b*c*x^6*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)+1/32*(a+b*asin(c*x))^2*sqrt(d-c^2*d*x^2)/(b*c^5*sqrt(1-c^2*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 70,
+   "integrand": "(d-c^2*d*x^2)^(3/2)*(a+b*asin(c*x))/x^2",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-(d-c^2*d*x^2)^(3/2)*(a+b*asin(c*x))/x-3/2*c^2*d*x*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)+1/4*b*c^3*d*x^2*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)-3/4*c*d*(a+b*asin(c*x))^2*sqrt(d-c^2*d*x^2)/(b*sqrt(1-c^2*x^2))+b*c*d*ln(x)*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 86,
+   "integrand": "(d-c^2*d*x^2)^(5/2)*(a+b*asin(c*x))/x^2",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "-5/4*c^2*d*x*(d-c^2*d*x^2)^(3/2)*(a+b*asin(c*x))-(d-c^2*d*x^2)^(5/2)*(a+b*asin(c*x))/x-15/8*c^2*d^2*x*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)+9/16*b*c^3*d^2*x^2*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)-1/16*b*c^5*d^2*x^4*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)-15/16*c*d^2*(a+b*asin(c*x))^2*sqrt(d-c^2*d*x^2)/(b*sqrt(1-c^2*x^2))+b*c*d^2*ln(x)*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 103,
+   "integrand": "x*asin(a*x)/sqrt(1-a^2*x^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "x/a-asin(a*x)*sqrt(1-a^2*x^2)/a^2",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 120,
+   "integrand": "x^3*(a+b*asin(c*x))/(d-c^2*d*x^2)^(3/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "x^2*(a+b*asin(c*x))/(c^2*d*sqrt(d-c^2*d*x^2))-b*x*sqrt(1-c^2*x^2)/(c^3*d*sqrt(d-c^2*d*x^2))-b*atanh(c*x)*sqrt(1-c^2*x^2)/(c^4*d*sqrt(d-c^2*d*x^2))+2*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/(c^4*d^2)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 136,
+   "integrand": "(a+b*asin(c*x))/(x^2*(d-c^2*d*x^2)^(5/2))",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "(-a-b*asin(c*x))/(d*x*(d-c^2*d*x^2)^(3/2))+4/3*c^2*x*(a+b*asin(c*x))/(d*(d-c^2*d*x^2)^(3/2))+8/3*c^2*x*(a+b*asin(c*x))/(d^2*sqrt(d-c^2*d*x^2))-1/6*b*c/(d^2*sqrt(1-c^2*x^2)*sqrt(d-c^2*d*x^2))+b*c*ln(x)*sqrt(1-c^2*x^2)/(d^2*sqrt(d-c^2*d*x^2))+5/6*b*c*ln(1-c^2*x^2)*sqrt(1-c^2*x^2)/(d^2*sqrt(d-c^2*d*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 173,
+   "integrand": "x^4*(d-c^2*d*x^2)^3*(a+b*asin(c*x))^2",
+   "variable": "x",
+   "steps": 21,
+   "antiderivative": "-100976/4002075*b^2*d^3*x/c^4-50488/12006225*b^2*d^3*x^3/c^2-12622/6670125*b^2*d^3*x^5+9410/1120581*b^2*c^2*d^3*x^7-182/29403*b^2*c^4*d^3*x^9+2/1331*b^2*c^6*d^3*x^11+16/693*b*d^3*(1-c^2*x^2)^(3/2)*(a+b*asin(c*x))/c^5-4/1155*b*d^3*(1-c^2*x^2)^(5/2)*(a+b*asin(c*x))/c^5+2/1617*b*d^3*(1-c^2*x^2)^(7/2)*(a+b*asin(c*x))/c^5-8/297*b*d^3*(1-c^2*x^2)^(9/2)*(a+b*asin(c*x))/c^5+2/121*b*d^3*(1-c^2*x^2)^(11/2)*(a+b*asin(c*x))/c^5+16/1155*d^3*x^5*(a+b*asin(c*x))^2+8/231*d^3*x^5*(1-c^2*x^2)*(a+b*asin(c*x))^2+2/33*d^3*x^5*(1-c^2*x^2)^2*(a+b*asin(c*x))^2+1/11*d^3*x^5*(1-c^2*x^2)^3*(a+b*asin(c*x))^2+256/17325*b*d^3*(a+b*asin(c*x))*sqrt(1-c^2*x^2)/c^5+128/17325*b*d^3*x^2*(a+b*asin(c*x))*sqrt(1-c^2*x^2)/c^3+32/5775*b*d^3*x^4*(a+b*asin(c*x))*sqrt(1-c^2*x^2)/c",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 218,
+   "integrand": "x^2*(d-c^2*d*x^2)^(3/2)*(a+b*asin(c*x))^2",
+   "variable": "x",
+   "steps": 17,
+   "antiderivative": "1/6*x^3*(d-c^2*d*x^2)^(3/2)*(a+b*asin(c*x))^2-7/1152*b^2*d*x*sqrt(d-c^2*d*x^2)/c^2-43/1728*b^2*d*x^3*sqrt(d-c^2*d*x^2)+1/108*b^2*c^2*d*x^5*sqrt(d-c^2*d*x^2)-1/16*d*x*(a+b*asin(c*x))^2*sqrt(d-c^2*d*x^2)/c^2+1/8*d*x^3*(a+b*asin(c*x))^2*sqrt(d-c^2*d*x^2)+7/1152*b^2*d*asin(c*x)*sqrt(d-c^2*d*x^2)/(c^3*sqrt(1-c^2*x^2))+1/16*b*d*x^2*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/(c*sqrt(1-c^2*x^2))-7/48*b*c*d*x^4*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)+1/18*b*c^3*d*x^6*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)+1/48*d*(a+b*asin(c*x))^3*sqrt(d-c^2*d*x^2)/(b*c^3*sqrt(1-c^2*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 265,
+   "integrand": "x^2*asin(a*x)^2/sqrt(1-a^2*x^2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/4*asin(a*x)/a^3+1/2*x^2*asin(a*x)/a+1/6*asin(a*x)^3/a^3+1/4*x*sqrt(1-a^2*x^2)/a^2-1/2*x*asin(a*x)^2*sqrt(1-a^2*x^2)/a^2",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 304,
+   "integrand": "x^2*asin(a*x)^3/sqrt(1-a^2*x^2)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-3/8*x^2/a-3/8*asin(a*x)^2/a^3+3/4*x^2*asin(a*x)^2/a+1/8*asin(a*x)^4/a^3+3/4*x*asin(a*x)*sqrt(1-a^2*x^2)/a^2-1/2*x*asin(a*x)^3*sqrt(1-a^2*x^2)/a^2",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 461,
+   "integrand": "asin(x/a)^(3/2)/(a^2-x^2)^(1/2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "2/5*a*asin(x/a)^(5/2)*sqrt(1-x^2/a^2)/sqrt(a^2-x^2)",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 511,
+   "integrand": "(d+c*d*x)^(1/2)*(f-c*f*x)^(3/2)*(a+b*asin(c*x))",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "1/2*f*x*(a+b*asin(c*x))*sqrt(d+c*d*x)*sqrt(f-c*f*x)+1/3*f*(1-c^2*x^2)*(a+b*asin(c*x))*sqrt(d+c*d*x)*sqrt(f-c*f*x)/c-1/3*b*f*x*sqrt(d+c*d*x)*sqrt(f-c*f*x)/sqrt(1-c^2*x^2)-1/4*b*c*f*x^2*sqrt(d+c*d*x)*sqrt(f-c*f*x)/sqrt(1-c^2*x^2)+1/9*b*c^2*f*x^3*sqrt(d+c*d*x)*sqrt(f-c*f*x)/sqrt(1-c^2*x^2)+1/4*f*(a+b*asin(c*x))^2*sqrt(d+c*d*x)*sqrt(f-c*f*x)/(b*c*sqrt(1-c^2*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "f"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 524,
+   "integrand": "(a+b*asin(c*x))/((d+c*d*x)^(1/2)*sqrt(f-c*f*x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*(a+b*asin(c*x))^2*sqrt(1-c^2*x^2)/(b*c*sqrt(d+c*d*x)*sqrt(f-c*f*x))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "f"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 537,
+   "integrand": "(a+b*asin(c*x))/((d+c*d*x)^(3/2)*(f-c*f*x)^(5/2))",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-1/6*b*d*(1-c^2*x^2)^(5/2)/(c*(1-c*x)*(d+c*d*x)^(5/2)*(f-c*f*x)^(5/2))+1/3*d*(1+c*x)*(1-c^2*x^2)*(a+b*asin(c*x))/(c*(d+c*d*x)^(5/2)*(f-c*f*x)^(5/2))+2/3*d*x*(1-c^2*x^2)^2*(a+b*asin(c*x))/((d+c*d*x)^(5/2)*(f-c*f*x)^(5/2))-1/6*b*d*(1-c^2*x^2)^(5/2)*atanh(c*x)/(c*(d+c*d*x)^(5/2)*(f-c*f*x)^(5/2))+1/3*b*d*(1-c^2*x^2)^(5/2)*ln(1-c^2*x^2)/(c*(d+c*d*x)^(5/2)*(f-c*f*x)^(5/2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "f"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 554,
+   "integrand": "(ee-c*ee*x)^(5/2)*(a+b*asin(c*x))^2/(d+c*d*x)^(1/2)",
+   "variable": "x",
+   "steps": 17,
+   "antiderivative": "-68/9*b^2*ee^3*(1-c^2*x^2)/(c*sqrt(d+c*d*x)*sqrt(ee-c*ee*x))+3/4*b^2*ee^3*x*(1-c^2*x^2)/(sqrt(d+c*d*x)*sqrt(ee-c*ee*x))+2/27*b^2*ee^3*(1-c^2*x^2)^2/(c*sqrt(d+c*d*x)*sqrt(ee-c*ee*x))+11/3*ee^3*(1-c^2*x^2)*(a+b*asin(c*x))^2/(c*sqrt(d+c*d*x)*sqrt(ee-c*ee*x))-3/2*ee^3*x*(1-c^2*x^2)*(a+b*asin(c*x))^2/(sqrt(d+c*d*x)*sqrt(ee-c*ee*x))+1/3*c*ee^3*x^2*(1-c^2*x^2)*(a+b*asin(c*x))^2/(sqrt(d+c*d*x)*sqrt(ee-c*ee*x))-3/4*b^2*ee^3*asin(c*x)*sqrt(1-c^2*x^2)/(c*sqrt(d+c*d*x)*sqrt(ee-c*ee*x))-22/3*b*ee^3*x*(a+b*asin(c*x))*sqrt(1-c^2*x^2)/(sqrt(d+c*d*x)*sqrt(ee-c*ee*x))+3/2*b*c*ee^3*x^2*(a+b*asin(c*x))*sqrt(1-c^2*x^2)/(sqrt(d+c*d*x)*sqrt(ee-c*ee*x))-2/9*b*c^2*ee^3*x^3*(a+b*asin(c*x))*sqrt(1-c^2*x^2)/(sqrt(d+c*d*x)*sqrt(ee-c*ee*x))+5/6*ee^3*(a+b*asin(c*x))^3*sqrt(1-c^2*x^2)/(b*c*sqrt(d+c*d*x)*sqrt(ee-c*ee*x))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4a (f x)^m (d-c^2 d x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 587,
+   "integrand": "(a+b*asin(c*x))^2/((d+c*d*x)^(1/2)*(ee-c*ee*x)^(1/2))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/3*(a+b*asin(c*x))^3*sqrt(1-c^2*x^2)/(b*c*sqrt(d+c*d*x)*sqrt(ee-c*ee*x))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4b (f x)^m (d+e x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 15,
+   "integrand": "(d+ee*x^2)^2*(a+b*asin(c*x))/x^2",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-1/9*b*ee^2*(1-c^2*x^2)^(3/2)/c^3-d^2*(a+b*asin(c*x))/x+2*d*ee*x*(a+b*asin(c*x))+1/3*ee^2*x^3*(a+b*asin(c*x))-b*c*d^2*atanh(sqrt(1-c^2*x^2))+1/3*b*ee*(6*c^2*d+ee)*sqrt(1-c^2*x^2)/c^3",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.4b (f x)^m (d+e x^2)^p (a+b arcsin(c x))^n.mac",
+   "index": 55,
+   "integrand": "(a+b*asin(c*x))/(d+ee*x^2)^(3/2)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "b*atan(sqrt(ee)*sqrt(1-c^2*x^2)/(c*sqrt(d+ee*x^2)))/(d*sqrt(ee))+x*(a+b*asin(c*x))/(d*sqrt(d+ee*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 7,
+   "integrand": "(a+b*asin(c*x))/(d+ee*x)^4",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/3*(-a-b*asin(c*x))/(ee*(d+ee*x)^3)+1/6*b*c^3*(2*c^2*d^2+ee^2)*atan((ee+c^2*d*x)/(sqrt(c^2*d^2-ee^2)*sqrt(1-c^2*x^2)))/(ee*(c^2*d^2-ee^2)^(5/2))+1/6*b*c*sqrt(1-c^2*x^2)/((c^2*d^2-ee^2)*(d+ee*x)^2)+1/2*b*c^3*d*sqrt(1-c^2*x^2)/((c^2*d^2-ee^2)^2*(d+ee*x))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 41,
+   "integrand": "(f+g*x)*(d-c^2*d*x^2)^(5/2)*(a+b*asin(c*x))",
+   "variable": "x",
+   "steps": 14,
+   "antiderivative": "1/36*b*d^2*f*(1-c^2*x^2)^(5/2)*sqrt(d-c^2*d*x^2)/c+5/16*d^2*f*x*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)+5/24*d^2*f*x*(1-c^2*x^2)*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)+1/6*d^2*f*x*(1-c^2*x^2)^2*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)-1/7*d^2*g*(1-c^2*x^2)^3*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/c^2+1/7*b*d^2*g*x*sqrt(d-c^2*d*x^2)/(c*sqrt(1-c^2*x^2))-25/96*b*c*d^2*f*x^2*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)-1/7*b*c*d^2*g*x^3*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)+5/96*b*c^3*d^2*f*x^4*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)+3/35*b*c^3*d^2*g*x^5*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)-1/49*b*c^5*d^2*g*x^7*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)+5/32*d^2*f*(a+b*asin(c*x))^2*sqrt(d-c^2*d*x^2)/(b*c*sqrt(1-c^2*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "f",
+    "g"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 62,
+   "integrand": "(f+g*x)^2*(d-c^2*d*x^2)^(3/2)*(a+b*asin(c*x))^2",
+   "variable": "x",
+   "steps": 36,
+   "antiderivative": "32/75*b^2*d*f*g*sqrt(d-c^2*d*x^2)/c^2-15/64*b^2*d*f^2*x*sqrt(d-c^2*d*x^2)-7/1152*b^2*d*g^2*x*sqrt(d-c^2*d*x^2)/c^2-43/1728*b^2*d*g^2*x^3*sqrt(d-c^2*d*x^2)+1/108*b^2*c^2*d*g^2*x^5*sqrt(d-c^2*d*x^2)+16/225*b^2*d*f*g*(1-c^2*x^2)*sqrt(d-c^2*d*x^2)/c^2-1/32*b^2*d*f^2*x*(1-c^2*x^2)*sqrt(d-c^2*d*x^2)+4/125*b^2*d*f*g*(1-c^2*x^2)^2*sqrt(d-c^2*d*x^2)/c^2+1/8*b*d*f^2*(1-c^2*x^2)^(3/2)*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/c+3/8*d*f^2*x*(a+b*asin(c*x))^2*sqrt(d-c^2*d*x^2)-1/16*d*g^2*x*(a+b*asin(c*x))^2*sqrt(d-c^2*d*x^2)/c^2+1/8*d*g^2*x^3*(a+b*asin(c*x))^2*sqrt(d-c^2*d*x^2)+1/4*d*f^2*x*(1-c^2*x^2)*(a+b*asin(c*x))^2*sqrt(d-c^2*d*x^2)+1/6*d*g^2*x^3*(1-c^2*x^2)*(a+b*asin(c*x))^2*sqrt(d-c^2*d*x^2)-2/5*d*f*g*(1-c^2*x^2)^2*(a+b*asin(c*x))^2*sqrt(d-c^2*d*x^2)/c^2+9/64*b^2*d*f^2*asin(c*x)*sqrt(d-c^2*d*x^2)/(c*sqrt(1-c^2*x^2))+7/1152*b^2*d*g^2*asin(c*x)*sqrt(d-c^2*d*x^2)/(c^3*sqrt(1-c^2*x^2))+4/5*b*d*f*g*x*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/(c*sqrt(1-c^2*x^2))-3/8*b*c*d*f^2*x^2*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)+1/16*b*d*g^2*x^2*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/(c*sqrt(1-c^2*x^2))-8/15*b*c*d*f*g*x^3*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)-7/48*b*c*d*g^2*x^4*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)+4/25*b*c^3*d*f*g*x^5*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)+1/18*b*c^3*d*g^2*x^6*(a+b*asin(c*x))*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)+1/8*d*f^2*(a+b*asin(c*x))^3*sqrt(d-c^2*d*x^2)/(b*c*sqrt(1-c^2*x^2))+1/48*d*g^2*(a+b*asin(c*x))^3*sqrt(d-c^2*d*x^2)/(b*c^3*sqrt(1-c^2*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "f",
+    "g"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 95,
+   "integrand": "(f+g*x)*(a+b*asin(c*x))/(d+ee*x)^6",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-1/5*(ee*f-d*g)*(a+b*asin(c*x))/(ee^2*(d+ee*x)^5)-1/4*g*(a+b*asin(c*x))/(ee^2*(d+ee*x)^4)+1/40*b*c^5*(c^2*d^2*ee^2*(24*ee*f-19*d*g)+3*ee^4*(ee*f-6*d*g)+2*c^4*d^4*(4*ee*f+d*g))*atan((ee+c^2*d*x)/(sqrt(c^2*d^2-ee^2)*sqrt(1-c^2*x^2)))/(ee^2*(c^2*d^2-ee^2)^(9/2))+1/20*b*c*(ee*f-d*g)*sqrt(1-c^2*x^2)/(ee*(c^2*d^2-ee^2)*(d+ee*x)^4)-1/60*b*c*(5*ee^2*g-c^2*d*(7*ee*f-2*d*g))*sqrt(1-c^2*x^2)/(ee*(c^2*d^2-ee^2)^2*(d+ee*x)^3)+1/120*b*c^3*(ee^2*(9*ee*f-34*d*g)+c^2*d^2*(26*ee*f-d*g))*sqrt(1-c^2*x^2)/(ee*(c^2*d^2-ee^2)^3*(d+ee*x)^2)-1/24*b*c^3*(4*ee^4*g-c^2*d*ee^2*(11*ee*f-18*d*g)-c^4*d^3*(10*ee*f+d*g))*sqrt(1-c^2*x^2)/(ee*(c^2*d^2-ee^2)^4*(d+ee*x))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f",
+    "g"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 121,
+   "integrand": "x^3*asin(a+b*x)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-1/32*(3+24*a^2+8*a^4)*asin(a+b*x)/b^4+1/4*x^4*asin(a+b*x)-7/48*a*x^2*sqrt(1-(a+b*x)^2)/b^2+1/16*x^3*sqrt(1-(a+b*x)^2)/b-1/96*(4*a*(16+19*a^2)-(9+26*a^2)*(a+b*x))*sqrt(1-(a+b*x)^2)/b^4",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 138,
+   "integrand": "x*asin(a+b*x)^3",
+   "variable": "x",
+   "steps": 12,
+   "antiderivative": "3/8*asin(a+b*x)/b^2+6*a*(a+b*x)*asin(a+b*x)/b^2-3/4*(a+b*x)^2*asin(a+b*x)/b^2-1/4*asin(a+b*x)^3/b^2-1/2*a^2*asin(a+b*x)^3/b^2+1/2*x^2*asin(a+b*x)^3+6*a*sqrt(1-(a+b*x)^2)/b^2-3/8*(a+b*x)*sqrt(1-(a+b*x)^2)/b^2-3*a*asin(a+b*x)^2*sqrt(1-(a+b*x)^2)/b^2+3/4*(a+b*x)*asin(a+b*x)^2*sqrt(1-(a+b*x)^2)/b^2",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 188,
+   "integrand": "(c*ee+d*ee*x)^3*(a+b*asin(c+d*x))^2",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-3/32*b^2*ee^3*(c+d*x)^2/d-1/32*b^2*ee^3*(c+d*x)^4/d-3/32*ee^3*(a+b*asin(c+d*x))^2/d+1/4*ee^3*(c+d*x)^4*(a+b*asin(c+d*x))^2/d+3/16*b*ee^3*(c+d*x)*(a+b*asin(c+d*x))*sqrt(1-(c+d*x)^2)/d+1/8*b*ee^3*(c+d*x)^3*(a+b*asin(c+d*x))*sqrt(1-(c+d*x)^2)/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 208,
+   "integrand": "(a+b*asin(c+d*x))^4",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "24*b^4*x-12*b^2*(c+d*x)*(a+b*asin(c+d*x))^2/d+(c+d*x)*(a+b*asin(c+d*x))^4/d-24*b^3*(a+b*asin(c+d*x))*sqrt(1-(c+d*x)^2)/d+4*b*(a+b*asin(c+d*x))^3*sqrt(1-(c+d*x)^2)/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 331,
+   "integrand": "1/(asin(a+b*x)^3*sqrt(1-a^2-2*a*b*x-b^2*x^2))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(-1/2)/(b*asin(a+b*x)^2)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 349,
+   "integrand": "(a+b*asin(c*x^2))/x^11",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "1/10*(-a-b*asin(c*x^2))/x^10-3/80*b*c^5*atanh(sqrt(1-c^2*x^4))-1/40*b*c*sqrt(1-c^2*x^4)/x^8-3/80*b*c^3*sqrt(1-c^2*x^4)/x^4",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 372,
+   "integrand": "a+b*asin(c/x)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "a*x+b*x*acsc(x/c)+b*c*atanh(sqrt(1-c^2/x^2))",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 400,
+   "integrand": "(a+b*asin(1+d*x^2))^4",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "384*b^4*x-48*b^2*x*(a+b*asin(1+d*x^2))^2+x*(a+b*asin(1+d*x^2))^4-192*b^3*(a+b*asin(1+d*x^2))*sqrt(-2*d*x^2-d^2*x^4)/(d*x)+8*b*(a+b*asin(1+d*x^2))^3*sqrt(-2*d*x^2-d^2*x^4)/(d*x)",
+   "params": [
+    "a",
+    "b",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 440,
+   "integrand": "exp(1)^asin(a*x)*x",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/5*exp(1)^asin(a*x)*cos(2*asin(a*x))/a^2+1/10*exp(1)^asin(a*x)*sin(2*asin(a*x))/a^2",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.1 Inverse sine/5.1.5 Inverse sine functions.mac",
+   "index": 471,
+   "integrand": "1/(asin(sqrt(1+b*x^2))*sqrt(1+b*x^2))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "ln(asin(sqrt(1+b*x^2)))*sqrt(-b*x^2)/(b*x)",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.2 Inverse cosine/5.2.2 (d x)^m (a+b arccos(c x))^n.mac",
+   "index": 11,
+   "integrand": "x^4*acos(a*x)^2",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-16/75*x/a^4-8/225*x^3/a^2-2/125*x^5+1/5*x^5*acos(a*x)^2-16/75*acos(a*x)*sqrt(1-a^2*x^2)/a^5-8/75*x^2*acos(a*x)*sqrt(1-a^2*x^2)/a^3-2/25*x^4*acos(a*x)*sqrt(1-a^2*x^2)/a",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.2 Inverse cosine/5.2.2 (d x)^m (a+b arccos(c x))^n.mac",
+   "index": 32,
+   "integrand": "x^4*acos(a*x)^4",
+   "variable": "x",
+   "steps": 19,
+   "antiderivative": "16576/5625*x/a^4+1088/16875*x^3/a^2+24/3125*x^5-32/25*x*acos(a*x)^2/a^4-16/75*x^3*acos(a*x)^2/a^2-12/125*x^5*acos(a*x)^2+1/5*x^5*acos(a*x)^4+16576/5625*acos(a*x)*sqrt(1-a^2*x^2)/a^5+1088/5625*x^2*acos(a*x)*sqrt(1-a^2*x^2)/a^3+24/625*x^4*acos(a*x)*sqrt(1-a^2*x^2)/a-32/75*acos(a*x)^3*sqrt(1-a^2*x^2)/a^5-16/75*x^2*acos(a*x)^3*sqrt(1-a^2*x^2)/a^3-4/25*x^4*acos(a*x)^3*sqrt(1-a^2*x^2)/a",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.2 Inverse cosine/5.2.2 (d x)^m (a+b arccos(c x))^n.mac",
+   "index": 148,
+   "integrand": "x*(a+b*acos(c*x))^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/4*b^2*x^2-1/4*(a+b*acos(c*x))^2/c^2+1/2*x^2*(a+b*acos(c*x))^2-1/2*b*x*(a+b*acos(c*x))*sqrt(1-c^2*x^2)/c",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.2 Inverse cosine/5.2.5 Inverse cosine functions.mac",
+   "index": 25,
+   "integrand": "(f+g*x)^2*(d-c^2*d*x^2)^(5/2)*(a+b*acos(c*x))",
+   "variable": "x",
+   "steps": 26,
+   "antiderivative": "-1/36*b*d^2*f^2*(1-c^2*x^2)^(5/2)*sqrt(d-c^2*d*x^2)/c+5/16*d^2*f^2*x*(a+b*acos(c*x))*sqrt(d-c^2*d*x^2)-5/128*d^2*g^2*x*(a+b*acos(c*x))*sqrt(d-c^2*d*x^2)/c^2+5/64*d^2*g^2*x^3*(a+b*acos(c*x))*sqrt(d-c^2*d*x^2)+5/24*d^2*f^2*x*(1-c^2*x^2)*(a+b*acos(c*x))*sqrt(d-c^2*d*x^2)+5/48*d^2*g^2*x^3*(1-c^2*x^2)*(a+b*acos(c*x))*sqrt(d-c^2*d*x^2)+1/6*d^2*f^2*x*(1-c^2*x^2)^2*(a+b*acos(c*x))*sqrt(d-c^2*d*x^2)+1/8*d^2*g^2*x^3*(1-c^2*x^2)^2*(a+b*acos(c*x))*sqrt(d-c^2*d*x^2)-2/7*d^2*f*g*(1-c^2*x^2)^3*(a+b*acos(c*x))*sqrt(d-c^2*d*x^2)/c^2-2/7*b*d^2*f*g*x*sqrt(d-c^2*d*x^2)/(c*sqrt(1-c^2*x^2))+25/96*b*c*d^2*f^2*x^2*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)-5/256*b*d^2*g^2*x^2*sqrt(d-c^2*d*x^2)/(c*sqrt(1-c^2*x^2))+2/7*b*c*d^2*f*g*x^3*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)-5/96*b*c^3*d^2*f^2*x^4*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)+59/768*b*c*d^2*g^2*x^4*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)-6/35*b*c^3*d^2*f*g*x^5*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)-17/288*b*c^3*d^2*g^2*x^6*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)+2/49*b*c^5*d^2*f*g*x^7*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)+1/64*b*c^5*d^2*g^2*x^8*sqrt(d-c^2*d*x^2)/sqrt(1-c^2*x^2)-5/32*d^2*f^2*(a+b*acos(c*x))^2*sqrt(d-c^2*d*x^2)/(b*c*sqrt(1-c^2*x^2))-5/256*d^2*g^2*(a+b*acos(c*x))^2*sqrt(d-c^2*d*x^2)/(b*c^3*sqrt(1-c^2*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "f",
+    "g"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.2 Inverse cosine/5.2.5 Inverse cosine functions.mac",
+   "index": 48,
+   "integrand": "(c+d*x^2)^4*acos(a*x)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "4/945*d*(105*a^6*c^3+189*a^4*c^2*d+135*a^2*c*d^2+35*d^3)*(1-a^2*x^2)^(3/2)/a^9-2/525*d^2*(63*a^4*c^2+90*a^2*c*d+35*d^2)*(1-a^2*x^2)^(5/2)/a^9+4/441*d^3*(9*a^2*c+7*d)*(1-a^2*x^2)^(7/2)/a^9-1/81*d^4*(1-a^2*x^2)^(9/2)/a^9+c^4*x*acos(a*x)+4/3*c^3*d*x^3*acos(a*x)+6/5*c^2*d^2*x^5*acos(a*x)+4/7*c*d^3*x^7*acos(a*x)+1/9*d^4*x^9*acos(a*x)-1/315*(315*a^8*c^4+420*a^6*c^3*d+378*a^4*c^2*d^2+180*a^2*c*d^3+35*d^4)*sqrt(1-a^2*x^2)/a^9",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.2 Inverse cosine/5.2.5 Inverse cosine functions.mac",
+   "index": 78,
+   "integrand": "acos(x)*sqrt(1-x^2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/4*x^2-1/4*acos(x)^2+1/2*x*acos(x)*sqrt(1-x^2)",
+   "params": []
+  },
+  {
+   "source": "5 Inverse trig functions/5.2 Inverse cosine/5.2.5 Inverse cosine functions.mac",
+   "index": 97,
+   "integrand": "acos(sqrt(x))/x^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/2*acos(sqrt(x))/x^2+1/6*sqrt(1-x)/x^(3/2)+1/3*sqrt(1-x)/sqrt(x)",
+   "params": []
+  },
+  {
+   "source": "5 Inverse trig functions/5.2 Inverse cosine/5.2.5 Inverse cosine functions.mac",
+   "index": 115,
+   "integrand": "a+b*acos(-1+d*x^2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "a*x+b*x*acos(-1+d*x^2)-2*b*sqrt(2*d*x^2-d^2*x^4)/(d*x)",
+   "params": [
+    "a",
+    "b",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.2 (d x)^m (a+b arctan(c x^n))^p.mac",
+   "index": 5,
+   "integrand": "a+b*atan(c*x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "a*x+b*x*atan(c*x)-1/2*b*ln(1+c^2*x^2)/c",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.2 (d x)^m (a+b arctan(c x^n))^p.mac",
+   "index": 60,
+   "integrand": "x^5*(a+b*atan(c*x^2))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/12*b*x^4/c+1/6*x^6*(a+b*atan(c*x^2))+1/12*b*ln(1+c^2*x^4)/c^3",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.2 (d x)^m (a+b arctan(c x^n))^p.mac",
+   "index": 75,
+   "integrand": "x^3*(a+b*atan(c*x^2))^2",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-1/2*a*b*x^2/c-1/2*b^2*x^2*atan(c*x^2)/c+1/4*(a+b*atan(c*x^2))^2/c^2+1/4*x^4*(a+b*atan(c*x^2))^2+1/4*b^2*ln(1+c^2*x^4)/c^2",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.2 (d x)^m (a+b arctan(c x^n))^p.mac",
+   "index": 107,
+   "integrand": "x^7*(a+b*atan(c*x^3))",
+   "variable": "x",
+   "steps": 12,
+   "antiderivative": "-3/40*b*x^5/c+1/8*b*atan(c^(1/3)*x)/c^(8/3)+1/8*x^8*(a+b*atan(c*x^3))-1/16*b*atan(-2*c^(1/3)*x+sqrt(3))/c^(8/3)+1/16*b*atan(2*c^(1/3)*x+sqrt(3))/c^(8/3)+1/32*b*ln(1+c^(2/3)*x^2-c^(1/3)*x*sqrt(3))*sqrt(3)/c^(8/3)-1/32*b*ln(1+c^(2/3)*x^2+c^(1/3)*x*sqrt(3))*sqrt(3)/c^(8/3)",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.2 (d x)^m (a+b arctan(c x^n))^p.mac",
+   "index": 137,
+   "integrand": "(a+b*atan(c/x))/x^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/2*b/(c*x)+1/2*(-a-b*atan(c/x))/x^2+1/2*b*atan(x/c)/c^2",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.2 (d x)^m (a+b arctan(c x^n))^p.mac",
+   "index": 162,
+   "integrand": "atan(sqrt(x))/x^(3/2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "ln(x)-ln(1+x)-2*atan(sqrt(x))/sqrt(x)",
+   "params": []
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.3 (d+e x)^m (a+b arctan(c x^n))^p.mac",
+   "index": 28,
+   "integrand": "(d+ee*x)*(a+b*atan(c*x^3))",
+   "variable": "x",
+   "steps": 22,
+   "antiderivative": "-1/2*b*ee*atan(c^(1/3)*x)/c^(2/3)-1/2*b*d^2*atan(c*x^3)/ee+1/2*(d+ee*x)^2*(a+b*atan(c*x^3))/ee+1/4*b*ee*atan(-2*c^(1/3)*x+sqrt(3))/c^(2/3)-1/4*b*ee*atan(2*c^(1/3)*x+sqrt(3))/c^(2/3)+1/2*b*d*ln(1+c^(2/3)*x^2)/c^(1/3)-1/4*b*d*ln(1-c^(2/3)*x^2+c^(4/3)*x^4)/c^(1/3)+1/2*b*d*atan((1-2*c^(2/3)*x^2)/sqrt(3))*sqrt(3)/c^(1/3)-1/8*b*ee*ln(1+c^(2/3)*x^2-c^(1/3)*x*sqrt(3))*sqrt(3)/c^(2/3)+1/8*b*ee*ln(1+c^(2/3)*x^2+c^(1/3)*x*sqrt(3))*sqrt(3)/c^(2/3)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.4 u (a+b arctan(c x))^p.mac",
+   "index": 164,
+   "integrand": "x^3*(c+a^2*c*x^2)^3*atan(a*x)",
+   "variable": "x",
+   "steps": 18,
+   "antiderivative": "1/40*c^3*x/a^3-1/120*c^3*x^3/a-9/200*a*c^3*x^5-11/280*a^3*c^3*x^7-1/90*a^5*c^3*x^9-1/40*c^3*atan(a*x)/a^4+1/4*c^3*x^4*atan(a*x)+1/2*a^2*c^3*x^6*atan(a*x)+3/8*a^4*c^3*x^8*atan(a*x)+1/10*a^6*c^3*x^10*atan(a*x)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.4 u (a+b arctan(c x))^p.mac",
+   "index": 185,
+   "integrand": "x*atan(a*x)/(c+a^2*c*x^2)^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/4*x/(a*c^2*(1+a^2*x^2))+1/4*atan(a*x)/(a^2*c^2)-1/2*atan(a*x)/(a^2*c^2*(1+a^2*x^2))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.4 u (a+b arctan(c x))^p.mac",
+   "index": 207,
+   "integrand": "x^3*(c+a^2*c*x^2)^(3/2)*atan(a*x)",
+   "variable": "x",
+   "steps": 31,
+   "antiderivative": "17/560*c^(3/2)*atanh(a*x*sqrt(c)/sqrt(c+a^2*c*x^2))/a^4+3/112*c*x*sqrt(c+a^2*c*x^2)/a^3-23/840*c*x^3*sqrt(c+a^2*c*x^2)/a-1/42*a*c*x^5*sqrt(c+a^2*c*x^2)-2/35*c*atan(a*x)*sqrt(c+a^2*c*x^2)/a^4+1/35*c*x^2*atan(a*x)*sqrt(c+a^2*c*x^2)/a^2+8/35*c*x^4*atan(a*x)*sqrt(c+a^2*c*x^2)+1/7*a^2*c*x^6*atan(a*x)*sqrt(c+a^2*c*x^2)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.4 u (a+b arctan(c x))^p.mac",
+   "index": 239,
+   "integrand": "x^5*atan(a*x)/(c+a^2*c*x^2)^(5/2)",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "-1/9*x^3/(a^3*c*(c+a^2*c*x^2)^(3/2))+1/3*x^2*atan(a*x)/(a^4*c*(c+a^2*c*x^2)^(3/2))-atanh(a*x*sqrt(c)/sqrt(c+a^2*c*x^2))/(a^6*c^(5/2))-5/3*x/(a^5*c^2*sqrt(c+a^2*c*x^2))+5/3*atan(a*x)/(a^6*c^2*sqrt(c+a^2*c*x^2))+atan(a*x)*sqrt(c+a^2*c*x^2)/(a^6*c^3)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.4 u (a+b arctan(c x))^p.mac",
+   "index": 291,
+   "integrand": "x^2*atan(a*x)^2/(c+a^2*c*x^2)^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/4*x/(a^2*c^2*(1+a^2*x^2))+1/4*atan(a*x)/(a^3*c^2)-1/2*atan(a*x)/(a^3*c^2*(1+a^2*x^2))-1/2*x*atan(a*x)^2/(a^2*c^2*(1+a^2*x^2))+1/6*atan(a*x)^3/(a^3*c^2)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.4 u (a+b arctan(c x))^p.mac",
+   "index": 390,
+   "integrand": "atan(a*x)^3/(c+a^2*c*x^2)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/4*atan(a*x)^4/(a*c)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.4 u (a+b arctan(c x))^p.mac",
+   "index": 454,
+   "integrand": "atan(a*x)^3/(c+a^2*c*x^2)^(5/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "(-2/27)/(a*c*(c+a^2*c*x^2)^(3/2))-2/9*x*atan(a*x)/(c*(c+a^2*c*x^2)^(3/2))+1/3*atan(a*x)^2/(a*c*(c+a^2*c*x^2)^(3/2))+1/3*x*atan(a*x)^3/(c*(c+a^2*c*x^2)^(3/2))+(-40/9)/(a*c^2*sqrt(c+a^2*c*x^2))-40/9*x*atan(a*x)/(c^2*sqrt(c+a^2*c*x^2))+2*atan(a*x)^2/(a*c^2*sqrt(c+a^2*c*x^2))+2/3*x*atan(a*x)^3/(c^2*sqrt(c+a^2*c*x^2))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.4 u (a+b arctan(c x))^p.mac",
+   "index": 1114,
+   "integrand": "x^2*(d+ee*x^2)*(a+b*atan(c*x))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/30*b*(5*c^2*d-3*ee)*x^2/c^3-1/20*b*ee*x^4/c+1/3*d*x^3*(a+b*atan(c*x))+1/5*ee*x^5*(a+b*atan(c*x))+1/30*b*(5*c^2*d-3*ee)*ln(1+c^2*x^2)/c^5",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.4 u (a+b arctan(c x))^p.mac",
+   "index": 1131,
+   "integrand": "(d+ee*x^2)^2*(a+b*atan(c*x))/x^4",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/6*b*c*d^2/x^2-1/3*d^2*(a+b*atan(c*x))/x^3-2*d*ee*(a+b*atan(c*x))/x+ee^2*x*(a+b*atan(c*x))-1/3*b*c*d*(c^2*d-6*ee)*ln(x)+1/6*b*(c^4*d^2-6*c^2*d*ee-3*ee^2)*ln(1+c^2*x^2)/c",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.4 u (a+b arctan(c x))^p.mac",
+   "index": 1149,
+   "integrand": "(c+d*x^2)^4*atan(a*x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/630*d*(420*a^6*c^3-378*a^4*c^2*d+180*a^2*c*d^2-35*d^3)*x^2/a^7-1/1260*d^2*(378*a^4*c^2-180*a^2*c*d+35*d^2)*x^4/a^5-1/378*(36*a^2*c-7*d)*d^3*x^6/a^3-1/72*d^4*x^8/a+c^4*x*atan(a*x)+4/3*c^3*d*x^3*atan(a*x)+6/5*c^2*d^2*x^5*atan(a*x)+4/7*c*d^3*x^7*atan(a*x)+1/9*d^4*x^9*atan(a*x)-1/630*(315*a^8*c^4-420*a^6*c^3*d+378*a^4*c^2*d^2-180*a^2*c*d^3+35*d^4)*ln(1+a^2*x^2)/a^9",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.4 u (a+b arctan(c x))^p.mac",
+   "index": 1200,
+   "integrand": "x^3*(a+b*atan(c*x))/(d+ee*x^2)^(1/2)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "1/3*(d+ee*x^2)^(3/2)*(a+b*atan(c*x))/ee^2+1/6*b*(3*c^2*d+2*ee)*atanh(x*sqrt(ee)/sqrt(d+ee*x^2))/(c^3*ee^(3/2))+1/3*b*(2*c^2*d+ee)*atan(x*sqrt(c^2*d-ee)/sqrt(d+ee*x^2))*sqrt(c^2*d-ee)/(c^3*ee^2)-1/6*b*x*sqrt(d+ee*x^2)/(c*ee)-d*(a+b*atan(c*x))*sqrt(d+ee*x^2)/ee^2",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.4 u (a+b arctan(c x))^p.mac",
+   "index": 1222,
+   "integrand": "(a+b*atan(c*x))/(x^2*(d+ee*x^2)^(5/2))",
+   "variable": "x",
+   "steps": 13,
+   "antiderivative": "(-a-b*atan(c*x))/(d*x*(d+ee*x^2)^(3/2))-4/3*ee*x*(a+b*atan(c*x))/(d^2*(d+ee*x^2)^(3/2))-b*c*atanh(sqrt(d+ee*x^2)/sqrt(d))/d^(5/2)+1/3*b*(3*c^4*d^2-12*c^2*d*ee+8*ee^2)*atanh(c*sqrt(d+ee*x^2)/sqrt(c^2*d-ee))/(d^3*(c^2*d-ee)^(3/2))+b*c/(d^2*sqrt(d+ee*x^2))-8/3*b*ee/(c*d^3*sqrt(d+ee*x^2))-1/3*b*(3*c^4*d^2-12*c^2*d*ee+8*ee^2)/(c*d^3*(c^2*d-ee)*sqrt(d+ee*x^2))-8/3*ee*x*(a+b*atan(c*x))/(d^3*sqrt(d+ee*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.4 u (a+b arctan(c x))^p.mac",
+   "index": 1285,
+   "integrand": "x^4*(a+b*atan(c*x))*(d+ee*ln(1+c^2*x^2))",
+   "variable": "x",
+   "steps": 26,
+   "antiderivative": "-2/5*a*ee*x/c^4-77/300*b*ee*x^2/c^3+2/15*a*ee*x^3/c^2+9/200*b*ee*x^4/c-2/25*a*ee*x^5+2/5*a*ee*atan(c*x)/c^5-2/5*b*ee*x*atan(c*x)/c^4+2/15*b*ee*x^3*atan(c*x)/c^2-2/25*b*ee*x^5*atan(c*x)+1/5*b*ee*atan(c*x)^2/c^5+137/300*b*ee*ln(1+c^2*x^2)/c^5+1/20*b*ee*ln(1+c^2*x^2)^2/c^5+1/10*b*x^2*(d+ee*ln(1+c^2*x^2))/c^3-1/20*b*x^4*(d+ee*ln(1+c^2*x^2))/c+1/5*x^5*(a+b*atan(c*x))*(d+ee*ln(1+c^2*x^2))-1/10*b*ln(1+c^2*x^2)*(d+ee*ln(1+c^2*x^2))/c^5",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.5 u (a+b arctan(c+d x))^p.mac",
+   "index": 13,
+   "integrand": "(a+b*atan(c+d*x))^2/(c*ee+d*ee*x)^5",
+   "variable": "x",
+   "steps": 15,
+   "antiderivative": "-1/12*b^2/(d*ee^5*(c+d*x)^2)-1/6*b*(a+b*atan(c+d*x))/(d*ee^5*(c+d*x)^3)+1/2*b*(a+b*atan(c+d*x))/(d*ee^5*(c+d*x))+1/4*(a+b*atan(c+d*x))^2/(d*ee^5)-1/4*(a+b*atan(c+d*x))^2/(d*ee^5*(c+d*x)^4)-2/3*b^2*ln(c+d*x)/(d*ee^5)+1/3*b^2*ln(1+(c+d*x)^2)/(d*ee^5)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.5 u (a+b arctan(c+d x))^p.mac",
+   "index": 50,
+   "integrand": "atan(a+b*x)/x^4",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-1/6*b/((1+a^2)*x^2)+2/3*a*b^2/((1+a^2)^2*x)+1/3*a*(3-a^2)*b^3*atan(a+b*x)/(1+a^2)^3-1/3*atan(a+b*x)/x^3-1/3*(1-3*a^2)*b^3*ln(x)/(1+a^2)^3+1/6*(1-3*a^2)*b^3*ln(1+(a+b*x)^2)/(1+a^2)^3",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.6 Exponentials of inverse tangent.mac",
+   "index": 269,
+   "integrand": "exp(1)^(2*atan(a*x))/(c+a^2*c*x^2)^(3/2)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/5*exp(1)^(2*atan(a*x))*(2+a*x)/(a*c*sqrt(c+a^2*c*x^2))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.6 Exponentials of inverse tangent.mac",
+   "index": 293,
+   "integrand": "1/(exp(1)^(2*atan(a*x))*(c+a^2*c*x^2)^4)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "(-9/160)/(exp(1)^(2*atan(a*x))*a*c^4)+1/20*(-1+3*a*x)/(exp(1)^(2*atan(a*x))*a*c^4*(1+a^2*x^2)^3)-3/40*(1-2*a*x)/(exp(1)^(2*atan(a*x))*a*c^4*(1+a^2*x^2)^2)-9/80*(1-a*x)/(exp(1)^(2*atan(a*x))*a*c^4*(1+a^2*x^2))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.7 Inverse tangent functions.mac",
+   "index": 8,
+   "integrand": "atan(x*sqrt(-ee)/sqrt(d+ee*x^2))/x^7",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/6*atan(x*sqrt(-ee)/sqrt(d+ee*x^2))/x^6-2/45*(-ee)^(3/2)*sqrt(d+ee*x^2)/(d^2*x^3)-4/45*(-ee)^(5/2)*sqrt(d+ee*x^2)/(d^3*x)-1/30*sqrt(-ee)*sqrt(d+ee*x^2)/(d*x^5)",
+   "params": [
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.7 Inverse tangent functions.mac",
+   "index": 39,
+   "integrand": "atan(tan(a+b*x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*atan(tan(a+b*x))^2/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.7 Inverse tangent functions.mac",
+   "index": 122,
+   "integrand": "1/((1+x^2)*(2+atan(x)))",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "ln(2+atan(x))",
+   "params": []
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.7 Inverse tangent functions.mac",
+   "index": 136,
+   "integrand": "1/(atan(c*x/sqrt(a-c^2*x^2))*sqrt(d-c^2*d*x^2/a))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "ln(atan(c*x/sqrt(a-c^2*x^2)))*sqrt(a-c^2*x^2)/(c*sqrt(d-c^2*d*x^2/a))",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.3 Inverse tangent/5.3.7 Inverse tangent functions.mac",
+   "index": 150,
+   "integrand": "exp(1)^(c*(a+b*x))*atan(sech(a*c+b*c*x))",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "exp(1)^(a*c+b*c*x)*atan(sech(c*(a+b*x)))/(b*c)+1/2*ln(3+exp(1)^(2*c*(a+b*x))-2*sqrt(2))*(1-sqrt(2))/(b*c)+1/2*ln(3+exp(1)^(2*c*(a+b*x))+2*sqrt(2))*(1+sqrt(2))/(b*c)",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.4 Inverse cotangent/5.4.1 Inverse cotangent functions.mac",
+   "index": 13,
+   "integrand": "x^3*acot(a*x)^2",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "1/12*x^2/a^2-1/2*x*acot(a*x)/a^3+1/6*x^3*acot(a*x)/a-1/4*acot(a*x)^2/a^4+1/4*x^4*acot(a*x)^2-1/3*ln(1+a^2*x^2)/a^4",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.4 Inverse cotangent/5.4.1 Inverse cotangent functions.mac",
+   "index": 54,
+   "integrand": "(c+d*x^2)^2*acot(a*x)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/30*(10*a^2*c-3*d)*d*x^2/a^3+1/20*d^2*x^4/a+c^2*x*acot(a*x)+2/3*c*d*x^3*acot(a*x)+1/5*d^2*x^5*acot(a*x)+1/30*(15*a^4*c^2-10*a^2*c*d+3*d^2)*ln(1+a^2*x^2)/a^5",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.4 Inverse cotangent/5.4.1 Inverse cotangent functions.mac",
+   "index": 73,
+   "integrand": "x^5*acot(a*x^2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/12*x^4/a+1/6*x^6*acot(a*x^2)-1/12*ln(1+a^2*x^4)/a^3",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.4 Inverse cotangent/5.4.1 Inverse cotangent functions.mac",
+   "index": 88,
+   "integrand": "acot(sqrt(x))/x^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-acot(sqrt(x))/x+atan(sqrt(x))+1/sqrt(x)",
+   "params": []
+  },
+  {
+   "source": "5 Inverse trig functions/5.4 Inverse cotangent/5.4.1 Inverse cotangent functions.mac",
+   "index": 104,
+   "integrand": "acot(a+b*x)/x^3",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "1/2*b/((1+a^2)*x)-1/2*acot(a+b*x)/x^2+1/2*(1-a^2)*b^2*atan(a+b*x)/(1+a^2)^2+a*b^2*ln(x)/(1+a^2)^2-1/2*a*b^2*ln(1+(a+b*x)^2)/(1+a^2)^2",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.4 Inverse cotangent/5.4.1 Inverse cotangent functions.mac",
+   "index": 156,
+   "integrand": "acot(tan(a+b*x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/2*acot(tan(a+b*x))^2/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.4 Inverse cotangent/5.4.2 Exponentials of inverse cotangent.mac",
+   "index": 4,
+   "integrand": "exp(1)^acot(x)/(a+a*x^2)^(3/2)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-1/2*exp(1)^acot(x)*(1-x)/(a*sqrt(a+a*x^2))",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.5 Inverse secant/5.5.1 u (a+b arcsec(c x))^n.mac",
+   "index": 11,
+   "integrand": "(a+b*asec(c*x))/x^5",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-3/32*b*c^4*acsc(c*x)+1/4*(-a-b*asec(c*x))/x^4+1/16*b*c*sqrt(1+(-1)/(c^2*x^2))/x^3+3/32*b*c^3*sqrt(1+(-1)/(c^2*x^2))/x",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.5 Inverse secant/5.5.1 u (a+b arcsec(c x))^n.mac",
+   "index": 55,
+   "integrand": "(d+ee*x)^3*(a+b*asec(c*x))",
+   "variable": "x",
+   "steps": 11,
+   "antiderivative": "1/4*b*d^4*acsc(c*x)/ee+1/4*(d+ee*x)^4*(a+b*asec(c*x))/ee-1/2*b*d*(2*c^2*d^2+ee^2)*atanh(sqrt(1+(-1)/(c^2*x^2)))/c^3-1/6*b*ee*(9*c^2*d^2+ee^2)*x*sqrt(1+(-1)/(c^2*x^2))/c^3-1/2*b*d*ee^2*x^2*sqrt(1+(-1)/(c^2*x^2))/c-1/12*b*ee^3*x^3*sqrt(1+(-1)/(c^2*x^2))/c",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.5 Inverse secant/5.5.1 u (a+b arcsec(c x))^n.mac",
+   "index": 75,
+   "integrand": "x^5*(d+ee*x^2)*(a+b*asec(c*x))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/6*d*x^6*(a+b*asec(c*x))+1/8*ee*x^8*(a+b*asec(c*x))-1/72*b*(8*c^2*d+9*ee)*x*(-1+c^2*x^2)^(3/2)/(c^7*sqrt(c^2*x^2))-1/120*b*(4*c^2*d+9*ee)*x*(-1+c^2*x^2)^(5/2)/(c^7*sqrt(c^2*x^2))-1/56*b*ee*x*(-1+c^2*x^2)^(7/2)/(c^7*sqrt(c^2*x^2))-1/24*b*(4*c^2*d+3*ee)*x*sqrt(-1+c^2*x^2)/(c^7*sqrt(c^2*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.5 Inverse secant/5.5.1 u (a+b arcsec(c x))^n.mac",
+   "index": 105,
+   "integrand": "x*(a+b*asec(c*x))/(d+ee*x^2)^3",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "1/4*(-a-b*asec(c*x))/(ee*(d+ee*x^2)^2)+1/4*b*c*x*atan(sqrt(-1+c^2*x^2))/(d^2*ee*sqrt(c^2*x^2))-1/8*b*c*(3*c^2*d+2*ee)*x*atan(sqrt(ee)*sqrt(-1+c^2*x^2)/sqrt(c^2*d+ee))/(d^2*(c^2*d+ee)^(3/2)*sqrt(ee)*sqrt(c^2*x^2))-1/8*b*c*x*sqrt(-1+c^2*x^2)/(d*(c^2*d+ee)*(d+ee*x^2)*sqrt(c^2*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.5 Inverse secant/5.5.1 u (a+b arcsec(c x))^n.mac",
+   "index": 151,
+   "integrand": "x^3*(a+b*asec(c*x))/(d+ee*x^2)^(5/2)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "1/3*d*(a+b*asec(c*x))/(ee^2*(d+ee*x^2)^(3/2))-2/3*b*c*x*atan(sqrt(d+ee*x^2)/(sqrt(d)*sqrt(-1+c^2*x^2)))/(ee^2*sqrt(d)*sqrt(c^2*x^2))+(-a-b*asec(c*x))/(ee^2*sqrt(d+ee*x^2))+1/3*b*c*x*sqrt(-1+c^2*x^2)/(ee*(c^2*d+ee)*sqrt(c^2*x^2)*sqrt(d+ee*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.5 Inverse secant/5.5.2 Inverse secant functions.mac",
+   "index": 11,
+   "integrand": "asec(a/x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "x*acos(x/a)-a*sqrt(1-x^2/a^2)",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.5 Inverse secant/5.5.2 Inverse secant functions.mac",
+   "index": 38,
+   "integrand": "x^2*(a+b*asec(c+d*x^3))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "1/3*a*x^3+1/3*b*(c+d*x^3)*asec(c+d*x^3)/d-1/3*b*atanh(sqrt(1+(-1)/(c+d*x^3)^2))/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.6 Inverse cosecant/5.6.1 u (a+b arccsc(c x))^n.mac",
+   "index": 8,
+   "integrand": "(a+b*acsc(c*x))/x^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "(-a-b*acsc(c*x))/x-b*c*sqrt(1+(-1)/(c^2*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "5 Inverse trig functions/5.6 Inverse cosecant/5.6.1 u (a+b arccsc(c x))^n.mac",
+   "index": 29,
+   "integrand": "(a+b*acsc(c*x))^3/x^3",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-3/8*b^3*c^2*acsc(c*x)+3/4*b^2*(a+b*acsc(c*x))/x^2+1/4*c^2*(a+b*acsc(c*x))^3-1/2*(a+b*acsc(c*x))^3/x^2+3/8*b^3*c*sqrt(1+(-1)/(c^2*x^2))/x-3/4*b*c*(a+b*acsc(c*x))^2*sqrt(1+(-1)/(c^2*x^2))/x",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.1 (c+d x)^m (a+b sinh)^n.mac",
+   "index": 0,
+   "integrand": "(c+d*x)^4*sinh(a+b*x)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "24*d^4*cosh(a+b*x)/b^5+12*d^2*(c+d*x)^2*cosh(a+b*x)/b^3+(c+d*x)^4*cosh(a+b*x)/b-24*d^3*(c+d*x)*sinh(a+b*x)/b^4-4*d*(c+d*x)^3*sinh(a+b*x)/b^2",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.1 (c+d x)^m (a+b sinh)^n.mac",
+   "index": 296,
+   "integrand": "cosh(c+d*x)^2/(a+b*sinh(c+d*x))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-a*x/b^2+cosh(c+d*x)/(b*d)-2*atanh((b-a*tanh(1/2*(c+d*x)))/sqrt(a^2+b^2))*sqrt(a^2+b^2)/(b^2*d)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.1 (c+d x)^m (a+b sinh)^n.mac",
+   "index": 446,
+   "integrand": "csch(c+d*x)*sech(c+d*x)^3/(a+b*sinh(c+d*x))",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "-b^3*atan(sinh(c+d*x))/((a^2+b^2)^2*d)-1/2*b*atan(sinh(c+d*x))/((a^2+b^2)*d)-a*(a^2+2*b^2)*ln(cosh(c+d*x))/((a^2+b^2)^2*d)+ln(sinh(c+d*x))/(a*d)-b^4*ln(a+b*sinh(c+d*x))/(a*(a^2+b^2)^2*d)+1/2*sech(c+d*x)^2*(a-b*sinh(c+d*x))/((a^2+b^2)*d)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.3 (e x)^m (a+b sinh(c+d x^n))^p.mac",
+   "index": 97,
+   "integrand": "x^2*sinh(a+b*(c+d*x)^(1/3))",
+   "variable": "x",
+   "steps": 23,
+   "antiderivative": "120960*cosh(a+b*(c+d*x)^(1/3))/(b^9*d^3)+6*c^2*cosh(a+b*(c+d*x)^(1/3))/(b^3*d^3)-720*c*(c+d*x)^(1/3)*cosh(a+b*(c+d*x)^(1/3))/(b^5*d^3)+60480*(c+d*x)^(2/3)*cosh(a+b*(c+d*x)^(1/3))/(b^7*d^3)+3*c^2*(c+d*x)^(2/3)*cosh(a+b*(c+d*x)^(1/3))/(b*d^3)-120*c*(c+d*x)*cosh(a+b*(c+d*x)^(1/3))/(b^3*d^3)+5040*(c+d*x)^(4/3)*cosh(a+b*(c+d*x)^(1/3))/(b^5*d^3)-6*c*(c+d*x)^(5/3)*cosh(a+b*(c+d*x)^(1/3))/(b*d^3)+168*(c+d*x)^2*cosh(a+b*(c+d*x)^(1/3))/(b^3*d^3)+3*(c+d*x)^(8/3)*cosh(a+b*(c+d*x)^(1/3))/(b*d^3)+720*c*sinh(a+b*(c+d*x)^(1/3))/(b^6*d^3)-120960*(c+d*x)^(1/3)*sinh(a+b*(c+d*x)^(1/3))/(b^8*d^3)-6*c^2*(c+d*x)^(1/3)*sinh(a+b*(c+d*x)^(1/3))/(b^2*d^3)+360*c*(c+d*x)^(2/3)*sinh(a+b*(c+d*x)^(1/3))/(b^4*d^3)-20160*(c+d*x)*sinh(a+b*(c+d*x)^(1/3))/(b^6*d^3)+30*c*(c+d*x)^(4/3)*sinh(a+b*(c+d*x)^(1/3))/(b^2*d^3)-1008*(c+d*x)^(5/3)*sinh(a+b*(c+d*x)^(1/3))/(b^4*d^3)-24*(c+d*x)^(7/3)*sinh(a+b*(c+d*x)^(1/3))/(b^2*d^3)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.5 Hyperbolic sine functions.mac",
+   "index": 101,
+   "integrand": "1/(a+b*sinh(c+d*x))^2",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-2*a*atanh((b-a*tanh(1/2*(c+d*x)))/sqrt(a^2+b^2))/((a^2+b^2)^(3/2)*d)-b*cosh(c+d*x)/((a^2+b^2)*d*(a+b*sinh(c+d*x)))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.5 Hyperbolic sine functions.mac",
+   "index": 195,
+   "integrand": "sech(x)^3/(a+b*sinh(x))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "1/2*a*(a^2+3*b^2)*atan(sinh(x))/(a^2+b^2)^2-b^3*ln(cosh(x))/(a^2+b^2)^2+b^3*ln(a+b*sinh(x))/(a^2+b^2)^2+1/2*sech(x)^2*(b+a*sinh(x))/(a^2+b^2)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.5 Hyperbolic sine functions.mac",
+   "index": 249,
+   "integrand": "(A+B*coth(x))/(a+b*sinh(x))",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "B*ln(sinh(x))/a-B*ln(a+b*sinh(x))/a-2*A*atanh((b-a*tanh(1/2*x))/sqrt(a^2+b^2))/sqrt(a^2+b^2)",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.5 Hyperbolic sine functions.mac",
+   "index": 308,
+   "integrand": "exp(1)^(a+b*x)*csch(a+b*x)^5",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "(-4)/((1-exp(1)^(2*a+2*b*x))^4*b)+32/3/((1-exp(1)^(2*a+2*b*x))^3*b)+(-8)/((1-exp(1)^(2*a+2*b*x))^2*b)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.7 hyper^m (a+b sinh^n)^p.mac",
+   "index": 6,
+   "integrand": "csch(c+d*x)^2*(a+b*sinh(c+d*x)^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "b*x-a*coth(c+d*x)/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.7 hyper^m (a+b sinh^n)^p.mac",
+   "index": 40,
+   "integrand": "csch(c+d*x)^6/(a+b*sinh(c+d*x)^2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-(a^2+a*b+b^2)*coth(c+d*x)/(a^3*d)+1/3*(2*a+b)*coth(c+d*x)^3/(a^2*d)-1/5*coth(c+d*x)^5/(a*d)-b^3*atanh(sqrt(a-b)*tanh(c+d*x)/sqrt(a))/(a^(7/2)*d*sqrt(a-b))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.7 hyper^m (a+b sinh^n)^p.mac",
+   "index": 77,
+   "integrand": "csch(ee+f*x)*(a+b*sinh(ee+f*x)^2)^(3/2)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-a^(3/2)*atanh(cosh(ee+f*x)*sqrt(a)/sqrt(a-b+b*cosh(ee+f*x)^2))/f+1/2*(3*a-b)*atanh(cosh(ee+f*x)*sqrt(b)/sqrt(a-b+b*cosh(ee+f*x)^2))*sqrt(b)/f+1/2*b*cosh(ee+f*x)*sqrt(a-b+b*cosh(ee+f*x)^2)/f",
+   "params": [
+    "a",
+    "b",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.7 hyper^m (a+b sinh^n)^p.mac",
+   "index": 150,
+   "integrand": "sinh(c+d*x)^2*(a+b*sinh(c+d*x)^3)^2",
+   "variable": "x",
+   "steps": 11,
+   "antiderivative": "-1/2*a^2*x+35/128*b^2*x+2*a*b*cosh(c+d*x)/d-4/3*a*b*cosh(c+d*x)^3/d+2/5*a*b*cosh(c+d*x)^5/d+1/2*a^2*cosh(c+d*x)*sinh(c+d*x)/d-35/128*b^2*cosh(c+d*x)*sinh(c+d*x)/d+35/192*b^2*cosh(c+d*x)*sinh(c+d*x)^3/d-7/48*b^2*cosh(c+d*x)*sinh(c+d*x)^5/d+1/8*b^2*cosh(c+d*x)*sinh(c+d*x)^7/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.7 hyper^m (a+b sinh^n)^p.mac",
+   "index": 195,
+   "integrand": "sinh(c+d*x)^3*(a+b*sinh(c+d*x)^4)^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-(a+b)^2*cosh(c+d*x)/d+1/3*(a+b)*(a+5*b)*cosh(c+d*x)^3/d-2/5*b*(3*a+5*b)*cosh(c+d*x)^5/d+2/7*b*(a+5*b)*cosh(c+d*x)^7/d-5/9*b^2*cosh(c+d*x)^9/d+1/11*b^2*cosh(c+d*x)^11/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.7 hyper^m (a+b sinh^n)^p.mac",
+   "index": 227,
+   "integrand": "csch(c+d*x)^20*(a+b*sinh(c+d*x)^4)^3",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "(a+b)^3*coth(c+d*x)/d-(a+b)^2*(3*a+b)*coth(c+d*x)^3/d+3/5*(a+b)*(12*a^2+9*a*b+b^2)*coth(c+d*x)^5/d-1/7*(84*a^3+105*a^2*b+30*a*b^2+b^3)*coth(c+d*x)^7/d+1/3*a*(42*a^2+35*a*b+5*b^2)*coth(c+d*x)^9/d-3/11*a*(42*a^2+21*a*b+b^2)*coth(c+d*x)^11/d+21/13*a^2*(4*a+b)*coth(c+d*x)^13/d-1/5*a^2*(12*a+b)*coth(c+d*x)^15/d+9/17*a^3*coth(c+d*x)^17/d-1/19*a^3*coth(c+d*x)^19/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.7 hyper^m (a+b sinh^n)^p.mac",
+   "index": 259,
+   "integrand": "sinh(c+d*x)^6/(a-b*sinh(c+d*x)^4)^3",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "1/64*atanh(sqrt(sqrt(a)-sqrt(b))*tanh(c+d*x)/a^(1/4))*(4*a+3*b-10*sqrt(a)*sqrt(b))/(a^(5/4)*b^(3/2)*d*(sqrt(a)-sqrt(b))^(5/2))-1/64*atanh(sqrt(sqrt(a)+sqrt(b))*tanh(c+d*x)/a^(1/4))*(4*a+3*b+10*sqrt(a)*sqrt(b))/(a^(5/4)*b^(3/2)*d*(sqrt(a)+sqrt(b))^(5/2))+1/8*tanh(c+d*x)*(a*(a+3*b)-(a^2+6*a*b+b^2)*tanh(c+d*x)^2)/((a-b)^3*d*(a-2*a*tanh(c+d*x)^2+(a-b)*tanh(c+d*x)^4)^2)+1/32*tanh(c+d*x)*(2*a*(a^2-a*b-8*b^2)/(a-b)^3-(2*a^2+15*a*b+3*b^2)*tanh(c+d*x)^2/(a-b)^2)/(a*b*d*(a-2*a*tanh(c+d*x)^2+(a-b)*tanh(c+d*x)^4))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.7 hyper^m (a+b sinh^n)^p.mac",
+   "index": 296,
+   "integrand": "sech(c+d*x)*(a+b*sinh(c+d*x)^2)^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "(a-b)^2*atan(sinh(c+d*x))/d+(2*a-b)*b*sinh(c+d*x)/d+1/3*b^2*sinh(c+d*x)^3/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.7 hyper^m (a+b sinh^n)^p.mac",
+   "index": 328,
+   "integrand": "cosh(c+d*x)^6/(a+b*sinh(c+d*x)^2)^2",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-1/2*(4*a-5*b)*x/b^3+1/2*(a-b)^(3/2)*(4*a+b)*atanh(sqrt(a-b)*tanh(c+d*x)/sqrt(a))/(a^(3/2)*b^3*d)+1/2*cosh(c+d*x)*sinh(c+d*x)/(b*d*(a-(a-b)*tanh(c+d*x)^2))+1/2*(a-b)*(2*a-b)*tanh(c+d*x)/(a*b^2*d*(a-(a-b)*tanh(c+d*x)^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.7 hyper^m (a+b sinh^n)^p.mac",
+   "index": 365,
+   "integrand": "sech(ee+f*x)^5*(a+b*sinh(ee+f*x)^2)^(3/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "3/8*a^2*atan(sinh(ee+f*x)*sqrt(a-b)/sqrt(a+b*sinh(ee+f*x)^2))/(f*sqrt(a-b))+1/4*sech(ee+f*x)^3*(a+b*sinh(ee+f*x)^2)^(3/2)*tanh(ee+f*x)/f+3/8*a*sech(ee+f*x)*sqrt(a+b*sinh(ee+f*x)^2)*tanh(ee+f*x)/f",
+   "params": [
+    "a",
+    "b",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.7 hyper^m (a+b sinh^n)^p.mac",
+   "index": 434,
+   "integrand": "coth(ee+f*x)^4*sqrt(a+a*sinh(ee+f*x)^2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-2*csch(ee+f*x)*sech(ee+f*x)*sqrt(a*cosh(ee+f*x)^2)/f-1/3*csch(ee+f*x)^3*sech(ee+f*x)*sqrt(a*cosh(ee+f*x)^2)/f+sqrt(a*cosh(ee+f*x)^2)*tanh(ee+f*x)/f",
+   "params": [
+    "a",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.1 Hyperbolic sine/6.1.7 hyper^m (a+b sinh^n)^p.mac",
+   "index": 471,
+   "integrand": "coth(ee+f*x)^3*(a+b*sinh(ee+f*x)^2)^(3/2)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "1/6*(2*a+3*b)*(a+b*sinh(ee+f*x)^2)^(3/2)/(a*f)-1/2*csch(ee+f*x)^2*(a+b*sinh(ee+f*x)^2)^(5/2)/(a*f)-1/2*(2*a+3*b)*atanh(sqrt(a+b*sinh(ee+f*x)^2)/sqrt(a))*sqrt(a)/f+1/2*(2*a+3*b)*sqrt(a+b*sinh(ee+f*x)^2)/f",
+   "params": [
+    "a",
+    "b",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.2 Hyperbolic cosine/6.2.1 (c+d x)^m (a+b cosh)^n.mac",
+   "index": 10,
+   "integrand": "(c+d*x)*cosh(a+b*x)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*c*x+1/4*d*x^2-1/4*d*cosh(a+b*x)^2/b^2+1/2*(c+d*x)*cosh(a+b*x)*sinh(a+b*x)/b",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.2 Hyperbolic cosine/6.2.1 (c+d x)^m (a+b cosh)^n.mac",
+   "index": 155,
+   "integrand": "(c+d*x)^3*(a+b*cosh(ee+f*x))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "1/4*a*(c+d*x)^4/d-6*b*d^3*cosh(ee+f*x)/f^4-3*b*d*(c+d*x)^2*cosh(ee+f*x)/f^2+6*b*d^2*(c+d*x)*sinh(ee+f*x)/f^3+b*(c+d*x)^3*sinh(ee+f*x)/f",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.2 Hyperbolic cosine/6.2.3 (e x)^m (a+b cosh(c+d x^n))^p.mac",
+   "index": 21,
+   "integrand": "x*cosh(a+b*x^2)^7",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/2*sinh(a+b*x^2)/b+1/2*sinh(a+b*x^2)^3/b+3/10*sinh(a+b*x^2)^5/b+1/14*sinh(a+b*x^2)^7/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.2 Hyperbolic cosine/6.2.5 Hyperbolic cosine functions.mac",
+   "index": 35,
+   "integrand": "1/(1-cosh(c+d*x))",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-sinh(c+d*x)/(d*(1-cosh(c+d*x)))",
+   "params": [
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.2 Hyperbolic cosine/6.2.5 Hyperbolic cosine functions.mac",
+   "index": 67,
+   "integrand": "1/(a+b*cosh(c+d*x))^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "2*a*atanh(sqrt(a-b)*tanh(1/2*(c+d*x))/sqrt(a+b))/((a-b)^(3/2)*(a+b)^(3/2)*d)-b*sinh(c+d*x)/((a^2-b^2)*d*(a+b*cosh(c+d*x)))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.2 Hyperbolic cosine/6.2.5 Hyperbolic cosine functions.mac",
+   "index": 110,
+   "integrand": "(A+B*cosh(x))/(a+b*cosh(x))^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "2*(a*A-b*B)*atanh(sqrt(a-b)*tanh(1/2*x)/sqrt(a+b))/((a-b)^(3/2)*(a+b)^(3/2))-(A*b-a*B)*sinh(x)/((a^2-b^2)*(a+b*cosh(x)))",
+   "params": [
+    "A",
+    "B",
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.2 Hyperbolic cosine/6.2.5 Hyperbolic cosine functions.mac",
+   "index": 151,
+   "integrand": "sinh(x)^8/(a+a*cosh(x))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "5/16*x/a-5/16*cosh(x)*sinh(x)/a+5/24*cosh(x)*sinh(x)^3/a-1/6*cosh(x)*sinh(x)^5/a+1/7*sinh(x)^7/a",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.2 Hyperbolic cosine/6.2.5 Hyperbolic cosine functions.mac",
+   "index": 183,
+   "integrand": "coth(x)^2/(a+b*cosh(x))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "2*a^2*atanh(sqrt(a-b)*tanh(1/2*x)/sqrt(a+b))/((a-b)^(3/2)*(a+b)^(3/2))-a*coth(x)/(a^2-b^2)+b*csch(x)/(a^2-b^2)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.2 Hyperbolic cosine/6.2.5 Hyperbolic cosine functions.mac",
+   "index": 239,
+   "integrand": "cosh(a+b*ln(c*x^n))^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-2*b^2*n^2*x/(1-4*b^2*n^2)+x*cosh(a+b*ln(c*x^n))^2/(1-4*b^2*n^2)-2*b*n*x*cosh(a+b*ln(c*x^n))*sinh(a+b*ln(c*x^n))/(1-4*b^2*n^2)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "n"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.2 Hyperbolic cosine/6.2.5 Hyperbolic cosine functions.mac",
+   "index": 279,
+   "integrand": "exp(1)^x*sech(3*x)^2",
+   "variable": "x",
+   "steps": 13,
+   "antiderivative": "-2/3*exp(1)^x/(1+exp(1)^(6*x))+2/9*atan(exp(1)^x)-1/9*atan(-2*exp(1)^x+sqrt(3))+1/9*atan(2*exp(1)^x+sqrt(3))-1/6*ln(1+exp(1)^(2*x)-exp(1)^x*sqrt(3))/sqrt(3)+1/6*ln(1+exp(1)^(2*x)+exp(1)^x*sqrt(3))/sqrt(3)",
+   "params": []
+  },
+  {
+   "source": "6 Hyperbolic functions/6.2 Hyperbolic cosine/6.2.7 hyper^m (a+b cosh^n)^p.mac",
+   "index": 11,
+   "integrand": "csch(x)^5/(a+b*cosh(x)^2)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-1/8*(3*a^2+10*a*b+15*b^2)*atanh(cosh(x))/(a+b)^3+1/8*(3*a+7*b)*coth(x)*csch(x)/(a+b)^2-1/4*coth(x)*csch(x)^3/(a+b)-b^(5/2)*atan(cosh(x)*sqrt(b)/sqrt(a))/((a+b)^3*sqrt(a))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.2 Hyperbolic cosine/6.2.7 hyper^m (a+b cosh^n)^p.mac",
+   "index": 48,
+   "integrand": "(-1+cosh(x)^2)^(3/2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/3*coth(x)*(sinh(x)^2)^(3/2)-2/3*coth(x)*sqrt(sinh(x)^2)",
+   "params": []
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.1 (c+d x)^m (a+b tanh)^n.mac",
+   "index": 33,
+   "integrand": "(c+d*x)/(a+a*tanh(ee+f*x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/4*d*x/(a*f)+1/4*(c+d*x)^2/(a*d)-1/4*d/(f^2*(a+a*tanh(ee+f*x)))+1/2*(-c-d*x)/(f*(a+a*tanh(ee+f*x)))",
+   "params": [
+    "a",
+    "c",
+    "d",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.2 Hyperbolic tangent functions.mac",
+   "index": 27,
+   "integrand": "(-tanh(c+d*x)^2)^(3/2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-coth(c+d*x)*ln(cosh(c+d*x))*sqrt(-tanh(c+d*x)^2)/d+1/2*sqrt(-tanh(c+d*x)^2)*tanh(c+d*x)/d",
+   "params": [
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.2 Hyperbolic tangent functions.mac",
+   "index": 60,
+   "integrand": "1/(a+b*tanh(c+d*x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "a*x/(a^2-b^2)-b*ln(a*cosh(c+d*x)+b*sinh(c+d*x))/((a^2-b^2)*d)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.2 Hyperbolic tangent functions.mac",
+   "index": 93,
+   "integrand": "cosh(x)/(1+tanh(x))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "2/3*sinh(x)-1/3*cosh(x)/(1+tanh(x))",
+   "params": []
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.2 Hyperbolic tangent functions.mac",
+   "index": 127,
+   "integrand": "tanh(x)/(1+tanh(x))^(3/2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/2*atanh(sqrt(1+tanh(x))/sqrt(2))/sqrt(2)+(-1/2)/sqrt(1+tanh(x))+1/3/(1+tanh(x))^(3/2)",
+   "params": []
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.2 Hyperbolic tangent functions.mac",
+   "index": 161,
+   "integrand": "sqrt(a+b*tanh(x)^2+c*tanh(x)^4)*tanh(x)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-1/4*(b+2*c)*atanh(1/2*(b+2*c*tanh(x)^2)/(sqrt(c)*sqrt(a+b*tanh(x)^2+c*tanh(x)^4)))/sqrt(c)+1/2*atanh(1/2*(2*a+b+(b+2*c)*tanh(x)^2)/(sqrt(a+b+c)*sqrt(a+b*tanh(x)^2+c*tanh(x)^4)))*sqrt(a+b+c)-1/2*sqrt(a+b*tanh(x)^2+c*tanh(x)^4)",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.7 (d hyper)^m (a+b (c tanh)^n)^p.mac",
+   "index": 3,
+   "integrand": "sinh(c+d*x)*(a+b*tanh(c+d*x)^2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "(a+b)*cosh(c+d*x)/d+b*sech(c+d*x)/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.7 (d hyper)^m (a+b (c tanh)^n)^p.mac",
+   "index": 36,
+   "integrand": "csch(c+d*x)/(a+b*tanh(c+d*x)^2)^2",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-atanh(cosh(c+d*x))/(a^2*d)+1/2*b*sech(c+d*x)/(a*(a+b)*d*(a+b-b*sech(c+d*x)^2))+1/2*(3*a+2*b)*atanh(sech(c+d*x)*sqrt(b)/sqrt(a+b))*sqrt(b)/(a^2*(a+b)^(3/2)*d)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.7 (d hyper)^m (a+b (c tanh)^n)^p.mac",
+   "index": 72,
+   "integrand": "sinh(c+d*x)^4/(a+b*tanh(c+d*x)^3)",
+   "variable": "x",
+   "steps": 11,
+   "antiderivative": "-3/16*a*(a-5*b)*ln(1-tanh(c+d*x))/((a+b)^3*d)+3/16*a*(a+5*b)*ln(1+tanh(c+d*x))/((a-b)^3*d)-1/3*a^(2/3)*b^(1/3)*(a^4+7*a^2*b^2+b^4+3*a^(2/3)*b^(4/3)*(2*a^2+b^2))*ln(a^(1/3)+b^(1/3)*tanh(c+d*x))/((a^2-b^2)^3*d)+1/6*a^(2/3)*b^(1/3)*(a^4+7*a^2*b^2+b^4+3*a^(2/3)*b^(4/3)*(2*a^2+b^2))*ln(a^(2/3)-a^(1/3)*b^(1/3)*tanh(c+d*x)+b^(2/3)*tanh(c+d*x)^2)/((a^2-b^2)^3*d)-a^2*b*(a^2+2*b^2)*ln(a+b*tanh(c+d*x)^3)/((a^2-b^2)^3*d)-a^(2/3)*b^(1/3)*(a^2+3*a^(4/3)*b^(2/3)-b^2)*atan((a^(1/3)-2*b^(1/3)*tanh(c+d*x))/(a^(1/3)*sqrt(3)))/((a^(4/3)+a^(2/3)*b^(2/3)+b^(4/3))^3*d*sqrt(3))+1/16/((a+b)*d*(1-tanh(c+d*x))^2)+1/16*(-5*a+b)/((a+b)^2*d*(1-tanh(c+d*x)))+(-1/16)/((a-b)*d*(1+tanh(c+d*x))^2)+1/16*(5*a+b)/((a-b)^2*d*(1+tanh(c+d*x)))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.7 (d hyper)^m (a+b (c tanh)^n)^p.mac",
+   "index": 108,
+   "integrand": "sech(c+d*x)/(a+b*tanh(c+d*x)^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "atan(sinh(c+d*x)*sqrt(a+b)/sqrt(a))/(d*sqrt(a)*sqrt(a+b))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.7 (d hyper)^m (a+b (c tanh)^n)^p.mac",
+   "index": 140,
+   "integrand": "coth(c+d*x)^3*(a+b*tanh(c+d*x)^2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/2*a*coth(c+d*x)^2/d+(a+b)*ln(sinh(c+d*x))/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.7 (d hyper)^m (a+b (c tanh)^n)^p.mac",
+   "index": 172,
+   "integrand": "tanh(c+d*x)^2/(a+b*tanh(c+d*x)^2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "x/(a+b)-atan(sqrt(b)*tanh(c+d*x)/sqrt(a))*sqrt(a)/((a+b)*d*sqrt(b))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.7 (d hyper)^m (a+b (c tanh)^n)^p.mac",
+   "index": 204,
+   "integrand": "(-1+tanh(x)^2)^(3/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/2*atanh(tanh(x)/sqrt(-sech(x)^2))-1/2*sqrt(-sech(x)^2)*tanh(x)",
+   "params": []
+  },
+  {
+   "source": "6 Hyperbolic functions/6.3 Hyperbolic tangent/6.3.7 (d hyper)^m (a+b (c tanh)^n)^p.mac",
+   "index": 236,
+   "integrand": "coth(x)^3/sqrt(a+b*tanh(x)^2)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-1/2*(2*a-b)*atanh(sqrt(a+b*tanh(x)^2)/sqrt(a))/a^(3/2)+atanh(sqrt(a+b*tanh(x)^2)/sqrt(a+b))/sqrt(a+b)-1/2*coth(x)^2*sqrt(a+b*tanh(x)^2)/a",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.4 Hyperbolic cotangent/6.4.1 (c+d x)^m (a+b coth)^n.mac",
+   "index": 23,
+   "integrand": "(c+d*x)/(a+a*coth(ee+f*x))^2",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "3/16*d*x/(a^2*f)-1/8*d*x^2/a^2+1/4*x*(c+d*x)/a^2-1/16*d/(f^2*(a+a*coth(ee+f*x))^2)+1/4*(-c-d*x)/(f*(a+a*coth(ee+f*x))^2)-3/16*d/(f^2*(a^2+a^2*coth(ee+f*x)))+1/4*(-c-d*x)/(f*(a^2+a^2*coth(ee+f*x)))",
+   "params": [
+    "a",
+    "c",
+    "d",
+    "ee",
+    "f"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.4 Hyperbolic cotangent/6.4.2 Hyperbolic cotangent functions.mac",
+   "index": 32,
+   "integrand": "(b*coth(c+d*x)^3)^(4/3)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-b*(b*coth(c+d*x)^3)^(1/3)/d-1/3*b*coth(c+d*x)^2*(b*coth(c+d*x)^3)^(1/3)/d+b*x*(b*coth(c+d*x)^3)^(1/3)*tanh(c+d*x)",
+   "params": [
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.4 Hyperbolic cotangent/6.4.2 Hyperbolic cotangent functions.mac",
+   "index": 76,
+   "integrand": "(a+b*coth(c+d*x))^5",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "a*(a^4+10*a^2*b^2+5*b^4)*x-4*a*b^2*(a^2+b^2)*coth(c+d*x)/d-1/2*b*(3*a^2+b^2)*(a+b*coth(c+d*x))^2/d-2/3*a*b*(a+b*coth(c+d*x))^3/d-1/4*b*(a+b*coth(c+d*x))^4/d+b*(5*a^4+10*a^2*b^2+b^4)*ln(sinh(c+d*x))/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.4 Hyperbolic cotangent/6.4.2 Hyperbolic cotangent functions.mac",
+   "index": 108,
+   "integrand": "sech(x)/(1+coth(x))",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "atan(sinh(x))+cosh(x)-sinh(x)",
+   "params": []
+  },
+  {
+   "source": "6 Hyperbolic functions/6.4 Hyperbolic cotangent/6.4.2 Hyperbolic cotangent functions.mac",
+   "index": 141,
+   "integrand": "tanh(x)^2/(a+b*coth(x))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "a*x/(a^2-b^2)-b*ln(cosh(x))/a^2-b^3*ln(b*cosh(x)+a*sinh(x))/(a^2*(a^2-b^2))-tanh(x)/a",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.4 Hyperbolic cotangent/6.4.7 (d hyper)^m (a+b (c coth)^n)^p.mac",
+   "index": 0,
+   "integrand": "(a+b*coth(c+d*x)^2)^5",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "(a+b)^5*x-b*(5*a^4+10*a^3*b+10*a^2*b^2+5*a*b^3+b^4)*coth(c+d*x)/d-1/3*b^2*(10*a^3+10*a^2*b+5*a*b^2+b^3)*coth(c+d*x)^3/d-1/5*b^3*(10*a^2+5*a*b+b^2)*coth(c+d*x)^5/d-1/7*b^4*(5*a+b)*coth(c+d*x)^7/d-1/9*b^5*coth(c+d*x)^9/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.4 Hyperbolic cotangent/6.4.7 (d hyper)^m (a+b (c coth)^n)^p.mac",
+   "index": 32,
+   "integrand": "coth(x)^2/sqrt(a+b*coth(x)^2)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-atanh(coth(x)*sqrt(b)/sqrt(a+b*coth(x)^2))/sqrt(b)+atanh(coth(x)*sqrt(a+b)/sqrt(a+b*coth(x)^2))/sqrt(a+b)",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.5 Hyperbolic secant/6.5.2 (e x)^m (a+b sech(c+d x^n))^p.mac",
+   "index": 58,
+   "integrand": "(a+b*sech(c+d*sqrt(x)))^2/sqrt(x)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "4*a*b*atan(sinh(c+d*sqrt(x)))/d+2*a^2*sqrt(x)+2*b^2*tanh(c+d*sqrt(x))/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.5 Hyperbolic secant/6.5.3 Hyperbolic secant functions.mac",
+   "index": 46,
+   "integrand": "(a*sech(x)^4)^(3/2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "a*cosh(x)*sinh(x)*sqrt(a*sech(x)^4)-2/3*a*sinh(x)^2*sqrt(a*sech(x)^4)*tanh(x)+1/5*a*sinh(x)^2*sqrt(a*sech(x)^4)*tanh(x)^3",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.5 Hyperbolic secant/6.5.3 Hyperbolic secant functions.mac",
+   "index": 78,
+   "integrand": "(a+a*sech(c+d*x))^(3/2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "2*a^(3/2)*atanh(sqrt(a)*tanh(c+d*x)/sqrt(a+a*sech(c+d*x)))/d+2*a^2*tanh(c+d*x)/(d*sqrt(a+a*sech(c+d*x)))",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.5 Hyperbolic secant/6.5.3 Hyperbolic secant functions.mac",
+   "index": 111,
+   "integrand": "coth(x)^4/(a+a*sech(x))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "x/a-1/15*coth(x)*(15-8*sech(x))/a-1/15*coth(x)^3*(5-4*sech(x))/a-1/5*coth(x)^5*(1-sech(x))/a",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.5 Hyperbolic secant/6.5.3 Hyperbolic secant functions.mac",
+   "index": 154,
+   "integrand": "exp(1)^(c*(a+b*x))/sqrt(sech(a*c+b*c*x)^2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/4*exp(1)^(2*c*(a+b*x))*sech(a*c+b*c*x)/(b*c*sqrt(sech(a*c+b*c*x)^2))+1/2*x*sech(a*c+b*c*x)/sqrt(sech(a*c+b*c*x)^2)",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.5 Hyperbolic secant/6.5.7 (d hyper)^m (a+b (c sech)^n)^p.mac",
+   "index": 7,
+   "integrand": "csch(c+d*x)^4*(a+b*sech(c+d*x)^2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "(a+2*b)*coth(c+d*x)/d-1/3*(a+b)*coth(c+d*x)^3/d+b*tanh(c+d*x)/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.5 Hyperbolic secant/6.5.7 (d hyper)^m (a+b (c sech)^n)^p.mac",
+   "index": 40,
+   "integrand": "sinh(c+d*x)^4/(a+b*sech(c+d*x)^2)^3",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "3/8*(a^2+12*a*b+16*b^2)*x/a^5-3/8*(5*a^2+20*a*b+16*b^2)*atanh(sqrt(b)*tanh(c+d*x)/sqrt(a+b))*sqrt(b)/(a^5*d*sqrt(a+b))-1/8*(5*a+8*b)*cosh(c+d*x)*sinh(c+d*x)/(a^2*d*(a+b-b*tanh(c+d*x)^2)^2)+1/4*cosh(c+d*x)^3*sinh(c+d*x)/(a*d*(a+b-b*tanh(c+d*x)^2)^2)-1/8*b*(7*a+12*b)*tanh(c+d*x)/(a^3*d*(a+b-b*tanh(c+d*x)^2)^2)-3/2*b*(a+2*b)*tanh(c+d*x)/(a^4*d*(a+b-b*tanh(c+d*x)^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.5 Hyperbolic secant/6.5.7 (d hyper)^m (a+b (c sech)^n)^p.mac",
+   "index": 74,
+   "integrand": "cosh(c+d*x)^2/(a+b*sech(c+d*x)^2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/2*(a-2*b)*x/a^2+1/2*cosh(c+d*x)*sinh(c+d*x)/(a*d)+b^(3/2)*atanh(sqrt(b)*tanh(c+d*x)/sqrt(a+b))/(a^2*d*sqrt(a+b))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.5 Hyperbolic secant/6.5.7 (d hyper)^m (a+b (c sech)^n)^p.mac",
+   "index": 106,
+   "integrand": "coth(c+d*x)*(a+b*sech(c+d*x)^2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-b*ln(cosh(c+d*x))/d+(a+b)*ln(sinh(c+d*x))/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.5 Hyperbolic secant/6.5.7 (d hyper)^m (a+b (c sech)^n)^p.mac",
+   "index": 138,
+   "integrand": "tanh(c+d*x)^4/(a+b*sech(c+d*x)^2)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "x/a-(a+b)^(3/2)*atanh(sqrt(b)*tanh(c+d*x)/sqrt(a+b))/(a*b^(3/2)*d)+tanh(c+d*x)/(b*d)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.5 Hyperbolic secant/6.5.7 (d hyper)^m (a+b (c sech)^n)^p.mac",
+   "index": 170,
+   "integrand": "sqrt(1-sech(x)^2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "coth(x)*ln(cosh(x))*sqrt(tanh(x)^2)",
+   "params": []
+  },
+  {
+   "source": "6 Hyperbolic functions/6.5 Hyperbolic secant/6.5.7 (d hyper)^m (a+b (c sech)^n)^p.mac",
+   "index": 202,
+   "integrand": "tanh(x)^5/(a+b*sech(x)^2)^(3/2)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "atanh(sqrt(a+b*sech(x)^2)/sqrt(a))/a^(3/2)-(a+b)^2/(a*b^2*sqrt(a+b*sech(x)^2))-sqrt(a+b*sech(x)^2)/b^2",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.6 Hyperbolic cosecant/6.6.2 (e x)^m (a+b csch(c+d x^n))^p.mac",
+   "index": 62,
+   "integrand": "1/((a+b*csch(c+d*sqrt(x)))*sqrt(x))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "4*b*atanh((a-b*tanh(1/2*(c+d*sqrt(x))))/sqrt(a^2+b^2))/(a*d*sqrt(a^2+b^2))+2*sqrt(x)/a",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.6 Hyperbolic cosecant/6.6.3 Hyperbolic cosecant functions.mac",
+   "index": 47,
+   "integrand": "1/(a*csch(x)^4)^(5/2)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "63/256*coth(x)/(a^2*sqrt(a*csch(x)^4))-63/256*x*csch(x)^2/(a^2*sqrt(a*csch(x)^4))-21/128*cosh(x)*sinh(x)/(a^2*sqrt(a*csch(x)^4))+21/160*cosh(x)*sinh(x)^3/(a^2*sqrt(a*csch(x)^4))-9/80*cosh(x)*sinh(x)^5/(a^2*sqrt(a*csch(x)^4))+1/10*cosh(x)*sinh(x)^7/(a^2*sqrt(a*csch(x)^4))",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.6 Hyperbolic cosecant/6.6.3 Hyperbolic cosecant functions.mac",
+   "index": 122,
+   "integrand": "coth(x)^6/(a+b*csch(x))",
+   "variable": "x",
+   "steps": 16,
+   "antiderivative": "x/a-3/8*atanh(cosh(x))/b+1/2*(a^2+3*b^2)*atanh(cosh(x))/b^3-(a^4+3*a^2*b^2+3*b^4)*atanh(cosh(x))/b^5+2*(a^2+b^2)^(5/2)*atanh((a-b*tanh(1/2*x))/sqrt(a^2+b^2))/(a*b^5)-a*coth(x)/b^2+a*(a^2+3*b^2)*coth(x)/b^4+1/3*a*coth(x)^3/b^2+3/8*coth(x)*csch(x)/b-1/2*(a^2+3*b^2)*coth(x)*csch(x)/b^3-1/4*coth(x)*csch(x)^3/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.6 Hyperbolic cosecant/6.6.7 (d hyper)^m (a+b (c csch)^n)^p.mac",
+   "index": 1,
+   "integrand": "(a+b*csch(c+d*x)^2)^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "a^3*x-b*(3*a^2-3*a*b+b^2)*coth(c+d*x)/d-1/3*(3*a-2*b)*b^2*coth(c+d*x)^3/d-1/5*b^3*coth(c+d*x)^5/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 7,
+   "integrand": "cosh(a+b*x)*sinh(a+b*x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*sinh(a+b*x)^2/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 39,
+   "integrand": "csch(a+b*x)^4*sech(a+b*x)^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2*coth(a+b*x)/b-1/3*coth(a+b*x)^3/b+tanh(a+b*x)/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 71,
+   "integrand": "sinh(a+b*x)*tanh(a+b*x)^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-3/2*atan(sinh(a+b*x))/b+3/2*sinh(a+b*x)/b-1/2*sinh(a+b*x)*tanh(a+b*x)^2/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 103,
+   "integrand": "cosh(a+b*x)*coth(a+b*x)^4",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-2*csch(a+b*x)/b-1/3*csch(a+b*x)^3/b+sinh(a+b*x)/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 135,
+   "integrand": "tanh(c-b*x)*tanh(a+b*x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-x-coth(a+c)*ln(cosh(c-b*x))/b+coth(a+c)*ln(cosh(a+b*x))/b",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 167,
+   "integrand": "sinh(a+b*x)*sinh(c+d*x)^2",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/2*cosh(a+b*x)/b+1/4*cosh(a-2*c+(b-2*d)*x)/(b-2*d)+1/4*cosh(a+2*c+(b+2*d)*x)/(b+2*d)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 205,
+   "integrand": "coth(2*x)*sinh(x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/2*atan(sinh(x))+sinh(x)",
+   "params": []
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 239,
+   "integrand": "cosh(x)*sech(2*x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "atan(sinh(x)*sqrt(2))/sqrt(2)",
+   "params": []
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 300,
+   "integrand": "x*cosh(a+b*x)^3*sinh(a+b*x)^2",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "1/8*cosh(a+b*x)/b^2-1/144*cosh(3*a+3*b*x)/b^2-1/400*cosh(5*a+5*b*x)/b^2-1/8*x*sinh(a+b*x)/b+1/48*x*sinh(3*a+3*b*x)/b+1/80*x*sinh(5*a+5*b*x)/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 426,
+   "integrand": "x*cosh(a+b*x)*csch(a+b*x)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-atanh(cosh(a+b*x))/b^2-x*csch(a+b*x)/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 570,
+   "integrand": "x*(b+a*cosh(x))/(a+b*cosh(x))^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-ln(a+b*cosh(x))/b+x*sinh(x)/(a+b*cosh(x))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 608,
+   "integrand": "1/(a*cosh(c+d*x)-a*sinh(c+d*x))",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "1/(d*(a*cosh(c+d*x)-a*sinh(c+d*x)))",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 660,
+   "integrand": "1/(coth(x)+csch(x))^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "2/(1+cosh(x))+ln(1+cosh(x))",
+   "params": []
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 694,
+   "integrand": "coth(x)/(b*cosh(x)+a*sinh(x))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-atanh(cosh(x))/b+a*atanh((a*cosh(x)+b*sinh(x))/sqrt(a^2-b^2))/(b*sqrt(a^2-b^2))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 728,
+   "integrand": "(A+B*cosh(x))/(b*cosh(x)+c*sinh(x))^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/2*A*atan((c*cosh(x)+b*sinh(x))/sqrt(b^2-c^2))/(b^2-c^2)^(3/2)+1/2*(B*c+A*c*cosh(x)+A*b*sinh(x))/((b^2-c^2)*(b*cosh(x)+c*sinh(x))^2)+(b*B*c*cosh(x)+b^2*B*sinh(x))/((b^2-c^2)^2*(b*cosh(x)+c*sinh(x)))",
+   "params": [
+    "A",
+    "B",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 768,
+   "integrand": "(b*cosh(x)+c*sinh(x)+sqrt(b^2-c^2))^(3/2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "8/3*(c*cosh(x)+b*sinh(x))*sqrt(b^2-c^2)/sqrt(b*cosh(x)+c*sinh(x)+sqrt(b^2-c^2))+2/3*(c*cosh(x)+b*sinh(x))*sqrt(b*cosh(x)+c*sinh(x)+sqrt(b^2-c^2))",
+   "params": [
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 807,
+   "integrand": "1/(cosh(x)^2+sinh(x)^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "atan(tanh(x))",
+   "params": []
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 857,
+   "integrand": "1/(a+b*cosh(c+d*x)*sinh(c+d*x))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-2*atanh((b-2*a*tanh(c+d*x))/sqrt(4*a^2+b^2))/(d*sqrt(4*a^2+b^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 915,
+   "integrand": "exp(1)^(a+b*x)*cosh(a+b*x)^3*csch(a+b*x)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/4*exp(1)^(-a-b*x)/b+exp(1)^(a+b*x)/b+1/12*exp(1)^(3*a+3*b*x)/b-2*atanh(exp(1)^(a+b*x))/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 947,
+   "integrand": "exp(1)^(c+d*x)*cosh(a+b*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "-exp(1)^(c+d*x)*d*cosh(a+b*x)/(b^2-d^2)+exp(1)^(c+d*x)*b*sinh(a+b*x)/(b^2-d^2)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "6 Hyperbolic functions/6.7 Miscellaneous/6.7.1 Hyperbolic functions.mac",
+   "index": 994,
+   "integrand": "sech(x)^2*(2+tanh(x)^2)/(1+tanh(x)^3)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "ln(1+tanh(x))-2*atan((1-2*tanh(x))/sqrt(3))/sqrt(3)",
+   "params": []
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.1 Inverse hyperbolic sine/7.1.2 (d x)^m (a+b arcsinh(c x))^n.mac",
+   "index": 0,
+   "integrand": "x^4*asinh(a*x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "2/15*(1+a^2*x^2)^(3/2)/a^5-1/25*(1+a^2*x^2)^(5/2)/a^5+1/5*x^5*asinh(a*x)-1/5*sqrt(1+a^2*x^2)/a^5",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.1 Inverse hyperbolic sine/7.1.4a (f x)^m (d+c^2 d x^2)^p (a+b arcsinh(c x))^n.mac",
+   "index": 13,
+   "integrand": "(d+c^2*d*x^2)^2*(a+b*asinh(c*x))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-4/45*b*d^2*(1+c^2*x^2)^(3/2)/c-1/25*b*d^2*(1+c^2*x^2)^(5/2)/c+d^2*x*(a+b*asinh(c*x))+2/3*c^2*d^2*x^3*(a+b*asinh(c*x))+1/5*c^4*d^2*x^5*(a+b*asinh(c*x))-8/15*b*d^2*sqrt(1+c^2*x^2)/c",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.1 Inverse hyperbolic sine/7.1.4a (f x)^m (d+c^2 d x^2)^p (a+b arcsinh(c x))^n.mac",
+   "index": 88,
+   "integrand": "(a+b*asinh(c*x))/(x^4*sqrt(d+c^2*d*x^2))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/6*b*c*sqrt(1+c^2*x^2)/(x^2*sqrt(d+c^2*d*x^2))-2/3*b*c^3*ln(x)*sqrt(1+c^2*x^2)/sqrt(d+c^2*d*x^2)-1/3*(a+b*asinh(c*x))*sqrt(d+c^2*d*x^2)/(d*x^3)+2/3*c^2*(a+b*asinh(c*x))*sqrt(d+c^2*d*x^2)/(d*x)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.1 Inverse hyperbolic sine/7.1.4a (f x)^m (d+c^2 d x^2)^p (a+b arcsinh(c x))^n.mac",
+   "index": 154,
+   "integrand": "(d+c^2*d*x^2)^3*(a+b*asinh(c*x))^2",
+   "variable": "x",
+   "steps": 14,
+   "antiderivative": "4322/3675*b^2*d^3*x+1514/11025*b^2*c^2*d^3*x^3+234/6125*b^2*c^4*d^3*x^5+2/343*b^2*c^6*d^3*x^7-16/105*b*d^3*(1+c^2*x^2)^(3/2)*(a+b*asinh(c*x))/c-12/175*b*d^3*(1+c^2*x^2)^(5/2)*(a+b*asinh(c*x))/c-2/49*b*d^3*(1+c^2*x^2)^(7/2)*(a+b*asinh(c*x))/c+16/35*d^3*x*(a+b*asinh(c*x))^2+8/35*d^3*x*(1+c^2*x^2)*(a+b*asinh(c*x))^2+6/35*d^3*x*(1+c^2*x^2)^2*(a+b*asinh(c*x))^2+1/7*d^3*x*(1+c^2*x^2)^3*(a+b*asinh(c*x))^2-32/35*b*d^3*(a+b*asinh(c*x))*sqrt(1+c^2*x^2)/c",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.1 Inverse hyperbolic sine/7.1.4a (f x)^m (d+c^2 d x^2)^p (a+b arcsinh(c x))^n.mac",
+   "index": 317,
+   "integrand": "1/(asinh(a*x)*sqrt(1+a^2*x^2))",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "ln(asinh(a*x))/a",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.1 Inverse hyperbolic sine/7.1.5 Inverse hyperbolic sine functions.mac",
+   "index": 38,
+   "integrand": "(f+g*x)^3*(d+c^2*d*x^2)^(3/2)*(a+b*asinh(c*x))",
+   "variable": "x",
+   "steps": 24,
+   "antiderivative": "3/8*d*f^3*x*(a+b*asinh(c*x))*sqrt(d+c^2*d*x^2)+3/16*d*f*g^2*x*(a+b*asinh(c*x))*sqrt(d+c^2*d*x^2)/c^2+3/8*d*f*g^2*x^3*(a+b*asinh(c*x))*sqrt(d+c^2*d*x^2)+1/4*d*f^3*x*(1+c^2*x^2)*(a+b*asinh(c*x))*sqrt(d+c^2*d*x^2)+1/2*d*f*g^2*x^3*(1+c^2*x^2)*(a+b*asinh(c*x))*sqrt(d+c^2*d*x^2)+3/5*d*f^2*g*(1+c^2*x^2)^2*(a+b*asinh(c*x))*sqrt(d+c^2*d*x^2)/c^2-1/5*d*g^3*(1+c^2*x^2)^2*(a+b*asinh(c*x))*sqrt(d+c^2*d*x^2)/c^4+1/7*d*g^3*(1+c^2*x^2)^3*(a+b*asinh(c*x))*sqrt(d+c^2*d*x^2)/c^4-3/5*b*d*f^2*g*x*sqrt(d+c^2*d*x^2)/(c*sqrt(1+c^2*x^2))+2/35*b*d*g^3*x*sqrt(d+c^2*d*x^2)/(c^3*sqrt(1+c^2*x^2))-5/16*b*c*d*f^3*x^2*sqrt(d+c^2*d*x^2)/sqrt(1+c^2*x^2)-3/32*b*d*f*g^2*x^2*sqrt(d+c^2*d*x^2)/(c*sqrt(1+c^2*x^2))-2/5*b*c*d*f^2*g*x^3*sqrt(d+c^2*d*x^2)/sqrt(1+c^2*x^2)-1/105*b*d*g^3*x^3*sqrt(d+c^2*d*x^2)/(c*sqrt(1+c^2*x^2))-1/16*b*c^3*d*f^3*x^4*sqrt(d+c^2*d*x^2)/sqrt(1+c^2*x^2)-7/32*b*c*d*f*g^2*x^4*sqrt(d+c^2*d*x^2)/sqrt(1+c^2*x^2)-3/25*b*c^3*d*f^2*g*x^5*sqrt(d+c^2*d*x^2)/sqrt(1+c^2*x^2)-8/175*b*c*d*g^3*x^5*sqrt(d+c^2*d*x^2)/sqrt(1+c^2*x^2)-1/12*b*c^3*d*f*g^2*x^6*sqrt(d+c^2*d*x^2)/sqrt(1+c^2*x^2)-1/49*b*c^3*d*g^3*x^7*sqrt(d+c^2*d*x^2)/sqrt(1+c^2*x^2)+3/16*d*f^3*(a+b*asinh(c*x))^2*sqrt(d+c^2*d*x^2)/(b*c*sqrt(1+c^2*x^2))-3/32*d*f*g^2*(a+b*asinh(c*x))^2*sqrt(d+c^2*d*x^2)/(b*c^3*sqrt(1+c^2*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "f",
+    "g"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.1 Inverse hyperbolic sine/7.1.5 Inverse hyperbolic sine functions.mac",
+   "index": 130,
+   "integrand": "(a+b*asinh(c+d*x))^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "2*b^2*x+(c+d*x)*(a+b*asinh(c+d*x))^2/d-2*b*(a+b*asinh(c+d*x))*sqrt(1+(c+d*x)^2)/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.1 Inverse hyperbolic sine/7.1.5 Inverse hyperbolic sine functions.mac",
+   "index": 305,
+   "integrand": "asinh(a/x)/x^4",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/9*(1+a^2/x^2)^(3/2)/a^3-1/3*acsch(x/a)/x^3-1/3*sqrt(1+a^2/x^2)/a^3",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.2 Inverse hyperbolic cosine/7.2.2 (d x)^m (a+b arccosh(c x))^n.mac",
+   "index": 32,
+   "integrand": "x^4*acosh(a*x)^4",
+   "variable": "x",
+   "steps": 19,
+   "antiderivative": "16576/5625*x/a^4+1088/16875*x^3/a^2+24/3125*x^5+32/25*x*acosh(a*x)^2/a^4+16/75*x^3*acosh(a*x)^2/a^2+12/125*x^5*acosh(a*x)^2+1/5*x^5*acosh(a*x)^4-16576/5625*acosh(a*x)*sqrt(-1+a*x)*sqrt(1+a*x)/a^5-1088/5625*x^2*acosh(a*x)*sqrt(-1+a*x)*sqrt(1+a*x)/a^3-24/625*x^4*acosh(a*x)*sqrt(-1+a*x)*sqrt(1+a*x)/a-32/75*acosh(a*x)^3*sqrt(-1+a*x)*sqrt(1+a*x)/a^5-16/75*x^2*acosh(a*x)^3*sqrt(-1+a*x)*sqrt(1+a*x)/a^3-4/25*x^4*acosh(a*x)^3*sqrt(-1+a*x)*sqrt(1+a*x)/a",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.2 Inverse hyperbolic cosine/7.2.4a (f x)^m (d-c^2 d x^2)^p (a+b arccosh(c x))^n.mac",
+   "index": 74,
+   "integrand": "(d-c^2*d*x^2)^(3/2)*(a+b*acosh(c*x))/x^4",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "c^2*d*(a+b*acosh(c*x))*sqrt(d-c^2*d*x^2)/x-1/3*d*(1-c*x)*(1+c*x)*(a+b*acosh(c*x))*sqrt(d-c^2*d*x^2)/x^3-1/6*b*c*d*sqrt(d-c^2*d*x^2)/(x^2*sqrt(-1+c*x)*sqrt(1+c*x))-1/2*c^3*d*(a+b*acosh(c*x))^2*sqrt(d-c^2*d*x^2)/(b*sqrt(-1+c*x)*sqrt(1+c*x))-4/3*b*c^3*d*ln(x)*sqrt(d-c^2*d*x^2)/(sqrt(-1+c*x)*sqrt(1+c*x))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.2 Inverse hyperbolic cosine/7.2.4a (f x)^m (d-c^2 d x^2)^p (a+b arccosh(c x))^n.mac",
+   "index": 124,
+   "integrand": "x^4*(a+b*acosh(c*x))/(d-c^2*d*x^2)^(5/2)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-x*(a+b*acosh(c*x))/(c^4*d^2*sqrt(d-c^2*d*x^2))+1/3*x^3*(a+b*acosh(c*x))/(c^2*d^2*(1-c*x)*(1+c*x)*sqrt(d-c^2*d*x^2))+1/6*b*sqrt(-1+c*x)*sqrt(1+c*x)/(c^5*d^2*(1-c^2*x^2)*sqrt(d-c^2*d*x^2))+1/2*(a+b*acosh(c*x))^2*sqrt(-1+c*x)*sqrt(1+c*x)/(b*c^5*d^2*sqrt(d-c^2*d*x^2))+2/3*b*ln(1-c^2*x^2)*sqrt(-1+c*x)*sqrt(1+c*x)/(c^5*d^2*sqrt(d-c^2*d*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.2 Inverse hyperbolic cosine/7.2.4a (f x)^m (d-c^2 d x^2)^p (a+b arccosh(c x))^n.mac",
+   "index": 223,
+   "integrand": "x*acosh(a*x)^2/sqrt(1-a^2*x^2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-2*(1-a*x)*(1+a*x)/(a^2*sqrt(1-a^2*x^2))-(1-a*x)*(1+a*x)*acosh(a*x)^2/(a^2*sqrt(1-a^2*x^2))-2*x*acosh(a*x)*sqrt(-1+a*x)*sqrt(1+a*x)/(a*sqrt(1-a^2*x^2))",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.2 Inverse hyperbolic cosine/7.2.4b (f x)^m (d+e x^2)^p (a+b arccosh(c x))^n.mac",
+   "index": 13,
+   "integrand": "(d+ee*x^2)^2*(a+b*acosh(c*x))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "d^2*x*(a+b*acosh(c*x))+2/3*d*ee*x^3*(a+b*acosh(c*x))+1/5*ee^2*x^5*(a+b*acosh(c*x))+1/15*b*(15*c^4*d^2+10*c^2*d*ee+3*ee^2)*(1-c^2*x^2)/(c^5*sqrt(-1+c*x)*sqrt(1+c*x))-2/45*b*ee*(5*c^2*d+3*ee)*(1-c^2*x^2)^2/(c^5*sqrt(-1+c*x)*sqrt(1+c*x))+1/25*b*ee^2*(1-c^2*x^2)^3/(c^5*sqrt(-1+c*x)*sqrt(1+c*x))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.2 Inverse hyperbolic cosine/7.2.5 Inverse hyperbolic cosine functions.mac",
+   "index": 43,
+   "integrand": "(c+d*x^2)*acosh(a*x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "c*x*acosh(a*x)+1/3*d*x^3*acosh(a*x)-1/9*(9*a^2*c+2*d)*sqrt(-1+a*x)*sqrt(1+a*x)/a^3-1/9*d*x^2*sqrt(-1+a*x)*sqrt(1+a*x)/a",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.2 Inverse hyperbolic cosine/7.2.5 Inverse hyperbolic cosine functions.mac",
+   "index": 103,
+   "integrand": "(c*ee+d*ee*x)*(a+b*acosh(c+d*x))^2",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "1/4*b^2*ee*(c+d*x)^2/d-1/4*ee*(a+b*acosh(c+d*x))^2/d+1/2*ee*(c+d*x)^2*(a+b*acosh(c+d*x))^2/d-1/2*b*ee*(c+d*x)*(a+b*acosh(c+d*x))*sqrt(-1+c+d*x)*sqrt(1+c+d*x)/d",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.2 Inverse hyperbolic cosine/7.2.5 Inverse hyperbolic cosine functions.mac",
+   "index": 292,
+   "integrand": "1/(acosh(sqrt(1+b*x^2))*sqrt(1+b*x^2))",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "ln(acosh(sqrt(1+b*x^2)))*sqrt(-1+sqrt(1+b*x^2))*sqrt(1+sqrt(1+b*x^2))/(b*x)",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.2 (d x)^m (a+b arctanh(c x^n))^p.mac",
+   "index": 65,
+   "integrand": "x^3*(a+b*atanh(c*x^2))^2",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "1/2*a*b*x^2/c+1/2*b^2*x^2*atanh(c*x^2)/c-1/4*(a+b*atanh(c*x^2))^2/c^2+1/4*x^4*(a+b*atanh(c*x^2))^2+1/4*b^2*ln(1-c^2*x^4)/c^2",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.2 (d x)^m (a+b arctanh(c x^n))^p.mac",
+   "index": 156,
+   "integrand": "x^7*(a+b*atanh(c/x^2))",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "1/8*b*c^3*x^2+1/24*b*c*x^6+1/8*x^8*(a+b*atanh(c/x^2))-1/8*b*c^4*atanh(x^2/c)",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.2 (d x)^m (a+b arctanh(c x^n))^p.mac",
+   "index": 220,
+   "integrand": "x^2*(a+b*atanh(c*x^(3/2)))^2",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "2/3*a*b*x^(3/2)/c+2/3*b^2*x^(3/2)*atanh(c*x^(3/2))/c-1/3*(a+b*atanh(c*x^(3/2)))^2/c^2+1/3*x^3*(a+b*atanh(c*x^(3/2)))^2+1/3*b^2*ln(1-c^2*x^3)/c^2",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.4 u (a+b arctanh(c x))^p.mac",
+   "index": 30,
+   "integrand": "x^3*(d+c*d*x)^4*(a+b*atanh(c*x))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "11/8*b*d^4*x/c^3+24/35*b*d^4*x^2/c^2+11/24*b*d^4*x^3/c+12/35*b*d^4*x^4+9/40*b*c*d^4*x^5+2/21*b*c^2*d^4*x^6+1/56*b*c^3*d^4*x^7+1/4*d^4*x^4*(a+b*atanh(c*x))+4/5*c*d^4*x^5*(a+b*atanh(c*x))+c^2*d^4*x^6*(a+b*atanh(c*x))+4/7*c^3*d^4*x^7*(a+b*atanh(c*x))+1/8*c^4*d^4*x^8*(a+b*atanh(c*x))+769/560*b*d^4*ln(1-c*x)/c^4-1/560*b*d^4*ln(1+c*x)/c^4",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.4 u (a+b arctanh(c x))^p.mac",
+   "index": 205,
+   "integrand": "x*(1-a^2*x^2)^2*atanh(a*x)^2",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "2/45*(1-a^2*x^2)/a^2+1/60*(1-a^2*x^2)^2/a^2+8/45*x*atanh(a*x)/a+4/45*x*(1-a^2*x^2)*atanh(a*x)/a+1/15*x*(1-a^2*x^2)^2*atanh(a*x)/a-1/6*(1-a^2*x^2)^3*atanh(a*x)^2/a^2+4/45*ln(1-a^2*x^2)/a^2",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.4 u (a+b arctanh(c x))^p.mac",
+   "index": 346,
+   "integrand": "atanh(a*x)^3/(1-a^2*x^2)^4",
+   "variable": "x",
+   "steps": 13,
+   "antiderivative": "(-1/216)/(a*(1-a^2*x^2)^3)+(-65/2304)/(a*(1-a^2*x^2)^2)+(-245/768)/(a*(1-a^2*x^2))+1/36*x*atanh(a*x)/(1-a^2*x^2)^3+65/576*x*atanh(a*x)/(1-a^2*x^2)^2+245/384*x*atanh(a*x)/(1-a^2*x^2)+245/768*atanh(a*x)^2/a-1/12*atanh(a*x)^2/(a*(1-a^2*x^2)^3)-5/32*atanh(a*x)^2/(a*(1-a^2*x^2)^2)-15/32*atanh(a*x)^2/(a*(1-a^2*x^2))+1/6*x*atanh(a*x)^3/(1-a^2*x^2)^3+5/24*x*atanh(a*x)^3/(1-a^2*x^2)^2+5/16*x*atanh(a*x)^3/(1-a^2*x^2)+5/64*atanh(a*x)^4/a",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.4 u (a+b arctanh(c x))^p.mac",
+   "index": 514,
+   "integrand": "atanh(a*x)/(c+d*x^2)^(7/2)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "1/15*a/(c*(a^2*c+d)*(c+d*x^2)^(3/2))+1/5*x*atanh(a*x)/(c*(c+d*x^2)^(5/2))+4/15*x*atanh(a*x)/(c^2*(c+d*x^2)^(3/2))-1/15*(15*a^4*c^2+20*a^2*c*d+8*d^2)*atanh(a*sqrt(c+d*x^2)/sqrt(a^2*c+d))/(c^3*(a^2*c+d)^(5/2))+1/15*a*(7*a^2*c+4*d)/(c^2*(a^2*c+d)^2*sqrt(c+d*x^2))+8/15*x*atanh(a*x)/(c^3*sqrt(c+d*x^2))",
+   "params": [
+    "a",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 14,
+   "integrand": "exp(1)^(2*atanh(a*x))/x",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "ln(x)-2*ln(1-a*x)",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 53,
+   "integrand": "1/exp(1)^(3*atanh(a*x))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-3*asin(a*x)/a-2*(1-a*x)^2/(a*sqrt(1-a^2*x^2))-3*sqrt(1-a^2*x^2)/a",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 96,
+   "integrand": "1/(exp(1)^(1/2*atanh(a*x))*x^3)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "1/4*a*(1-a*x)^(1/4)*(1+a*x)^(3/4)/x-1/2*(1-a*x)^(5/4)*(1+a*x)^(3/4)/x^2+1/4*a^2*atan((1+a*x)^(1/4)/(1-a*x)^(1/4))-1/4*a^2*atanh((1+a*x)^(1/4)/(1-a*x)^(1/4))",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 157,
+   "integrand": "exp(1)^atanh(a*x)*(c-a*c*x)^4",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "7/12*c^4*(1-a^2*x^2)^(3/2)/a+7/20*c^4*(1-a*x)*(1-a^2*x^2)^(3/2)/a+1/5*c^4*(1-a*x)^2*(1-a^2*x^2)^(3/2)/a+7/8*c^4*asin(a*x)/a+7/8*c^4*x*sqrt(1-a^2*x^2)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 199,
+   "integrand": "(c-a*c*x)/exp(1)^atanh(a*x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "3/2*c*asin(a*x)/a+3/2*c*sqrt(1-a^2*x^2)/a+1/2*c*(1-a*x)*sqrt(1-a^2*x^2)/a",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 240,
+   "integrand": "exp(1)^(2*atanh(a*x))/(c-a*c*x)^(5/2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "4/5/(a*(c-a*c*x)^(5/2))+(-2/3)/(a*c*(c-a*c*x)^(3/2))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 287,
+   "integrand": "exp(1)^atanh(a*x)*x^2*(c-a*c*x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/8*c*asin(a*x)/a^3-1/8*c*x*sqrt(1-a^2*x^2)/a^2+1/4*c*x^3*sqrt(1-a^2*x^2)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 327,
+   "integrand": "exp(1)^atanh(a*x)*x^3/(c-a*c*x)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-3*asin(a*x)/(a^4*c)+(1+a*x)^2/(a^4*c*sqrt(1-a^2*x^2))+11/3*sqrt(1-a^2*x^2)/(a^4*c)+x*sqrt(1-a^2*x^2)/(a^3*c)+1/3*x^2*sqrt(1-a^2*x^2)/(a^2*c)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 366,
+   "integrand": "exp(1)^atanh(x)*x/(1+x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-sqrt(1-x)*sqrt(1+x)",
+   "params": []
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 407,
+   "integrand": "exp(1)^(3*atanh(a*x))*sqrt(c-a*c*x)/x^3",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "-23/4*a^2*(c-a*c*x)^(3/2)*atanh(sqrt(1+a*x))/(c*(1-a*x)^(3/2))+4*a^2*(c-a*c*x)^(3/2)*atanh(sqrt(1+a*x)/sqrt(2))*sqrt(2)/(c*(1-a*x)^(3/2))-1/2*(c-a*c*x)^(3/2)*sqrt(1+a*x)/(c*x^2*(1-a*x)^(3/2))-9/4*a*(c-a*c*x)^(3/2)*sqrt(1+a*x)/(c*x*(1-a*x)^(3/2))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 454,
+   "integrand": "exp(1)^atanh(a*x)/(c-c/(a*x))^4",
+   "variable": "x",
+   "steps": 13,
+   "antiderivative": "1/7*(1-a^2*x^2)^(3/2)/(a*c^4*(1-a*x)^5)-26/35*(1-a^2*x^2)^(3/2)/(a*c^4*(1-a*x)^4)+184/105*(1-a^2*x^2)^(3/2)/(a*c^4*(1-a*x)^3)+(1-a^2*x^2)^(3/2)/(a*c^4*(1-a*x)^2)+5*asin(a*x)/(a*c^4)-10*sqrt(1-a^2*x^2)/(a*c^4*(1-a*x))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 497,
+   "integrand": "1/(exp(1)^(2*atanh(a*x))*(c-c/(a*x)))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-x/c+ln(1+a*x)/(a*c)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 537,
+   "integrand": "(c-c/(a*x))^(3/2)/exp(1)^atanh(a*x)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-5*(c-c/(a*x))^(3/2)*x^(3/2)*asinh(sqrt(a)*sqrt(x))*sqrt(a)/(1-a*x)^(3/2)-2*(c-c/(a*x))^(3/2)*x*sqrt(1+a*x)/(1-a*x)^(3/2)+a*(c-c/(a*x))^(3/2)*x^2*sqrt(1+a*x)/(1-a*x)^(3/2)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 577,
+   "integrand": "exp(1)^(2*atanh(a*x))*sqrt(c-c/(a*x))/x^2",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "2/3*a*(c-c/(a*x))^(3/2)/c-4*a*sqrt(c-c/(a*x))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 628,
+   "integrand": "exp(1)^atanh(a*x)*(c-c/(a^2*x^2))^3",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "-1/24*c^3*(8+15*a*x)*(1-a^2*x^2)^(3/2)/(a^4*x^3)+1/20*c^3*(4+5*a*x)*(1-a^2*x^2)^(5/2)/(a^6*x^5)+c^3*asin(a*x)/a+15/8*c^3*atanh(sqrt(1-a^2*x^2))/a+1/8*c^3*(8-15*a*x)*sqrt(1-a^2*x^2)/(a^2*x)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 667,
+   "integrand": "1/(exp(1)^atanh(a*x)*(c-c/(a^2*x^2))^3)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-1/5*a^4*x^5*(1-a*x)/(c^3*(1-a^2*x^2)^(5/2))+1/15*a^2*x^3*(5-6*a*x)/(c^3*(1-a^2*x^2)^(3/2))+asin(a*x)/(a*c^3)-1/5*x*(5-8*a*x)/(c^3*sqrt(1-a^2*x^2))+16/5*sqrt(1-a^2*x^2)/(a*c^3)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 706,
+   "integrand": "exp(1)^(3*atanh(a*x))*(c-c/(a^2*x^2))^(5/2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/4*(c-c/(a^2*x^2))^(5/2)*x/(1-a^2*x^2)^(5/2)-a*(c-c/(a^2*x^2))^(5/2)*x^2/(1-a^2*x^2)^(5/2)-a^2*(c-c/(a^2*x^2))^(5/2)*x^3/(1-a^2*x^2)^(5/2)+2*a^3*(c-c/(a^2*x^2))^(5/2)*x^4/(1-a^2*x^2)^(5/2)-a^5*(c-c/(a^2*x^2))^(5/2)*x^6/(1-a^2*x^2)^(5/2)-3*a^4*(c-c/(a^2*x^2))^(5/2)*x^5*ln(x)/(1-a^2*x^2)^(5/2)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 745,
+   "integrand": "exp(1)^atanh(a*x)*sqrt(c-c/(a^2*x^2))/x^2",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/2*(1+a*x)^2*sqrt(c-c/(a^2*x^2))/(x*sqrt(1-a^2*x^2))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 784,
+   "integrand": "sqrt(c-c/(a^2*x^2))/(exp(1)^(3*atanh(a*x))*x^2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "3*a*sqrt(c-c/(a^2*x^2))/sqrt(1-a^2*x^2)-1/2*sqrt(c-c/(a^2*x^2))/(x*sqrt(1-a^2*x^2))+4*a^2*x*ln(x)*sqrt(c-c/(a^2*x^2))/sqrt(1-a^2*x^2)-4*a^2*x*ln(1+a*x)*sqrt(c-c/(a^2*x^2))/sqrt(1-a^2*x^2)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 852,
+   "integrand": "x^2/exp(1)^(2*atanh(a+b*x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-2*(1+a)*x/b^2+x^2/b-1/3*x^3+2*(1+a)^2*ln(1+a+b*x)/b^3",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 899,
+   "integrand": "exp(1)^atanh(a*x)*x^2/(c-a^2*c*x^2)^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/3*x^2*(1+a*x)/(a*c^2*(1-a^2*x^2)^(3/2))+(-2/3)/(a^3*c^2*sqrt(1-a^2*x^2))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 939,
+   "integrand": "exp(1)^atanh(a*x)*x^4/(1-a^2*x^2)^(5/2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/8/(a^5*(1-a*x)^2)+(-3/4)/(a^5*(1-a*x))+(-1/8)/(a^5*(1+a*x))-11/16*ln(1-a*x)/a^5-5/16*ln(1+a*x)/a^5",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 978,
+   "integrand": "exp(1)^atanh(a*x)*x^3/(c-a^2*c*x^2)^(5/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/8*sqrt(1-a^2*x^2)/(a^4*c^2*(1-a*x)^2*sqrt(c-a^2*c*x^2))-1/2*sqrt(1-a^2*x^2)/(a^4*c^2*(1-a*x)*sqrt(c-a^2*c*x^2))+1/8*sqrt(1-a^2*x^2)/(a^4*c^2*(1+a*x)*sqrt(c-a^2*c*x^2))+3/8*atanh(a*x)*sqrt(1-a^2*x^2)/(a^4*c^2*sqrt(c-a^2*c*x^2))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 1043,
+   "integrand": "exp(1)^(2*atanh(a*x))*(c-a^2*c*x^2)^3/x",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2*a*c^3*x-1/2*a^2*c^3*x^2-4/3*a^3*c^3*x^3-1/4*a^4*c^3*x^4+2/5*a^5*c^3*x^5+1/6*a^6*c^3*x^6+c^3*ln(x)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 1082,
+   "integrand": "exp(1)^(2*atanh(a*x))*(c-a^2*c*x^2)^(1/2)/x^3",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-3/2*a^2*atanh(sqrt(c-a^2*c*x^2)/sqrt(c))*sqrt(c)-1/2*sqrt(c-a^2*c*x^2)/x^2-2*a*sqrt(c-a^2*c*x^2)/x",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 1121,
+   "integrand": "exp(1)^(2*atanh(a*x))/(x^3*(c-a^2*c*x^2)^(3/2))",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "2/3*a^2*(1+a*x)/(c-a^2*c*x^2)^(3/2)-7/2*a^2*atanh(sqrt(c-a^2*c*x^2)/sqrt(c))/c^(3/2)+1/3*a^2*(9+10*a*x)/(c*sqrt(c-a^2*c*x^2))-1/2*sqrt(c-a^2*c*x^2)/(c^2*x^2)-2*a*sqrt(c-a^2*c*x^2)/(c^2*x)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 1169,
+   "integrand": "exp(1)^(3*atanh(a*x))/(c-a^2*c*x^2)^(3/2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/2*sqrt(1-a^2*x^2)/(a*c*(1-a*x)^2*sqrt(c-a^2*c*x^2))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 1232,
+   "integrand": "1/(exp(1)^(2*atanh(a*x))*(c-a^2*c*x^2)^2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "(-1/4)/(a*c^2*(1+a*x)^2)+(-1/4)/(a*c^2*(1+a*x))+1/4*atanh(a*x)/(a*c^2)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 1273,
+   "integrand": "(c-a^2*c*x^2)^(3/2)/exp(1)^(3*atanh(a*x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/4*c*(1-a*x)^4*sqrt(c-a^2*c*x^2)/(a*sqrt(1-a^2*x^2))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.6 Exponentials of inverse hyperbolic tangent functions.mac",
+   "index": 1354,
+   "integrand": "exp(1)^(n*atanh(a*x))/(c-a^2*c*x^2)^(7/2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-exp(1)^(n*atanh(a*x))*(n-5*a*x)/(a*c*(25-n^2)*(c-a^2*c*x^2)^(5/2))-20*exp(1)^(n*atanh(a*x))*(n-3*a*x)/(a*c^2*(9-n^2)*(25-n^2)*(c-a^2*c*x^2)^(3/2))-120*exp(1)^(n*atanh(a*x))*(n-a*x)/(a*c^3*(1-n^2)*(9-n^2)*(25-n^2)*sqrt(c-a^2*c*x^2))",
+   "params": [
+    "a",
+    "c",
+    "n"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.7 Inverse hyperbolic tangent functions.mac",
+   "index": 41,
+   "integrand": "atanh(tanh(a+b*x))/x^3",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/2*b/x-1/2*atanh(tanh(a+b*x))/x^2",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.7 Inverse hyperbolic tangent functions.mac",
+   "index": 82,
+   "integrand": "atanh(tanh(a+b*x))^4/x^11",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/1260*b^4/x^6-1/210*b^3*atanh(tanh(a+b*x))/x^7-1/60*b^2*atanh(tanh(a+b*x))^2/x^8-2/45*b*atanh(tanh(a+b*x))^3/x^9-1/10*atanh(tanh(a+b*x))^4/x^10",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.7 Inverse hyperbolic tangent functions.mac",
+   "index": 124,
+   "integrand": "atanh(tanh(a+b*x))^(3/2)/x",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2*atan(sqrt(atanh(tanh(a+b*x)))/sqrt(b*x-atanh(tanh(a+b*x))))*(b*x-atanh(tanh(a+b*x)))^(3/2)+2/3*atanh(tanh(a+b*x))^(3/2)-2*(b*x-atanh(tanh(a+b*x)))*sqrt(atanh(tanh(a+b*x)))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.7 Inverse hyperbolic tangent functions.mac",
+   "index": 163,
+   "integrand": "1/(x^2*atanh(tanh(a+b*x))^(5/2))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "5*b*atan(sqrt(atanh(tanh(a+b*x)))/sqrt(b*x-atanh(tanh(a+b*x))))/(b*x-atanh(tanh(a+b*x)))^(7/2)+(-1)/(x*atanh(tanh(a+b*x))^(5/2))+b/((b*x-atanh(tanh(a+b*x)))*atanh(tanh(a+b*x))^(5/2))-5/3*b/((b*x-atanh(tanh(a+b*x)))^2*atanh(tanh(a+b*x))^(3/2))+5*b/((b*x-atanh(tanh(a+b*x)))^3*sqrt(atanh(tanh(a+b*x))))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.7 Inverse hyperbolic tangent functions.mac",
+   "index": 202,
+   "integrand": "1/(atanh(tanh(a+b*x))^2*sqrt(x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "atanh(sqrt(b)*sqrt(x)/sqrt(b*x-atanh(tanh(a+b*x))))/((b*x-atanh(tanh(a+b*x)))^(3/2)*sqrt(b))+(-1)/(b*(b*x-atanh(tanh(a+b*x)))*sqrt(x))+(-1)/(b*atanh(tanh(a+b*x))*sqrt(x))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.7 Inverse hyperbolic tangent functions.mac",
+   "index": 241,
+   "integrand": "x^(3/2)/atanh(tanh(a+b*x))^(1/2)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "3/4*atanh(sqrt(b)*sqrt(x)/sqrt(atanh(tanh(a+b*x))))*(b*x-atanh(tanh(a+b*x)))^2/b^(5/2)+1/2*x^(3/2)*sqrt(atanh(tanh(a+b*x)))/b+3/4*(b*x-atanh(tanh(a+b*x)))*sqrt(x)*sqrt(atanh(tanh(a+b*x)))/b^2",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.3 Inverse hyperbolic tangent/7.3.7 Inverse hyperbolic tangent functions.mac",
+   "index": 358,
+   "integrand": "exp(1)^(c*(a+b*x))*atanh(sech(a*c+b*c*x))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "exp(1)^(a*c+b*c*x)*atanh(sech(c*(a+b*x)))/(b*c)+ln(1-exp(1)^(2*c*(a+b*x)))/(b*c)",
+   "params": [
+    "a",
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.1 Inverse hyperbolic cotangent functions.mac",
+   "index": 64,
+   "integrand": "acoth(a+b*x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "(a+b*x)*acoth(a+b*x)/b+1/2*ln(1-(a+b*x)^2)/b",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.1 Inverse hyperbolic cotangent functions.mac",
+   "index": 144,
+   "integrand": "acoth(tanh(a+b*x))^2/x^5",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/12*b*acoth(tanh(a+b*x))^3/(x^3*(b*x-acoth(tanh(a+b*x)))^2)+1/4*acoth(tanh(a+b*x))^3/(x^4*(b*x-acoth(tanh(a+b*x))))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.1 Inverse hyperbolic cotangent functions.mac",
+   "index": 187,
+   "integrand": "x*acoth(tanh(a+b*x))^n",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "x*acoth(tanh(a+b*x))^(1+n)/(b*(1+n))-acoth(tanh(a+b*x))^(2+n)/(b^2*(1+n)*(2+n))",
+   "params": [
+    "a",
+    "b",
+    "n"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 15,
+   "integrand": "exp(1)^(2*acoth(a*x))/x^3",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/2/x^2+2*a/x-2*a^2*ln(x)+2*a^2*ln(1-a*x)",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 54,
+   "integrand": "1/(exp(1)^(3*acoth(a*x))*x^2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "3*a*acsc(a*x)+2*(a+(-1)/x)^2/(a*sqrt(1+(-1)/(a^2*x^2)))+3*a*sqrt(1+(-1)/(a^2*x^2))",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 93,
+   "integrand": "1/(exp(1)^(1/2*acoth(a*x))*x^4)",
+   "variable": "x",
+   "steps": 15,
+   "antiderivative": "-3/8*a^3*(1+(-1)/(a*x))^(1/4)*(1+1/(a*x))^(3/4)-1/12*a^3*(1+(-1)/(a*x))^(5/4)*(1+1/(a*x))^(3/4)+1/3*a^2*(1+(-1)/(a*x))^(5/4)*(1+1/(a*x))^(3/4)/x-3/8*a^3*atan(1-(1+(-1)/(a*x))^(1/4)*sqrt(2)/(1+1/(a*x))^(1/4))/sqrt(2)+3/8*a^3*atan(1+(1+(-1)/(a*x))^(1/4)*sqrt(2)/(1+1/(a*x))^(1/4))/sqrt(2)-3/16*a^3*ln(1-(1+(-1)/(a*x))^(1/4)*sqrt(2)/(1+1/(a*x))^(1/4)+sqrt(1+(-1)/(a*x))/sqrt(1+1/(a*x)))/sqrt(2)+3/16*a^3*ln(1+(1+(-1)/(a*x))^(1/4)*sqrt(2)/(1+1/(a*x))^(1/4)+sqrt(1+(-1)/(a*x))/sqrt(1+1/(a*x)))/sqrt(2)",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 158,
+   "integrand": "exp(1)^acoth(a*x)*(c-a*c*x)^3",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "2/3*a^2*c^3*(1+(-1)/(a^2*x^2))^(3/2)*x^3-1/4*a^3*c^3*(1+(-1)/(a^2*x^2))^(3/2)*x^4+5/8*c^3*atanh(sqrt(1+(-1)/(a^2*x^2)))/a-5/8*a*c^3*x^2*sqrt(1+(-1)/(a^2*x^2))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 200,
+   "integrand": "1/(exp(1)^acoth(a*x)*(c-a*c*x))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-atanh(sqrt(1+(-1)/(a^2*x^2)))/(a*c)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 243,
+   "integrand": "exp(1)^(3*acoth(a*x))*(c-a*c*x)^(7/2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-44/63*(1+1/(a*x))^(5/2)*(c-a*c*x)^(7/2)/(a*(1+(-1)/(a*x))^(7/2))+214/315*(1+1/(a*x))^(5/2)*(c-a*c*x)^(7/2)/(a^2*(1+(-1)/(a*x))^(7/2)*x)+2/9*(1+1/(a*x))^(5/2)*x*(c-a*c*x)^(7/2)/(1+(-1)/(a*x))^(7/2)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 287,
+   "integrand": "exp(1)^acoth(x)/(1+x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "atanh(sqrt(1+1/x)*sqrt((-1+x)/x))",
+   "params": []
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 327,
+   "integrand": "exp(1)^acoth(x)/sqrt(1+x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "2*x*sqrt(1+1/x)*sqrt((-1+x)/x)/sqrt(1+x)",
+   "params": []
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 384,
+   "integrand": "exp(1)^acoth(a*x)/(c-c/(a*x))^3",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "-8/5*(a+1/x)/(a^2*c^3*(1+(-1)/(a^2*x^2))^(5/2))-4/15*(5*a+8/x)/(a^2*c^3*(1+(-1)/(a^2*x^2))^(3/2))+4*atanh(sqrt(1+(-1)/(a^2*x^2)))/(a*c^3)+1/15*(-60*a+(-79)/x)/(a^2*c^3*sqrt(1+(-1)/(a^2*x^2)))+x*sqrt(1+(-1)/(a^2*x^2))/c^3",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 423,
+   "integrand": "(c-c/(a*x))/exp(1)^(2*acoth(a*x))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "c*x+c*ln(x)/a-4*c*ln(1+a*x)/a",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 465,
+   "integrand": "sqrt(c-c/(a*x))/exp(1)^acoth(a*x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-3*atanh(sqrt(c)*sqrt(1+(-1)/(a^2*x^2))/sqrt(c-c/(a*x)))*sqrt(c)/a+c*x*sqrt(1+(-1)/(a^2*x^2))/sqrt(c-c/(a*x))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 505,
+   "integrand": "exp(1)^(2*acoth(a*x))*sqrt(c-c/(a*x))/x^5",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-14/3*a^4*(c-c/(a*x))^(3/2)/c+18/5*a^4*(c-c/(a*x))^(5/2)/c^2-10/7*a^4*(c-c/(a*x))^(7/2)/c^3+2/9*a^4*(c-c/(a*x))^(9/2)/c^4+4*a^4*sqrt(c-c/(a*x))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 559,
+   "integrand": "exp(1)^acoth(a*x)/(c-a^2*c*x^2)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "exp(1)^acoth(a*x)/(a*c)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 598,
+   "integrand": "(c-a^2*c*x^2)^3/exp(1)^(2*acoth(a*x))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "4/5*c^3*(1-a*x)^5/a-2/3*c^3*(1-a*x)^6/a+1/7*c^3*(1-a*x)^7/a",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 637,
+   "integrand": "exp(1)^(3*acoth(a*x))/sqrt(c-a^2*c*x^2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "2*x*sqrt(1+(-1)/(a^2*x^2))/((1-a*x)*sqrt(c-a^2*c*x^2))+x*ln(1-a*x)*sqrt(1+(-1)/(a^2*x^2))/sqrt(c-a^2*c*x^2)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 676,
+   "integrand": "exp(1)^(2*acoth(a*x))*sqrt(c-a^2*c*x^2)/x",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "-2*atan(a*x*sqrt(c)/sqrt(c-a^2*c*x^2))*sqrt(c)+atanh(sqrt(c-a^2*c*x^2)/sqrt(c))*sqrt(c)+sqrt(c-a^2*c*x^2)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 715,
+   "integrand": "sqrt(c-a^2*c*x^2)/(exp(1)^(2*acoth(a*x))*x)",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "2*atan(a*x*sqrt(c)/sqrt(c-a^2*c*x^2))*sqrt(c)+atanh(sqrt(c-a^2*c*x^2)/sqrt(c))*sqrt(c)+sqrt(c-a^2*c*x^2)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 778,
+   "integrand": "exp(1)^acoth(a*x)/(c-c/(a^2*x^2))^4",
+   "variable": "x",
+   "steps": 12,
+   "antiderivative": "(-8/7)/(a*c^4*(1+(-1)/(a*x))^(7/2)*(1+1/(a*x))^(5/2))+(-11/7)/(a*c^4*(1+(-1)/(a*x))^(5/2)*(1+1/(a*x))^(5/2))+(-62/21)/(a*c^4*(1+(-1)/(a*x))^(3/2)*(1+1/(a*x))^(5/2))+x/(c^4*(1+(-1)/(a*x))^(7/2)*(1+1/(a*x))^(5/2))+atanh(sqrt(1+(-1)/(a*x))*sqrt(1+1/(a*x)))/(a*c^4)+(-269/21)/(a*c^4*(1+1/(a*x))^(5/2)*sqrt(1+(-1)/(a*x)))+262/35*sqrt(1+(-1)/(a*x))/(a*c^4*(1+1/(a*x))^(5/2))+163/35*sqrt(1+(-1)/(a*x))/(a*c^4*(1+1/(a*x))^(3/2))+128/35*sqrt(1+(-1)/(a*x))/(a*c^4*sqrt(1+1/(a*x)))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 817,
+   "integrand": "1/(exp(1)^(2*acoth(a*x))*(c-c/(a^2*x^2)))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "x/c+(-1)/(a*c*(1+a*x))-2*ln(1+a*x)/(a*c)",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 856,
+   "integrand": "(c-c/(a^2*x^2))^(3/2)/exp(1)^acoth(a*x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/2*c*sqrt(c-c/(a^2*x^2))/(a^3*x^2*sqrt(1+(-1)/(a^2*x^2)))+c*sqrt(c-c/(a^2*x^2))/(a^2*x*sqrt(1+(-1)/(a^2*x^2)))+c*x*sqrt(c-c/(a^2*x^2))/sqrt(1+(-1)/(a^2*x^2))-c*ln(x)*sqrt(c-c/(a^2*x^2))/(a*sqrt(1+(-1)/(a^2*x^2)))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.4 Inverse hyperbolic cotangent/7.4.2 Exponentials of inverse hyperbolic cotangent functions.mac",
+   "index": 895,
+   "integrand": "exp(1)^(3*acoth(a*x))*x^2*sqrt(c-c/(a^2*x^2))",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "4*x*sqrt(c-c/(a^2*x^2))/(a^2*sqrt(1+(-1)/(a^2*x^2)))+3/2*x^2*sqrt(c-c/(a^2*x^2))/(a*sqrt(1+(-1)/(a^2*x^2)))+1/3*x^3*sqrt(c-c/(a^2*x^2))/sqrt(1+(-1)/(a^2*x^2))+4*ln(1-a*x)*sqrt(c-c/(a^2*x^2))/(a^3*sqrt(1+(-1)/(a^2*x^2)))",
+   "params": [
+    "a",
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.5 Inverse hyperbolic secant/7.5.1 u (a+b arcsech(c x))^n.mac",
+   "index": 17,
+   "integrand": "asech(a*x)^3/x^4",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "2/27*((1-a*x)/(1+a*x))^(3/2)*(1+a*x)^3/x^3-2/9*asech(a*x)/x^3-4/3*a^2*asech(a*x)/x-1/3*asech(a*x)^3/x^3+14/9*a^2*(1+a*x)*sqrt((1-a*x)/(1+a*x))/x+1/3*(1+a*x)*asech(a*x)^2*sqrt((1-a*x)/(1+a*x))/x^3+2/3*a^2*(1+a*x)*asech(a*x)^2*sqrt((1-a*x)/(1+a*x))/x",
+   "params": [
+    "a"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.5 Inverse hyperbolic secant/7.5.1 u (a+b arcsech(c x))^n.mac",
+   "index": 96,
+   "integrand": "x*(d+ee*x^2)*(a+b*asech(c*x))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "1/4*(d+ee*x^2)^2*(a+b*asech(c*x))/ee+1/12*b*ee*(1-c^2*x^2)^(3/2)*sqrt(1/(1+c*x))*sqrt(1+c*x)/c^4-1/4*b*d^2*atanh(sqrt(1-c^2*x^2))*sqrt(1/(1+c*x))*sqrt(1+c*x)/ee-1/4*b*(2*c^2*d+ee)*sqrt(1/(1+c*x))*sqrt(1+c*x)*sqrt(1-c^2*x^2)/c^4",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.5 Inverse hyperbolic secant/7.5.2 Inverse hyperbolic secant functions.mac",
+   "index": 22,
+   "integrand": "asech(sqrt(x))",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "x*asech(sqrt(x))+(-1+x)/(sqrt(x)*sqrt(-1+1/sqrt(x))*sqrt(1+1/sqrt(x)))",
+   "params": []
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.5 Inverse hyperbolic secant/7.5.2 Inverse hyperbolic secant functions.mac",
+   "index": 88,
+   "integrand": "exp(1)^asech(c*x)*x^4/(1-c^2*x^2)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "-1/2*x^2/c^3-1/2*ln(1-c^2*x^2)/c^5-2/3*sqrt(1-c*x)/(c^5*sqrt(1/(1+c*x)))-1/3*x^2*sqrt(1-c*x)/(c^3*sqrt(1/(1+c*x)))",
+   "params": [
+    "c"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.6 Inverse hyperbolic cosecant/7.6.1 u (a+b arccsch(c x))^n.mac",
+   "index": 75,
+   "integrand": "x^4*(d+ee*x^2)*(a+b*acsch(c*x))",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "1/5*d*x^5*(a+b*acsch(c*x))+1/7*ee*x^7*(a+b*acsch(c*x))-1/560*b*(42*c^2*d-25*ee)*x*atan(c*x/sqrt(-1-c^2*x^2))/(c^6*sqrt(-c^2*x^2))-1/560*b*(42*c^2*d-25*ee)*x^2*sqrt(-1-c^2*x^2)/(c^5*sqrt(-c^2*x^2))+1/840*b*(42*c^2*d-25*ee)*x^4*sqrt(-1-c^2*x^2)/(c^3*sqrt(-c^2*x^2))+1/42*b*ee*x^6*sqrt(-1-c^2*x^2)/(c*sqrt(-c^2*x^2))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee"
+   ]
+  },
+  {
+   "source": "7 Inverse hyperbolic functions/7.6 Inverse hyperbolic cosecant/7.6.2 Inverse hyperbolic cosecant functions.mac",
+   "index": 2,
+   "integrand": "x*acsch(a+b*x)",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "-1/2*a^2*acsch(a+b*x)/b^2+1/2*x^2*acsch(a+b*x)-a*atanh(sqrt(1+1/(a+b*x)^2))/b^2+1/2*(a+b*x)*sqrt(1+1/(a+b*x)^2)/b^2",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 0,
+   "integrand": "x^5*erf(b*x)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-5/16*erf(b*x)/b^6+1/6*x^6*erf(b*x)+5/8*x/(exp(1)^(b^2*x^2)*b^5*sqrt(pi))+5/12*x^3/(exp(1)^(b^2*x^2)*b^3*sqrt(pi))+1/6*x^5/(exp(1)^(b^2*x^2)*b*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 1,
+   "integrand": "x^3*erf(b*x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-3/16*erf(b*x)/b^4+1/4*x^4*erf(b*x)+3/8*x/(exp(1)^(b^2*x^2)*b^3*sqrt(pi))+1/4*x^3/(exp(1)^(b^2*x^2)*b*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 2,
+   "integrand": "x*erf(b*x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-1/4*erf(b*x)/b^2+1/2*x^2*erf(b*x)+1/2*x/(exp(1)^(b^2*x^2)*b*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 4,
+   "integrand": "erf(b*x)/x^3",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "-b^2*erf(b*x)-1/2*erf(b*x)/x^2-b/(exp(1)^(b^2*x^2)*x*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 5,
+   "integrand": "erf(b*x)/x^5",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/3*b^4*erf(b*x)-1/4*erf(b*x)/x^4-1/6*b/(exp(1)^(b^2*x^2)*x^3*sqrt(pi))+1/3*b^3/(exp(1)^(b^2*x^2)*x*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 6,
+   "integrand": "erf(b*x)/x^7",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-4/45*b^6*erf(b*x)-1/6*erf(b*x)/x^6-1/15*b/(exp(1)^(b^2*x^2)*x^5*sqrt(pi))+2/45*b^3/(exp(1)^(b^2*x^2)*x^3*sqrt(pi))-4/45*b^5/(exp(1)^(b^2*x^2)*x*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 7,
+   "integrand": "x^6*erf(b*x)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/7*x^7*erf(b*x)+6/7/(exp(1)^(b^2*x^2)*b^7*sqrt(pi))+6/7*x^2/(exp(1)^(b^2*x^2)*b^5*sqrt(pi))+3/7*x^4/(exp(1)^(b^2*x^2)*b^3*sqrt(pi))+1/7*x^6/(exp(1)^(b^2*x^2)*b*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 8,
+   "integrand": "x^4*erf(b*x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "1/5*x^5*erf(b*x)+2/5/(exp(1)^(b^2*x^2)*b^5*sqrt(pi))+2/5*x^2/(exp(1)^(b^2*x^2)*b^3*sqrt(pi))+1/5*x^4/(exp(1)^(b^2*x^2)*b*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 9,
+   "integrand": "x^2*erf(b*x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/3*x^3*erf(b*x)+1/3/(exp(1)^(b^2*x^2)*b^3*sqrt(pi))+1/3*x^2/(exp(1)^(b^2*x^2)*b*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 10,
+   "integrand": "erf(b*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "x*erf(b*x)+1/(exp(1)^(b^2*x^2)*b*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 14,
+   "integrand": "(c+d*x)^3*erf(a+b*x)",
+   "variable": "x",
+   "steps": 12,
+   "antiderivative": "-3/16*d^3*erf(a+b*x)/b^4-3/4*d*(b*c-a*d)^2*erf(a+b*x)/b^4-1/4*(b*c-a*d)^4*erf(a+b*x)/(b^4*d)+1/4*(c+d*x)^4*erf(a+b*x)/d+d^2*(b*c-a*d)/(exp(1)^((a+b*x)^2)*b^4*sqrt(pi))+(b*c-a*d)^3/(exp(1)^((a+b*x)^2)*b^4*sqrt(pi))+3/8*d^3*(a+b*x)/(exp(1)^((a+b*x)^2)*b^4*sqrt(pi))+3/2*d*(b*c-a*d)^2*(a+b*x)/(exp(1)^((a+b*x)^2)*b^4*sqrt(pi))+d^2*(b*c-a*d)*(a+b*x)^2/(exp(1)^((a+b*x)^2)*b^4*sqrt(pi))+1/4*d^3*(a+b*x)^3/(exp(1)^((a+b*x)^2)*b^4*sqrt(pi))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 15,
+   "integrand": "(c+d*x)^2*erf(a+b*x)",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "-1/2*d*(b*c-a*d)*erf(a+b*x)/b^3-1/3*(b*c-a*d)^3*erf(a+b*x)/(b^3*d)+1/3*(c+d*x)^3*erf(a+b*x)/d+1/3*d^2/(exp(1)^((a+b*x)^2)*b^3*sqrt(pi))+(b*c-a*d)^2/(exp(1)^((a+b*x)^2)*b^3*sqrt(pi))+d*(b*c-a*d)*(a+b*x)/(exp(1)^((a+b*x)^2)*b^3*sqrt(pi))+1/3*d^2*(a+b*x)^2/(exp(1)^((a+b*x)^2)*b^3*sqrt(pi))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 16,
+   "integrand": "(c+d*x)*erf(a+b*x)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-1/4*d*erf(a+b*x)/b^2-1/2*(b*c-a*d)^2*erf(a+b*x)/(b^2*d)+1/2*(c+d*x)^2*erf(a+b*x)/d+(b*c-a*d)/(exp(1)^((a+b*x)^2)*b^2*sqrt(pi))+1/2*d*(a+b*x)/(exp(1)^((a+b*x)^2)*b^2*sqrt(pi))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 17,
+   "integrand": "erf(a+b*x)",
+   "variable": "x",
+   "steps": 1,
+   "antiderivative": "(a+b*x)*erf(a+b*x)/b+1/(exp(1)^((a+b*x)^2)*b*sqrt(pi))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 21,
+   "integrand": "x^5*erf(b*x)^2",
+   "variable": "x",
+   "steps": 12,
+   "antiderivative": "11/12/(exp(1)^(2*b^2*x^2)*pi*b^6)+7/12*x^2/(exp(1)^(2*b^2*x^2)*pi*b^4)+1/6*x^4/(exp(1)^(2*b^2*x^2)*pi*b^2)-5/16*erf(b*x)^2/b^6+1/6*x^6*erf(b*x)^2+5/4*x*erf(b*x)/(exp(1)^(b^2*x^2)*b^5*sqrt(pi))+5/6*x^3*erf(b*x)/(exp(1)^(b^2*x^2)*b^3*sqrt(pi))+1/3*x^5*erf(b*x)/(exp(1)^(b^2*x^2)*b*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 22,
+   "integrand": "x^3*erf(b*x)^2",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "1/2/(exp(1)^(2*b^2*x^2)*pi*b^4)+1/4*x^2/(exp(1)^(2*b^2*x^2)*pi*b^2)-3/16*erf(b*x)^2/b^4+1/4*x^4*erf(b*x)^2+3/4*x*erf(b*x)/(exp(1)^(b^2*x^2)*b^3*sqrt(pi))+1/2*x^3*erf(b*x)/(exp(1)^(b^2*x^2)*b*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 23,
+   "integrand": "x*erf(b*x)^2",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/2/(exp(1)^(2*b^2*x^2)*pi*b^2)-1/4*erf(b*x)^2/b^2+1/2*x^2*erf(b*x)^2+x*erf(b*x)/(exp(1)^(b^2*x^2)*b*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 28,
+   "integrand": "x^4*erf(b*x)^2",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "11/20*x/(exp(1)^(2*b^2*x^2)*pi*b^4)+1/5*x^3/(exp(1)^(2*b^2*x^2)*pi*b^2)+1/5*x^5*erf(b*x)^2+4/5*erf(b*x)/(exp(1)^(b^2*x^2)*b^5*sqrt(pi))+4/5*x^2*erf(b*x)/(exp(1)^(b^2*x^2)*b^3*sqrt(pi))+2/5*x^4*erf(b*x)/(exp(1)^(b^2*x^2)*b*sqrt(pi))-43/40*erf(b*x*sqrt(2))/(b^5*sqrt(2*pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 29,
+   "integrand": "x^2*erf(b*x)^2",
+   "variable": "x",
+   "steps": 6,
+   "antiderivative": "1/3*x/(exp(1)^(2*b^2*x^2)*pi*b^2)+1/3*x^3*erf(b*x)^2+2/3*erf(b*x)/(exp(1)^(b^2*x^2)*b^3*sqrt(pi))+2/3*x^2*erf(b*x)/(exp(1)^(b^2*x^2)*b*sqrt(pi))-5/6*erf(b*x*sqrt(2))/(b^3*sqrt(2*pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 30,
+   "integrand": "erf(b*x)^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "x*erf(b*x)^2-erf(b*x*sqrt(2))*sqrt(2/pi)/b+2*erf(b*x)/(exp(1)^(b^2*x^2)*b*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 34,
+   "integrand": "(c+d*x)^2*erf(a+b*x)^2",
+   "variable": "x",
+   "steps": 16,
+   "antiderivative": "d*(b*c-a*d)/(exp(1)^(2*(a+b*x)^2)*pi*b^3)+1/3*d^2*(a+b*x)/(exp(1)^(2*(a+b*x)^2)*pi*b^3)-1/2*d*(b*c-a*d)*erf(a+b*x)^2/b^3+(b*c-a*d)^2*(a+b*x)*erf(a+b*x)^2/b^3+d*(b*c-a*d)*(a+b*x)^2*erf(a+b*x)^2/b^3+1/3*d^2*(a+b*x)^3*erf(a+b*x)^2/b^3-(b*c-a*d)^2*erf((a+b*x)*sqrt(2))*sqrt(2/pi)/b^3+2/3*d^2*erf(a+b*x)/(exp(1)^((a+b*x)^2)*b^3*sqrt(pi))+2*(b*c-a*d)^2*erf(a+b*x)/(exp(1)^((a+b*x)^2)*b^3*sqrt(pi))+2*d*(b*c-a*d)*(a+b*x)*erf(a+b*x)/(exp(1)^((a+b*x)^2)*b^3*sqrt(pi))+2/3*d^2*(a+b*x)^2*erf(a+b*x)/(exp(1)^((a+b*x)^2)*b^3*sqrt(pi))-5/6*d^2*erf((a+b*x)*sqrt(2))/(b^3*sqrt(2*pi))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 35,
+   "integrand": "(c+d*x)*erf(a+b*x)^2",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "1/2*d/(exp(1)^(2*(a+b*x)^2)*pi*b^2)-1/4*d*erf(a+b*x)^2/b^2+(b*c-a*d)*(a+b*x)*erf(a+b*x)^2/b^2+1/2*d*(a+b*x)^2*erf(a+b*x)^2/b^2-(b*c-a*d)*erf((a+b*x)*sqrt(2))*sqrt(2/pi)/b^2+2*(b*c-a*d)*erf(a+b*x)/(exp(1)^((a+b*x)^2)*b^2*sqrt(pi))+d*(a+b*x)*erf(a+b*x)/(exp(1)^((a+b*x)^2)*b^2*sqrt(pi))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 36,
+   "integrand": "erf(a+b*x)^2",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "(a+b*x)*erf(a+b*x)^2/b-erf((a+b*x)*sqrt(2))*sqrt(2/pi)/b+2*erf(a+b*x)/(exp(1)^((a+b*x)^2)*b*sqrt(pi))",
+   "params": [
+    "a",
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 39,
+   "integrand": "x^2*erf(d*(a+b*ln(c*x^n)))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/3*x^3*erf(d*(a+b*ln(c*x^n)))-1/3*exp(1)^(1/4*(9-12*a*b*d^2*n)/(b^2*d^2*n^2))*x^3*erf(1/2*(2*a*b*d^2+(-3)/n+2*b^2*d^2*ln(c*x^n))/(b*d))/(c*x^n)^(3/n)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "n"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 40,
+   "integrand": "x*erf(d*(a+b*ln(c*x^n)))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "1/2*x^2*erf(d*(a+b*ln(c*x^n)))-1/2*exp(1)^((1-2*a*b*d^2*n)/(b^2*d^2*n^2))*x^2*erf((a*b*d^2+(-1)/n+b^2*d^2*ln(c*x^n))/(b*d))/(c*x^n)^(2/n)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "n"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 41,
+   "integrand": "erf(d*(a+b*ln(c*x^n)))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "x*erf(d*(a+b*ln(c*x^n)))-exp(1)^(1/4*(1-4*a*b*d^2*n)/(b^2*d^2*n^2))*x*erf(1/2*(2*a*b*d^2+(-1)/n+2*b^2*d^2*ln(c*x^n))/(b*d))/(c*x^n)^(1/n)",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "n"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 42,
+   "integrand": "erf(d*(a+b*ln(c*x^n)))/x",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "erf(d*(a+b*ln(c*x^n)))*(a+b*ln(c*x^n))/(b*n)+1/(exp(1)^(d^2*(a+b*ln(c*x^n))^2)*b*d*n*sqrt(pi))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "n"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 43,
+   "integrand": "erf(d*(a+b*ln(c*x^n)))/x^2",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-erf(d*(a+b*ln(c*x^n)))/x+exp(1)^(1/4/(b^2*d^2*n^2)+a/(b*n))*(c*x^n)^(1/n)*erf(1/2*(2*a*b*d^2+1/n+2*b^2*d^2*ln(c*x^n))/(b*d))/x",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "n"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 44,
+   "integrand": "erf(d*(a+b*ln(c*x^n)))/x^3",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/2*erf(d*(a+b*ln(c*x^n)))/x^2+1/2*exp(1)^((1+2*a*b*d^2*n)/(b^2*d^2*n^2))*(c*x^n)^(2/n)*erf((1+a*b*d^2*n+b^2*d^2*n*ln(c*x^n))/(b*d*n))/x^2",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "n"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 45,
+   "integrand": "(ee*x)^m*erf(d*(a+b*ln(c*x^n)))",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "(ee*x)^(1+m)*erf(d*(a+b*ln(c*x^n)))/(ee*(1+m))+exp(1)^(1/4*(1+m)*(1+m-4*a*b*d^2*n)/(b^2*d^2*n^2))*x*(ee*x)^m*erf(1/2*(1+m-2*a*b*d^2*n-2*b^2*d^2*n*ln(c*x^n))/(b*d*n))/((1+m)*(c*x^n)^((1+m)/n))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "ee",
+    "m",
+    "n"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 46,
+   "integrand": "exp(1)^(c-b^2*x^2)*erf(b*x)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/6*exp(1)^c*erf(b*x)^3*sqrt(pi)/b",
+   "params": [
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 47,
+   "integrand": "exp(1)^(c-b^2*x^2)*erf(b*x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/4*exp(1)^c*erf(b*x)^2*sqrt(pi)/b",
+   "params": [
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 48,
+   "integrand": "exp(1)^(c-b^2*x^2)/erf(b*x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*exp(1)^c*ln(erf(b*x))*sqrt(pi)/b",
+   "params": [
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 49,
+   "integrand": "exp(1)^(c-b^2*x^2)/erf(b*x)^2",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/2*exp(1)^c*sqrt(pi)/(b*erf(b*x))",
+   "params": [
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 50,
+   "integrand": "exp(1)^(c-b^2*x^2)/erf(b*x)^3",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/4*exp(1)^c*sqrt(pi)/(b*erf(b*x)^2)",
+   "params": [
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 51,
+   "integrand": "exp(1)^(c-b^2*x^2)*erf(b*x)^n",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*exp(1)^c*erf(b*x)^(1+n)*sqrt(pi)/(b*(1+n))",
+   "params": [
+    "b",
+    "c",
+    "n"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 52,
+   "integrand": "exp(1)^(c+d*x^2)*x^5*erf(b*x)",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "exp(1)^(c+d*x^2)*erf(b*x)/d^3-exp(1)^(c+d*x^2)*x^2*erf(b*x)/d^2+1/2*exp(1)^(c+d*x^2)*x^4*erf(b*x)/d+1/2*exp(1)^c*b*erf(x*sqrt(b^2-d))/((b^2-d)^(3/2)*d^2)-3/8*exp(1)^c*b*erf(x*sqrt(b^2-d))/((b^2-d)^(5/2)*d)-exp(1)^(c-(b^2-d)*x^2)*b*x/((b^2-d)*d^2*sqrt(pi))+3/4*exp(1)^(c-(b^2-d)*x^2)*b*x/((b^2-d)^2*d*sqrt(pi))+1/2*exp(1)^(c-(b^2-d)*x^2)*b*x^3/((b^2-d)*d*sqrt(pi))-exp(1)^c*b*erf(x*sqrt(b^2-d))/(d^3*sqrt(b^2-d))",
+   "params": [
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 53,
+   "integrand": "exp(1)^(c+d*x^2)*x^3*erf(b*x)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/2*exp(1)^(c+d*x^2)*erf(b*x)/d^2+1/2*exp(1)^(c+d*x^2)*x^2*erf(b*x)/d-1/4*exp(1)^c*b*erf(x*sqrt(b^2-d))/((b^2-d)^(3/2)*d)+1/2*exp(1)^(c-(b^2-d)*x^2)*b*x/((b^2-d)*d*sqrt(pi))+1/2*exp(1)^c*b*erf(x*sqrt(b^2-d))/(d^2*sqrt(b^2-d))",
+   "params": [
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 54,
+   "integrand": "exp(1)^(c+d*x^2)*x*erf(b*x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*exp(1)^(c+d*x^2)*erf(b*x)/d-1/2*exp(1)^c*b*erf(x*sqrt(b^2-d))/(d*sqrt(b^2-d))",
+   "params": [
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 63,
+   "integrand": "exp(1)^(c+b^2*x^2)*x^5*erf(b*x)",
+   "variable": "x",
+   "steps": 8,
+   "antiderivative": "exp(1)^(c+b^2*x^2)*erf(b*x)/b^6-exp(1)^(c+b^2*x^2)*x^2*erf(b*x)/b^4+1/2*exp(1)^(c+b^2*x^2)*x^4*erf(b*x)/b^2-2*exp(1)^c*x/(b^5*sqrt(pi))+2/3*exp(1)^c*x^3/(b^3*sqrt(pi))-1/5*exp(1)^c*x^5/(b*sqrt(pi))",
+   "params": [
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 64,
+   "integrand": "exp(1)^(c+b^2*x^2)*x^3*erf(b*x)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/2*exp(1)^(c+b^2*x^2)*erf(b*x)/b^4+1/2*exp(1)^(c+b^2*x^2)*x^2*erf(b*x)/b^2+exp(1)^c*x/(b^3*sqrt(pi))-1/3*exp(1)^c*x^3/(b*sqrt(pi))",
+   "params": [
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 65,
+   "integrand": "exp(1)^(c+b^2*x^2)*x*erf(b*x)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/2*exp(1)^(c+b^2*x^2)*erf(b*x)/b^2-exp(1)^c*x/(b*sqrt(pi))",
+   "params": [
+    "b",
+    "c"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 74,
+   "integrand": "x^5*erf(b*x)/exp(1)^(b^2*x^2)",
+   "variable": "x",
+   "steps": 9,
+   "antiderivative": "-erf(b*x)/(exp(1)^(b^2*x^2)*b^6)-x^2*erf(b*x)/(exp(1)^(b^2*x^2)*b^4)-1/2*x^4*erf(b*x)/(exp(1)^(b^2*x^2)*b^2)+43/32*erf(b*x*sqrt(2))/(b^6*sqrt(2))-11/16*x/(exp(1)^(2*b^2*x^2)*b^5*sqrt(pi))-1/4*x^3/(exp(1)^(2*b^2*x^2)*b^3*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 75,
+   "integrand": "x^3*erf(b*x)/exp(1)^(b^2*x^2)",
+   "variable": "x",
+   "steps": 5,
+   "antiderivative": "-1/2*erf(b*x)/(exp(1)^(b^2*x^2)*b^4)-1/2*x^2*erf(b*x)/(exp(1)^(b^2*x^2)*b^2)+5/8*erf(b*x*sqrt(2))/(b^4*sqrt(2))-1/4*x/(exp(1)^(2*b^2*x^2)*b^3*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 76,
+   "integrand": "x*erf(b*x)/exp(1)^(b^2*x^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "-1/2*erf(b*x)/(exp(1)^(b^2*x^2)*b^2)+1/2*erf(b*x*sqrt(2))/(b^2*sqrt(2))",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 80,
+   "integrand": "x^4*erf(b*x)/exp(1)^(b^2*x^2)",
+   "variable": "x",
+   "steps": 7,
+   "antiderivative": "-3/4*x*erf(b*x)/(exp(1)^(b^2*x^2)*b^4)-1/2*x^3*erf(b*x)/(exp(1)^(b^2*x^2)*b^2)+(-1/2)/(exp(1)^(2*b^2*x^2)*b^5*sqrt(pi))-1/4*x^2/(exp(1)^(2*b^2*x^2)*b^3*sqrt(pi))+3/16*erf(b*x)^2*sqrt(pi)/b^5",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 81,
+   "integrand": "x^2*erf(b*x)/exp(1)^(b^2*x^2)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/2*x*erf(b*x)/(exp(1)^(b^2*x^2)*b^2)+(-1/4)/(exp(1)^(2*b^2*x^2)*b^3*sqrt(pi))+1/8*erf(b*x)^2*sqrt(pi)/b^3",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 82,
+   "integrand": "erf(b*x)/exp(1)^(b^2*x^2)",
+   "variable": "x",
+   "steps": 2,
+   "antiderivative": "1/4*erf(b*x)^2*sqrt(pi)/b",
+   "params": [
+    "b"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 85,
+   "integrand": "exp(1)^(c+d*x^2)*x^3*erf(a+b*x)",
+   "variable": "x",
+   "steps": 10,
+   "antiderivative": "-1/2*exp(1)^(c+d*x^2)*erf(a+b*x)/d^2+1/2*exp(1)^(c+d*x^2)*x^2*erf(a+b*x)/d-1/2*exp(1)^(c+a^2*d/(b^2-d))*a^2*b^3*erf((a*b+(b^2-d)*x)/sqrt(b^2-d))/((b^2-d)^(5/2)*d)-1/4*exp(1)^(c+a^2*d/(b^2-d))*b*erf((a*b+(b^2-d)*x)/sqrt(b^2-d))/((b^2-d)^(3/2)*d)-1/2*exp(1)^(-a^2+c-2*a*b*x-(b^2-d)*x^2)*a*b^2/((b^2-d)^2*d*sqrt(pi))+1/2*exp(1)^(-a^2+c-2*a*b*x-(b^2-d)*x^2)*b*x/((b^2-d)*d*sqrt(pi))+1/2*exp(1)^(c+a^2*d/(b^2-d))*b*erf((a*b+(b^2-d)*x)/sqrt(b^2-d))/(d^2*sqrt(b^2-d))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 86,
+   "integrand": "exp(1)^(c+d*x^2)*x*erf(a+b*x)",
+   "variable": "x",
+   "steps": 3,
+   "antiderivative": "1/2*exp(1)^(c+d*x^2)*erf(a+b*x)/d-1/2*exp(1)^(c+a^2*d/(b^2-d))*b*erf((a*b+(b^2-d)*x)/sqrt(b^2-d))/(d*sqrt(b^2-d))",
+   "params": [
+    "a",
+    "b",
+    "c",
+    "d"
+   ]
+  },
+  {
+   "source": "8 Special functions/8.1 Error functions.mac",
+   "index": 94,
+   "integrand": "erf(b*x)/(exp(1)^(b^2*x^2)*x^3)+b^2*erf(b*x)/(exp(1)^(b^2*x^2)*x)",
+   "variable": "x",
+   "steps": 4,
+   "antiderivative": "-1/2*erf(b*x)/(exp(1)^(b^2*x^2)*x^2)-b^2*erf(b*x*sqrt(2))*sqrt(2)-b/(exp(1)^(2*b^2*x^2)*x*sqrt(pi))",
+   "params": [
+    "b"
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
Closes #16. Third and final PR in this repo's stack (based on #21).

`scripts/rubi-convert.mjs` scans the MIT-licensed [RuleBasedIntegration/MaximaSyntaxTestSuite](https://github.com/RuleBasedIntegration/MaximaSyntaxTestSuite) — all **72,254 entries, exactly matching the published total** (a good sign the parser saw everything) — translates Maxima syntax to `Symbolic`'s grammar, filters to fully-supported function sets (41,970 qualify), and deterministically curates 90 per category into a committed 324KB fixture (771 problems, attribution embedded, regenerable byte-for-byte).

**The one subtle translation bug avoided**: Maxima's bare `e` is a free *parameter* (Euler's number is `%e`), but `Symbolic.parse` resolves bare `e` to Euler's constant — so the converter renames the parameter to `ee`. Without that, every problem using `e` would have silently bound it to 2.718 and "verified" nonsense.

**Tier 1** (broad, fully offline — no subprocess, unlike #14): differentiate Rubi's *own* optimal antiderivative and check numeric equivalence with the integrand at sampled in-domain points — the calculus identity d/dx ∫f = f as a self-checking property. **Result: all 771 real-world problems verify, zero divergences** in parse/differentiate/evaluate.

**Tier 2** (narrow): where `Symbolic.integrate` accepts a 1–2-step problem, its own antiderivative must differentiate back to the integrand. Declining with `NotIntegrableError` is an expected counted outcome; succeeding *wrongly* is the only failure. Measured baseline: **7 verified, 174 honest declines, zero wrong antiderivatives** — the success floor is a documented ratchet at that baseline (Rubi's low-step problems lean on symbolic-exponent forms outside the documented elementary-rule coverage).

Mutation-verified: corrupting one fixture antiderivative by 0.1% was caught and pinpointed to the exact problem, sample point, and both values. Full suite 489/489, typecheck + biome clean.