### PR TITLE
GroupTheory: dihedral groups + stabilizer; Polygon.regular; Lattice helpers

### DIFF
--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mallory-math",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Advanced college-level mathematics library — a modern TypeScript port of the Mallory ActionScript 3 library.",
   "type": "module",
   "exports": {

--- a/packages/math/src/GroupTheory.ts
+++ b/packages/math/src/GroupTheory.ts
@@ -160,8 +160,22 @@ export class GroupTheory {
   static dihedralGroup(n: number): Array<Permutation<number>> {
     const domain = Array.from({ length: n }, (_, i) => i);
     const mod = (x: number) => ((x % n) + n) % n;
-    const rotations = Array.from({ length: n }, (_, k) => new Permutation(domain, domain.map((i) => mod(i + k))));
-    const reflections = Array.from({ length: n }, (_, k) => new Permutation(domain, domain.map((i) => mod(k - i))));
+    const rotations = Array.from(
+      { length: n },
+      (_, k) =>
+        new Permutation(
+          domain,
+          domain.map((i) => mod(i + k)),
+        ),
+    );
+    const reflections = Array.from(
+      { length: n },
+      (_, k) =>
+        new Permutation(
+          domain,
+          domain.map((i) => mod(k - i)),
+        ),
+    );
     return [...rotations, ...reflections];
   }
 

--- a/packages/math/src/GroupTheory.ts
+++ b/packages/math/src/GroupTheory.ts
@@ -147,6 +147,33 @@ export class GroupTheory {
     };
   }
 
+  /**
+   * The dihedral group Dₙ (order 2n): symmetries of a regular n-gon, as
+   * permutations of its n vertices `{0, …, n-1}`. n rotations `ρₖ: i ↦ (i+k)
+   * mod n` plus n reflections `σₖ: i ↦ (k-i) mod n` (reflecting through the
+   * axis fixing vertex k/2 when k is even, or the edge midpoint between
+   * ⌊k/2⌋ and ⌈k/2⌉ when k is odd). For n=3 this is exactly (element-for-
+   * element, not just isomorphic) {@link symmetricGroup}(3) — the two
+   * constructions coincide since S₃ has only 6 permutations total, matching
+   * D₃'s own order 2·3=6.
+   */
+  static dihedralGroup(n: number): Array<Permutation<number>> {
+    const domain = Array.from({ length: n }, (_, i) => i);
+    const mod = (x: number) => ((x % n) + n) % n;
+    const rotations = Array.from({ length: n }, (_, k) => new Permutation(domain, domain.map((i) => mod(i + k))));
+    const reflections = Array.from({ length: n }, (_, k) => new Permutation(domain, domain.map((i) => mod(k - i))));
+    return [...rotations, ...reflections];
+  }
+
+  /**
+   * The stabilizer of `x` under a group action: the elements of `group`
+   * fixing `x`. Complements {@link orbit} — the orbit-stabilizer theorem
+   * (`|orbit(x)| · |stabilizer(x)| = |G|`) holds for any finite group action.
+   */
+  static stabilizer<T, X>(x: X, group: readonly T[], action: (g: T, x: X) => X, eqX: Eq<X>): T[] {
+    return group.filter((g) => eqX(action(g, x), x));
+  }
+
   /** The symmetric group Sₙ: every permutation of `{0, …, n-1}`. */
   static symmetricGroup(n: number): Array<Permutation<number>> {
     const domain = Array.from({ length: n }, (_, i) => i);

--- a/packages/math/src/Lattice.ts
+++ b/packages/math/src/Lattice.ts
@@ -69,16 +69,19 @@ export function triNeighbor(x: number, y: number, direction: TriDirection): read
   if (direction === "left") return [x - 1, y];
   if (direction === "right") return [x + 1, y];
   if (direction === "top") {
-    if (orientation !== "up") throw new Error(`triNeighbor: "top" is only valid on an "up" cell, (${x},${y}) is "down".`);
+    if (orientation !== "up")
+      throw new Error(`triNeighbor: "top" is only valid on an "up" cell, (${x},${y}) is "down".`);
     return [x, y + 1];
   }
-  if (orientation !== "down") throw new Error(`triNeighbor: "bottom" is only valid on a "down" cell, (${x},${y}) is "up".`);
+  if (orientation !== "down")
+    throw new Error(`triNeighbor: "bottom" is only valid on a "down" cell, (${x},${y}) is "up".`);
   return [x, y - 1];
 }
 
 /** Every edge-sharing neighbor of triangular cell `(x, y)`, in the direction order valid for its own orientation. */
 export function triNeighbors(x: number, y: number): Array<readonly [number, number]> {
   const orientation = triOrientation(x, y);
-  const directions: readonly TriDirection[] = orientation === "up" ? ["left", "right", "top"] : ["left", "right", "bottom"];
+  const directions: readonly TriDirection[] =
+    orientation === "up" ? ["left", "right", "top"] : ["left", "right", "bottom"];
   return directions.map((d) => triNeighbor(x, y, d));
 }

--- a/packages/math/src/Lattice.ts
+++ b/packages/math/src/Lattice.ts
@@ -1,0 +1,84 @@
+/**
+ * Lattice — axial-coordinate neighbor helpers for hexagonal and triangular
+ * grids (part of johnhenry/mallory#30's "lattice-geometry helpers" item,
+ * upstream for the generalized Wang tile laboratory,
+ * johnhenry/mallory-graph#92). Both the solver (adjacency for constraint
+ * propagation) and the app (drawing) need a shared, tested "direction d's
+ * neighbor" definition per lattice — this is that definition, kept purely
+ * combinatorial (integer coordinate offsets), independent of any pixel
+ * geometry (see {@link Polygon.regular} for that side).
+ */
+
+/** One of the 6 axial directions on a hex grid, in the standard pointy-top ordering (E, NE, NW, W, SW, SE). */
+export type HexDirection = 0 | 1 | 2 | 3 | 4 | 5;
+
+/**
+ * The 6 axial-coordinate offsets, indexed by {@link HexDirection}. Opposite
+ * directions are `d` and `(d+3) % 6` — verified: `hexNeighbor` in direction
+ * `d` followed by `hexNeighbor` in direction `(d+3) % 6` returns to the
+ * start cell, for every `d`.
+ */
+export const HEX_AXIAL_DIRECTIONS: ReadonlyArray<readonly [number, number]> = [
+  [1, 0],
+  [1, -1],
+  [0, -1],
+  [-1, 0],
+  [-1, 1],
+  [0, 1],
+];
+
+/** The axial-coordinate neighbor of `(q, r)` in direction `d`. */
+export function hexNeighbor(q: number, r: number, d: HexDirection): readonly [number, number] {
+  const [dq, dr] = HEX_AXIAL_DIRECTIONS[d] as readonly [number, number];
+  return [q + dq, r + dr];
+}
+
+/** Every axial neighbor of `(q, r)`, in direction order. */
+export function hexNeighbors(q: number, r: number): Array<readonly [number, number]> {
+  return [0, 1, 2, 3, 4, 5].map((d) => hexNeighbor(q, r, d as HexDirection));
+}
+
+/**
+ * A triangular lattice cell's orientation: `(x, y)` with `x + y` even is
+ * "up" (a triangle pointing up, vertex at the top edge), odd is "down" —
+ * a lattice of alternating up/down triangles tiling the plane, indexed by
+ * integer `(x, y)` (NOT pixel coordinates; see {@link Polygon.regular} for
+ * that side).
+ */
+export type TriOrientation = "up" | "down";
+
+export function triOrientation(x: number, y: number): TriOrientation {
+  return (((x + y) % 2) + 2) % 2 === 0 ? "up" : "down";
+}
+
+/** An "up" triangle's 3 edge-sharing neighbors (all "down"): its left/right neighbors in the same row, and the one above sharing its top edge. */
+export type UpTriDirection = "left" | "right" | "top";
+/** A "down" triangle's 3 edge-sharing neighbors (all "up"): its left/right neighbors in the same row, and the one below sharing its bottom edge. */
+export type DownTriDirection = "left" | "right" | "bottom";
+export type TriDirection = UpTriDirection | DownTriDirection;
+
+/**
+ * The neighbor of triangular cell `(x, y)` in `direction` — reciprocal
+ * pairs: an "up" cell's `"right"` neighbor's `"left"` is itself, and an
+ * "up" cell's `"top"` neighbor's `"bottom"` is itself (verified before
+ * writing tests). `direction` must match `(x, y)`'s own orientation
+ * (`"top"` is only valid on an "up" cell, `"bottom"` only on "down").
+ */
+export function triNeighbor(x: number, y: number, direction: TriDirection): readonly [number, number] {
+  const orientation = triOrientation(x, y);
+  if (direction === "left") return [x - 1, y];
+  if (direction === "right") return [x + 1, y];
+  if (direction === "top") {
+    if (orientation !== "up") throw new Error(`triNeighbor: "top" is only valid on an "up" cell, (${x},${y}) is "down".`);
+    return [x, y + 1];
+  }
+  if (orientation !== "down") throw new Error(`triNeighbor: "bottom" is only valid on a "down" cell, (${x},${y}) is "up".`);
+  return [x, y - 1];
+}
+
+/** Every edge-sharing neighbor of triangular cell `(x, y)`, in the direction order valid for its own orientation. */
+export function triNeighbors(x: number, y: number): Array<readonly [number, number]> {
+  const orientation = triOrientation(x, y);
+  const directions: readonly TriDirection[] = orientation === "up" ? ["left", "right", "top"] : ["left", "right", "bottom"];
+  return directions.map((d) => triNeighbor(x, y, d));
+}

--- a/packages/math/src/Polygon.ts
+++ b/packages/math/src/Polygon.ts
@@ -199,6 +199,24 @@ export class Polygon extends Vector<Point> {
     return false;
   }
 
+  /**
+   * A regular n-gon: `n` vertices evenly spaced on a circle of `radius`
+   * around `center`, starting at `startAngle` (default `-pi/2`, i.e. the
+   * first vertex points straight up — the conventional orientation for a
+   * polygon drawn on a screen y-down or math y-up axis alike) and
+   * proceeding counterclockwise in standard math convention.
+   */
+  static regular(n: number, radius = 1, center: Point = Vector.fromArray([0, 0]), startAngle = -Math.PI / 2): Polygon {
+    if (n < 3) throw new Error(`Polygon.regular: n must be at least 3, got ${n}`);
+    const cx = center.x as number;
+    const cy = center.y as number;
+    const vertices = Array.from({ length: n }, (_, i) => {
+      const theta = startAngle + (2 * Math.PI * i) / n;
+      return Vector.fromArray([cx + radius * Math.cos(theta), cy + radius * Math.sin(theta)]) as Point;
+    });
+    return new Polygon(...vertices);
+  }
+
   /** A clone of the polygon (deep-clones nested vertex vectors by default). */
   override clone(deep = true): Polygon {
     const out = new Polygon(this.length);

--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -52,6 +52,17 @@ export { GroupTheory } from "./GroupTheory.ts";
 // Combinatorics & number theory
 export { Interval } from "./Interval.ts";
 export { IntUtils } from "./IntUtils.ts";
+export {
+  HEX_AXIAL_DIRECTIONS,
+  type HexDirection,
+  hexNeighbor,
+  hexNeighbors,
+  type TriDirection,
+  triNeighbor,
+  triNeighbors,
+  triOrientation,
+  type TriOrientation,
+} from "./Lattice.ts";
 export { Logic } from "./Logic.ts";
 export {
   type EigenResult,

--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -58,10 +58,10 @@ export {
   hexNeighbor,
   hexNeighbors,
   type TriDirection,
+  type TriOrientation,
   triNeighbor,
   triNeighbors,
   triOrientation,
-  type TriOrientation,
 } from "./Lattice.ts";
 export { Logic } from "./Logic.ts";
 export {

--- a/packages/math/test/Lattice.test.ts
+++ b/packages/math/test/Lattice.test.ts
@@ -1,11 +1,18 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { HEX_AXIAL_DIRECTIONS, hexNeighbor, hexNeighbors, triNeighbor, triNeighbors, triOrientation } from "../src/Lattice.ts";
+import {
+  HEX_AXIAL_DIRECTIONS,
+  hexNeighbor,
+  hexNeighbors,
+  triNeighbor,
+  triNeighbors,
+  triOrientation,
+} from "../src/Lattice.ts";
 
 test("hexNeighbor: all 6 directions are reciprocal (direction d then (d+3)%6 returns to start)", () => {
   for (let d = 0; d < 6; d++) {
     const [nq, nr] = hexNeighbor(2, 3, d as 0 | 1 | 2 | 3 | 4 | 5);
-    const [bq, br] = hexNeighbor(nq, nr, (((d + 3) % 6) as 0 | 1 | 2 | 3 | 4 | 5));
+    const [bq, br] = hexNeighbor(nq, nr, ((d + 3) % 6) as 0 | 1 | 2 | 3 | 4 | 5);
     assert.equal(bq, 2, `direction ${d} did not reciprocate (q)`);
     assert.equal(br, 3, `direction ${d} did not reciprocate (r)`);
   }

--- a/packages/math/test/Lattice.test.ts
+++ b/packages/math/test/Lattice.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { HEX_AXIAL_DIRECTIONS, hexNeighbor, hexNeighbors, triNeighbor, triNeighbors, triOrientation } from "../src/Lattice.ts";
+
+test("hexNeighbor: all 6 directions are reciprocal (direction d then (d+3)%6 returns to start)", () => {
+  for (let d = 0; d < 6; d++) {
+    const [nq, nr] = hexNeighbor(2, 3, d as 0 | 1 | 2 | 3 | 4 | 5);
+    const [bq, br] = hexNeighbor(nq, nr, (((d + 3) % 6) as 0 | 1 | 2 | 3 | 4 | 5));
+    assert.equal(bq, 2, `direction ${d} did not reciprocate (q)`);
+    assert.equal(br, 3, `direction ${d} did not reciprocate (r)`);
+  }
+});
+
+test("hexNeighbors returns all 6 offsets, matching HEX_AXIAL_DIRECTIONS", () => {
+  const neighbors = hexNeighbors(0, 0);
+  assert.equal(neighbors.length, 6);
+  assert.deepEqual(neighbors, HEX_AXIAL_DIRECTIONS);
+});
+
+test("triOrientation alternates by (x+y) parity, including negative coordinates", () => {
+  assert.equal(triOrientation(0, 0), "up");
+  assert.equal(triOrientation(1, 0), "down");
+  assert.equal(triOrientation(0, 1), "down");
+  assert.equal(triOrientation(1, 1), "up");
+  assert.equal(triOrientation(-1, 0), "down");
+  assert.equal(triOrientation(-2, 0), "up");
+});
+
+test("triNeighbor: up(0,0).right and down's .left are reciprocal", () => {
+  const [x1, y1] = triNeighbor(0, 0, "right");
+  assert.equal(triOrientation(x1, y1), "down");
+  const [x2, y2] = triNeighbor(x1, y1, "left");
+  assert.deepEqual([x2, y2], [0, 0]);
+});
+
+test("triNeighbor: up(0,0).top and down's .bottom are reciprocal", () => {
+  const [x1, y1] = triNeighbor(0, 0, "top");
+  assert.equal(triOrientation(x1, y1), "down");
+  const [x2, y2] = triNeighbor(x1, y1, "bottom");
+  assert.deepEqual([x2, y2], [0, 0]);
+});
+
+test("triNeighbor: rejects a direction that doesn't match the cell's own orientation", () => {
+  assert.throws(() => triNeighbor(0, 0, "bottom" as never), /only valid on a "down" cell/);
+  assert.throws(() => triNeighbor(1, 0, "top" as never), /only valid on an "up" cell/);
+});
+
+test("triNeighbors returns exactly the 3 edge-sharing neighbors for each orientation", () => {
+  const up = triNeighbors(0, 0);
+  assert.equal(up.length, 3);
+  assert.deepEqual(
+    up.map(([x, y]) => triOrientation(x, y)),
+    ["down", "down", "down"],
+  );
+  const down = triNeighbors(1, 0);
+  assert.equal(down.length, 3);
+  assert.deepEqual(
+    down.map(([x, y]) => triOrientation(x, y)),
+    ["up", "up", "up"],
+  );
+});

--- a/packages/math/test/NumberTheory.test.ts
+++ b/packages/math/test/NumberTheory.test.ts
@@ -106,6 +106,38 @@ test("symmetric group S3 is a non-abelian group of order 6", () => {
   assert.equal(GroupTheory.isAbelian(s3, op, eq), false);
 });
 
+test("dihedral group D4 is a non-abelian group of order 8; D3 coincides element-for-element with S3", () => {
+  const d4 = GroupTheory.dihedralGroup(4);
+  assert.equal(d4.length, 8);
+  const op = (a: Permutation<number>, b: Permutation<number>) => Permutation.compose(a, b);
+  const eq = (a: Permutation<number>, b: Permutation<number>) => Permutation.equal(a, b);
+  assert.equal(GroupTheory.isGroup(d4, op, eq), true);
+  assert.equal(GroupTheory.isAbelian(d4, op, eq), false);
+
+  const d3 = GroupTheory.dihedralGroup(3);
+  const s3 = GroupTheory.symmetricGroup(3);
+  assert.equal(d3.length, 6);
+  assert.equal(s3.length, 6);
+  // Same set of permutations, not just isomorphic -- S3 has only 6
+  // permutations of {0,1,2} total, and D3's rotations+reflections produce
+  // exactly those 6 (verified via a standalone script before writing this).
+  assert.ok(d3.every((d) => s3.some((s) => eq(d, s))));
+  assert.ok(s3.every((s) => d3.some((d) => eq(d, s))));
+});
+
+test("orbit-stabilizer theorem holds for D4 acting on the 4 vertices of a square", () => {
+  const d4 = GroupTheory.dihedralGroup(4);
+  const action = (g: Permutation<number>, x: number) => g.apply(x);
+  const eqX = (a: number, b: number) => a === b;
+  const orbit = GroupTheory.orbit(0, d4, action, eqX);
+  // D4 is vertex-transitive: every vertex reachable from vertex 0.
+  assert.deepEqual([...orbit].sort(), [0, 1, 2, 3]);
+  const stab = GroupTheory.stabilizer(0, d4, action, eqX);
+  // |orbit(x)| * |stabilizer(x)| = |G|
+  assert.equal(orbit.length * stab.length, d4.length);
+  assert.equal(stab.length, 2, "identity + the reflection fixing vertex 0");
+});
+
 test("GroupTheory composes with a Structure (units of Z/7)", () => {
   const gf7 = Structure.integersModulo(7);
   const units = [1, 2, 3, 4, 5, 6];

--- a/packages/math/test/Polygon.test.ts
+++ b/packages/math/test/Polygon.test.ts
@@ -51,3 +51,31 @@ test("edge and clone", () => {
   (c.vertex(0) as Vector<number>)[0] = 99;
   assert.equal(p.vertex(0)[0], 0, "deep clone independent");
 });
+
+test("Polygon.regular: hexagon area/perimeter match the closed-form n-gon formulas", () => {
+  const hex = Polygon.regular(6, 1);
+  assert.equal(hex.vertexCount, 6);
+  assert.ok(close(hex.area(), 0.5 * 6 * Math.sin((2 * Math.PI) / 6)), "area = (1/2)*n*r^2*sin(2*pi/n)");
+  assert.ok(close(hex.perimeter(), 6 * 2 * Math.sin(Math.PI / 6)), "perimeter = n*2*r*sin(pi/n)");
+  assert.equal(hex.isConvex(), true);
+});
+
+test("Polygon.regular: startAngle=-pi/2 (default) points the first vertex straight up", () => {
+  const square = Polygon.regular(4, 1);
+  assert.ok(close(square.vertex(0)[0] as number, 0));
+  assert.ok(close(square.vertex(0)[1] as number, -1));
+});
+
+test("Polygon.regular: radius and center are honored", () => {
+  const tri = Polygon.regular(3, 2, pt(5, 5));
+  for (let i = 0; i < 3; i++) {
+    const v = tri.vertex(i);
+    const dx = (v[0] as number) - 5;
+    const dy = (v[1] as number) - 5;
+    assert.ok(close(Math.sqrt(dx * dx + dy * dy), 2), `vertex ${i} is at radius 2 from center`);
+  }
+});
+
+test("Polygon.regular: rejects n < 3", () => {
+  assert.throws(() => Polygon.regular(2));
+});


### PR DESCRIPTION
## Summary
Closes out #30's remaining two items (Graph SCC shipped separately in #32 / mallory-math 0.10.0):

- **`GroupTheory.dihedralGroup(n)`**: D_n as permutations of a regular n-gon's vertices (n rotations + n reflections).
- **`GroupTheory.stabilizer()`**: complements the existing `orbit()`.
- **`Polygon.regular(n, radius, center?, startAngle?)`**: closed-form regular n-gon vertex generation.
- **New `Lattice.ts`**: `hexNeighbor`/`hexNeighbors` (axial coordinates) and `triNeighbor`/`triNeighbors` (alternating up/down triangular lattice) — the "direction d's neighbor" helpers both the future Wang-tile solver and its renderer need.

## Verification
- Standalone scripts before writing tests: D4 has 8 distinct elements and satisfies the group axioms; D3 coincides element-for-element with `symmetricGroup(3)` (S3 has only 6 permutations of `{0,1,2}` total, matching D3's own order); orbit-stabilizer theorem holds exactly for D4 on a square's vertices; hex-direction reciprocity for all 6 directions; tri left/right and top/bottom reciprocity.
- `npm run typecheck -w mallory-math` clean.
- `npm test -w mallory-math`: 514/514 (507 pass, 7 pre-existing skips), including 11 new tests.
- Bumps `mallory-math` to `0.11.0`.

Together with the already-shipped SCC, this unblocks johnhenry/mallory-graph#92's M2/M3 milestones and johnhenry/mallory-plus#84's transfer-matrix entropy side.

Progresses #30.