### PR TITLE
Bump mallory-iteration to 2.0.0 — first real release

### DIFF
--- a/packages/iteration/jsr.json
+++ b/packages/iteration/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnhenry/mallory-iteration",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/iteration/package.json
+++ b/packages/iteration/package.json
@@ -76,7 +76,7 @@
     "url": "git+https://github.com/johnhenry/mallory.git",
     "directory": "packages/iteration"
   },
-  "version": "0.0.0",
+  "version": "2.0.0",
   "description": "Sync + async iterator algebra for TypeScript \u2014 transducers, Python-itertools parity, terminal consumers, bounded concurrency, cancellation, and backpressure-aware channels. Zero runtime dependencies.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/iteration/readme.md
+++ b/packages/iteration/readme.md
@@ -14,9 +14,9 @@ Requires **Node.js 22.12+** (or an equivalent Iterator-Helpers-capable engine).
 
 > **Provenance.** This library was previously published as `async-itertools`; the 1.x releases
 > and the "2.0" milestones referenced below (transducer rewrite, cancellation, bounded
-> concurrency, backpressure) describe that history under the old name. It now ships fresh as
+> concurrency, backpressure) describe that history under the old name. It now ships as
 > `mallory-iteration`, part of the [Mallory](https://github.com/johnhenry/mallory) family,
-> starting at version 0.0.0.
+> continuing that lineage at version 2.0.0.
 
 ## What's new in 2.0
 


### PR DESCRIPTION
## Summary
`mallory-iteration` has been a fully-functional, tested library since the monorepo consolidation, but its `package.json` version was left at the `0.0.0` placeholder -- never actually published for real. This bumps it to `2.0.0`, continuing the `async-itertools` lineage (which reached `1.0.1` on npm before this consolidation) under the new name -- matching the readme's own already-written "What's new in 2.0" section and the genuine breaking export-surface reorganization versus 1.x (itertools/consumers reorganized, `reducer` dropped, `abort`/`concurrency` added).

Also updates the readme's provenance note, which still said "starting at version 0.0.0".

This does NOT publish anything by itself -- per `publish.yml`'s own doc comment, publishing happens when a GitHub Release is cut after this merges.

## Test plan
- [x] `npm run typecheck` clean
- [x] Full `npm test` (79 tests) passing
- [x] `npm run build` clean
- [x] `npx biome check packages/iteration` clean
- [x] `node scripts/publish-workspaces.mjs --dry-run` confirms this is the ONLY package that would newly publish (`mallory-math` stays skipped, already at 0.9.0 on the registry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)