### PR TITLE
New package: mallory-math-prototype-patch (opt-in Number.prototype complex arithmetic) (#28)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -382,6 +382,10 @@
       "resolved": "packages/math",
       "link": true
     },
+    "node_modules/mallory-math-prototype-patch": {
+      "resolved": "packages/math-prototype-patch",
+      "link": true
+    },
     "node_modules/markdown-it": {
       "version": "14.3.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
@@ -543,7 +547,7 @@
     },
     "packages/math": {
       "name": "mallory-math",
-      "version": "0.8.0",
+      "version": "0.11.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.5.1",
@@ -553,6 +557,21 @@
       },
       "engines": {
         "node": ">=22.6.0"
+      }
+    },
+    "packages/math-prototype-patch": {
+      "name": "mallory-math-prototype-patch",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "mallory-math": "^0.11.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "typescript": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     }
   }

--- a/packages/math-prototype-patch/README.md
+++ b/packages/math-prototype-patch/README.md
@@ -1,0 +1,106 @@
+# mallory-math-prototype-patch
+
+An **opt-in**, collision-checked patch of `Number.prototype` with
+[`mallory-math`](https://www.npmjs.com/package/mallory-math)'s `ComplexNumber`
+fluent arithmetic/trig methods, so a plain JS number can participate directly
+in complex arithmetic:
+
+```ts
+import { ComplexNumber } from "mallory-math";
+import { patchNumberPrototype } from "mallory-math-prototype-patch";
+
+patchNumberPrototype();
+
+(3).add(new ComplexNumber(1, 2)); // ComplexNumber(4, 2) -- instead of new ComplexNumber(3).add(...)
+(2).power(ComplexNumber.I);       // 2^i, ComplexNumber(0.7692389013, 0.6389612763)
+```
+
+## ⚠️ Only call `patchNumberPrototype()` if you understand the global side effect
+
+`Number.prototype` is shared, process-wide, mutable state. Calling
+`patchNumberPrototype()` anywhere in your process changes what `(3).add`
+means for **every module that runs afterward** — not just the file that
+called it, and not just code that imported this package. That's a
+categorically bigger risk surface than adding a method to `ComplexNumber`
+itself, which is exactly why this is a separate package and not part of
+`mallory-math` core (see
+[johnhenry/mallory#28](https://github.com/johnhenry/mallory/issues/28)).
+
+Nothing runs on import. You always opt in explicitly:
+
+```ts
+import { patchNumberPrototype } from "mallory-math-prototype-patch";
+patchNumberPrototype(); // <-- the actual mutation happens here, and only here
+```
+
+## Collision safety
+
+`patchNumberPrototype()` checks every method name it's about to add
+(`PATCH_METHOD_NAMES`) against `Number.prototype`'s existing own properties
+first. If **any** of them already exist — another library, a polyfill, a
+previous call from unrelated code — it throws a
+`NumberPrototypeCollisionError` naming exactly which ones, and adds
+**nothing** (all-or-nothing, never a partial patch). Calling it again while
+*this* package's own patch is already active is a no-op, not a
+self-collision.
+
+```ts
+import { NumberPrototypeCollisionError, patchNumberPrototype } from "mallory-math-prototype-patch";
+
+try {
+  patchNumberPrototype();
+} catch (e) {
+  if (e instanceof NumberPrototypeCollisionError) {
+    console.error("Can't patch, already defined:", e.collidingNames);
+  }
+}
+```
+
+## Undoing it
+
+```ts
+import { unpatchNumberPrototype, isNumberPrototypePatched } from "mallory-math-prototype-patch";
+
+unpatchNumberPrototype();       // removes exactly what patchNumberPrototype() added; no-op if not patched
+isNumberPrototypePatched();     // false
+```
+
+## Patched methods
+
+`add`, `subtract`, `multiply`, `divide`, `power`, `conjugate`, `reciprocal`,
+`magnitude`, `angle`, `neg`, `sine`, `cosine`, `tangent`, `squareRoot`,
+`logarithm`, `toComplexNumber` — mirroring `ComplexNumber`'s own fluent
+arithmetic/trig surface. All patched methods are defined
+non-enumerable (won't show up in `for...in`/`Object.keys` over a number, and
+won't appear when iterating a plain object either).
+
+## TypeScript types
+
+Calling `patchNumberPrototype()` doesn't change what TypeScript thinks
+`Number.prototype` looks like — `(3).add(...)` won't type-check unless you
+*also* opt into the ambient type augmentation, as a **separate** import:
+
+```ts
+import "mallory-math-prototype-patch/global"; // ambient `interface Number { add(...): ComplexNumber; ... }`
+import { patchNumberPrototype } from "mallory-math-prototype-patch";
+
+patchNumberPrototype();
+const z = (3).add(1); // now type-checks as ComplexNumber, no cast needed
+```
+
+This is deliberately split from the main entry point: a `declare global`
+block is a whole-program effect the instant *any* file imports it, whether
+or not `patchNumberPrototype()` was ever actually called at runtime.
+Importing `"mallory-math-prototype-patch/global"` without calling
+`patchNumberPrototype()` gives you types for methods that don't exist yet;
+calling `patchNumberPrototype()` without importing `/global` gives you real
+methods TypeScript doesn't know about. Do both, deliberately, or neither.
+
+## Install & use
+
+```bash
+npm install mallory-math-prototype-patch
+npm test           # run the node:test suite
+npm run typecheck  # tsc --noEmit (src/ only, matching this monorepo's convention)
+npm run build      # emit ./dist (ESM + .d.ts)
+```

--- a/packages/math-prototype-patch/jsr.json
+++ b/packages/math-prototype-patch/jsr.json
@@ -1,0 +1,12 @@
+{
+  "name": "@johnhenry/mallory-math-prototype-patch",
+  "version": "0.1.0",
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts",
+    "./global": "./src/global.ts"
+  },
+  "publish": {
+    "exclude": ["test", "**/*.test.ts"]
+  }
+}

--- a/packages/math-prototype-patch/package.json
+++ b/packages/math-prototype-patch/package.json
@@ -20,7 +20,6 @@
     "README.md"
   ],
   "scripts": {
-    "prepare": "npm run build",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "node --test --experimental-strip-types 'test/**/*.test.ts'",

--- a/packages/math-prototype-patch/package.json
+++ b/packages/math-prototype-patch/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "mallory-math-prototype-patch",
+  "version": "0.1.0",
+  "description": "OPT-IN, collision-checked Number.prototype patch adding mallory-math's ComplexNumber fluent arithmetic to plain numbers. Never merged into core mallory-math -- see the README before using.",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./global": {
+      "types": "./dist/global.d.ts",
+      "import": "./dist/global.js"
+    }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "prepare": "npm run build",
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-strip-types 'test/**/*.test.ts'",
+    "lint": "biome lint .",
+    "format": "biome format --write .",
+    "check": "biome check .",
+    "check:fix": "biome check --write .",
+    "prepublishOnly": "npm run typecheck && npm run check && npm test && npm run build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/johnhenry/mallory.git",
+    "directory": "packages/math-prototype-patch"
+  },
+  "keywords": [
+    "complex-number",
+    "number-prototype",
+    "monkey-patch",
+    "typescript"
+  ],
+  "author": "John Henry",
+  "license": "MIT",
+  "dependencies": {
+    "mallory-math": "^0.11.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.9.0"
+  },
+  "engines": {
+    "node": ">=22.12.0"
+  }
+}

--- a/packages/math-prototype-patch/src/global.ts
+++ b/packages/math-prototype-patch/src/global.ts
@@ -1,0 +1,37 @@
+/**
+ * Ambient TYPE augmentation for `Number.prototype`, matching the methods
+ * `patchNumberPrototype()` (see `./index.ts`) adds at runtime -- kept as a
+ * SEPARATE opt-in import (`import "mallory-math-prototype-patch/global";`)
+ * rather than folded into the main entry point, since a `declare global`
+ * block is a whole-program effect the moment ANY file imports it,
+ * regardless of whether `patchNumberPrototype()` was ever actually
+ * called. Importing this without calling `patchNumberPrototype()` gives
+ * you types for methods that don't exist at runtime; importing
+ * `patchNumberPrototype()` without this gives you real methods TypeScript
+ * doesn't know about. Do both, deliberately, or neither.
+ */
+import type { ComplexNumber } from "mallory-math";
+
+/** See index.ts's identical local alias -- mallory-math doesn't export `CNInput` publicly. */
+type CNInput = ComplexNumber | number;
+
+declare global {
+  interface Number {
+    add(other?: CNInput): ComplexNumber;
+    subtract(other?: CNInput): ComplexNumber;
+    multiply(other?: CNInput): ComplexNumber;
+    divide(other?: CNInput): ComplexNumber;
+    power(exponent?: CNInput, selector?: number): ComplexNumber;
+    conjugate(): ComplexNumber;
+    reciprocal(): ComplexNumber;
+    magnitude(): number;
+    angle(): number;
+    neg(): ComplexNumber;
+    sine(): ComplexNumber;
+    cosine(): ComplexNumber;
+    tangent(): ComplexNumber;
+    squareRoot(): ComplexNumber;
+    logarithm(base?: CNInput, selectA?: number, selectB?: number): ComplexNumber;
+    toComplexNumber(): ComplexNumber;
+  }
+}

--- a/packages/math-prototype-patch/src/index.ts
+++ b/packages/math-prototype-patch/src/index.ts
@@ -1,0 +1,141 @@
+/**
+ * mallory-math-prototype-patch (issue #28) — an OPT-IN, collision-checked
+ * patch of `Number.prototype` with `ComplexNumber`'s fluent arithmetic/
+ * trig methods, so a plain JS number can participate directly in complex
+ * arithmetic: `(3).add(new ComplexNumber(1, 2))` instead of
+ * `new ComplexNumber(3).add(...)`.
+ *
+ * Deliberately a SEPARATE package from `mallory-math` itself, never
+ * merged into core -- patching a built-in prototype is a process-wide,
+ * global-realm effect (every module in the process observes it, not just
+ * callers that imported this package), a categorically bigger risk
+ * surface than adding a method to `ComplexNumber`. Nothing here runs on
+ * import: `patchNumberPrototype()` must be called explicitly. See the
+ * README before calling it.
+ */
+import { ComplexNumber } from "mallory-math";
+
+/**
+ * mirrors mallory-math's own (internal, unexported) `CNInput` -- anything
+ * `ComplexNumber`'s fluent methods accept as an operand. Defined locally
+ * rather than depending on an export mallory-math doesn't make public,
+ * keeping this package's surface fully self-contained.
+ */
+type CNInput = ComplexNumber | number;
+
+const PATCH_METHODS = {
+  add(this: number, other: CNInput = 0): ComplexNumber {
+    return new ComplexNumber(this).add(other);
+  },
+  subtract(this: number, other: CNInput = 0): ComplexNumber {
+    return new ComplexNumber(this).subtract(other);
+  },
+  multiply(this: number, other: CNInput = 1): ComplexNumber {
+    return new ComplexNumber(this).multiply(other);
+  },
+  divide(this: number, other: CNInput = 1): ComplexNumber {
+    return new ComplexNumber(this).divide(other);
+  },
+  power(this: number, exponent: CNInput = 1, selector = 0): ComplexNumber {
+    return new ComplexNumber(this).power(exponent, selector);
+  },
+  conjugate(this: number): ComplexNumber {
+    return new ComplexNumber(this).conjugate();
+  },
+  reciprocal(this: number): ComplexNumber {
+    return new ComplexNumber(this).reciprocal();
+  },
+  magnitude(this: number): number {
+    return new ComplexNumber(this).magnitude();
+  },
+  angle(this: number): number {
+    return new ComplexNumber(this).angle();
+  },
+  neg(this: number): ComplexNumber {
+    return new ComplexNumber(this).neg();
+  },
+  sine(this: number): ComplexNumber {
+    return new ComplexNumber(this).sine();
+  },
+  cosine(this: number): ComplexNumber {
+    return new ComplexNumber(this).cosine();
+  },
+  tangent(this: number): ComplexNumber {
+    return new ComplexNumber(this).tangent();
+  },
+  squareRoot(this: number): ComplexNumber {
+    return new ComplexNumber(this).squareRoot();
+  },
+  logarithm(this: number, base: CNInput = Math.E, selectA = 0, selectB = 0): ComplexNumber {
+    return new ComplexNumber(this).logarithm(base, selectA, selectB);
+  },
+  toComplexNumber(this: number): ComplexNumber {
+    return new ComplexNumber(this);
+  },
+} satisfies Record<string, (this: number, ...args: any[]) => unknown>;
+
+/** Every method name this package would add -- for introspection before committing to `patchNumberPrototype()`. */
+export const PATCH_METHOD_NAMES: readonly string[] = Object.keys(PATCH_METHODS);
+
+export class NumberPrototypeCollisionError extends Error {
+  readonly collidingNames: readonly string[];
+  constructor(collidingNames: readonly string[]) {
+    super(
+      `Number.prototype already defines: ${collidingNames.join(", ")}. ` +
+        "mallory-math-prototype-patch refuses to overwrite an existing member -- " +
+        "something else (another library, a polyfill, a previous patch) already claimed it.",
+    );
+    this.name = "NumberPrototypeCollisionError";
+    this.collidingNames = collidingNames;
+  }
+}
+
+let patched = false;
+
+/** Whether `patchNumberPrototype()` has been called (and not since undone by `unpatchNumberPrototype()`) in this process. */
+export function isNumberPrototypePatched(): boolean {
+  return patched;
+}
+
+/**
+ * Patches `Number.prototype` with `ComplexNumber`'s fluent arithmetic/trig
+ * methods (see {@link PATCH_METHOD_NAMES} for the exact list).
+ *
+ * THIS IS A GLOBAL, PROCESS-WIDE SIDE EFFECT: it mutates the one shared
+ * `Number.prototype` every module in the process reads from, not just
+ * callers that imported this package. Only call this if you understand
+ * and accept that -- see the README's "only call this if..." warning.
+ *
+ * Refuses to patch (throws {@link NumberPrototypeCollisionError}) if ANY
+ * target name already exists as an own property of `Number.prototype` --
+ * never silently overwrites something else's method. Idempotent: calling
+ * it again while already patched by THIS function is a no-op (not a
+ * collision against itself).
+ */
+export function patchNumberPrototype(): void {
+  if (patched) return;
+  const colliding = PATCH_METHOD_NAMES.filter((name) => Object.hasOwn(Number.prototype, name));
+  if (colliding.length > 0) throw new NumberPrototypeCollisionError(colliding);
+  for (const name of PATCH_METHOD_NAMES) {
+    Object.defineProperty(Number.prototype, name, {
+      value: PATCH_METHODS[name as keyof typeof PATCH_METHODS],
+      writable: true,
+      configurable: true,
+      enumerable: false,
+    });
+  }
+  patched = true;
+}
+
+/**
+ * Reverses {@link patchNumberPrototype} -- removes exactly the members it
+ * added. No-op if not currently patched (whether never patched, or
+ * already unpatched).
+ */
+export function unpatchNumberPrototype(): void {
+  if (!patched) return;
+  for (const name of PATCH_METHOD_NAMES) {
+    delete (Number.prototype as unknown as Record<string, unknown>)[name];
+  }
+  patched = false;
+}

--- a/packages/math-prototype-patch/test/global-types.test.ts
+++ b/packages/math-prototype-patch/test/global-types.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { ComplexNumber } from "mallory-math";
+import "../src/global.ts";
+import { patchNumberPrototype, unpatchNumberPrototype } from "../src/index.ts";
+
+afterEach(() => {
+  unpatchNumberPrototype();
+});
+
+test("global.ts's ambient types let TS compile a call to a patched method with no `as any`, and it works once actually patched", () => {
+  patchNumberPrototype();
+  // No cast needed here -- this is exactly what importing "../src/global.ts"
+  // buys a consumer over index.test.ts's `as any` workaround.
+  const result: ComplexNumber = (3).add(new ComplexNumber(1, 2));
+  assert.equal(result.value, 4);
+  assert.equal(result.iValue, 2);
+});

--- a/packages/math-prototype-patch/test/index.test.ts
+++ b/packages/math-prototype-patch/test/index.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import { ComplexNumber } from "mallory-math";
+import {
+  isNumberPrototypePatched,
+  NumberPrototypeCollisionError,
+  PATCH_METHOD_NAMES,
+  patchNumberPrototype,
+  unpatchNumberPrototype,
+} from "../src/index.ts";
+
+// Every test unpatches afterward -- these tests mutate the one shared,
+// process-wide Number.prototype, so leaving it patched would leak into
+// every OTHER test file's run (node:test runs files in the same process).
+afterEach(() => {
+  unpatchNumberPrototype();
+});
+
+test("isNumberPrototypePatched: false before patching, true after, false again after unpatching", () => {
+  assert.equal(isNumberPrototypePatched(), false);
+  patchNumberPrototype();
+  assert.equal(isNumberPrototypePatched(), true);
+  unpatchNumberPrototype();
+  assert.equal(isNumberPrototypePatched(), false);
+});
+
+test("patchNumberPrototype: adds exactly PATCH_METHOD_NAMES as non-enumerable own properties of Number.prototype", () => {
+  patchNumberPrototype();
+  for (const name of PATCH_METHOD_NAMES) {
+    assert.ok(Object.hasOwn(Number.prototype, name), `missing ${name}`);
+    const descriptor = Object.getOwnPropertyDescriptor(Number.prototype, name);
+    assert.equal(
+      descriptor?.enumerable,
+      false,
+      `${name} should not be enumerable (would show up in for...in over numbers)`,
+    );
+  }
+  // Doesn't leak into a plain object's for...in either.
+  for (const _key in {}) assert.fail("unexpected enumerable key");
+});
+
+test("patchNumberPrototype: is idempotent when called twice in a row (not a self-collision)", () => {
+  patchNumberPrototype();
+  assert.doesNotThrow(() => patchNumberPrototype());
+  assert.equal(isNumberPrototypePatched(), true);
+});
+
+test("patchNumberPrototype: throws NumberPrototypeCollisionError and patches nothing if a target name already exists", () => {
+  const marker = () => "not mine";
+  Object.defineProperty(Number.prototype, "add", { value: marker, configurable: true });
+  try {
+    assert.throws(() => patchNumberPrototype(), NumberPrototypeCollisionError);
+    assert.equal(isNumberPrototypePatched(), false);
+    // Every other (non-colliding) method must ALSO be absent -- an
+    // all-or-nothing patch, not a partial one that silently skipped `add`.
+    assert.ok(!Object.hasOwn(Number.prototype, "subtract"));
+  } finally {
+    delete (Number.prototype as unknown as Record<string, unknown>).add;
+  }
+});
+
+test("NumberPrototypeCollisionError: names the exact colliding member(s)", () => {
+  Object.defineProperty(Number.prototype, "magnitude", { value: () => 0, configurable: true });
+  Object.defineProperty(Number.prototype, "angle", { value: () => 0, configurable: true });
+  try {
+    assert.throws(
+      () => patchNumberPrototype(),
+      (e: unknown) => {
+        assert.ok(e instanceof NumberPrototypeCollisionError);
+        assert.deepEqual([...e.collidingNames].sort(), ["angle", "magnitude"]);
+        return true;
+      },
+    );
+  } finally {
+    delete (Number.prototype as unknown as Record<string, unknown>).magnitude;
+    delete (Number.prototype as unknown as Record<string, unknown>).angle;
+  }
+});
+
+test("unpatchNumberPrototype: no-op when not currently patched", () => {
+  assert.equal(isNumberPrototypePatched(), false);
+  assert.doesNotThrow(() => unpatchNumberPrototype());
+  assert.equal(isNumberPrototypePatched(), false);
+});
+
+test("patched arithmetic: (3).add(1+2i) matches ComplexNumber(3).add(1+2i) exactly", () => {
+  patchNumberPrototype();
+  const patched = (3 as any).add(new ComplexNumber(1, 2));
+  const expected = new ComplexNumber(3).add(new ComplexNumber(1, 2));
+  assert.ok(patched instanceof ComplexNumber);
+  assert.equal(patched.value, expected.value);
+  assert.equal(patched.iValue, expected.iValue);
+});
+
+test("patched arithmetic: (2).power(i) matches the hand-computed Euler form e^(i*ln2)", () => {
+  patchNumberPrototype();
+  const result = (2 as any).power(ComplexNumber.I);
+  const expectedRe = Math.cos(Math.log(2));
+  const expectedIm = Math.sin(Math.log(2));
+  assert.ok(Math.abs(result.value - expectedRe) < 1e-9);
+  assert.ok(Math.abs(result.iValue - expectedIm) < 1e-9);
+});
+
+test("patched arithmetic: (4).magnitude() and (4).angle() match a real ComplexNumber's", () => {
+  patchNumberPrototype();
+  const n = 4 as any;
+  assert.equal(n.magnitude(), new ComplexNumber(4).magnitude());
+  assert.equal(n.angle(), new ComplexNumber(4).angle());
+});
+
+test("patched arithmetic: (5).toComplexNumber() equals new ComplexNumber(5)", () => {
+  patchNumberPrototype();
+  const z = (5 as any).toComplexNumber();
+  assert.ok(z instanceof ComplexNumber);
+  assert.ok(z.equals(new ComplexNumber(5)));
+});
+
+test("after unpatchNumberPrototype, the added methods are gone from plain numbers", () => {
+  patchNumberPrototype();
+  unpatchNumberPrototype();
+  assert.equal(typeof (3 as any).add, "undefined");
+});

--- a/packages/math-prototype-patch/tsconfig.json
+++ b/packages/math-prototype-patch/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "ESNext.Disposable"],
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": false,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Closes #28. A new, separate package (`mallory-math-prototype-patch`), following the issue's own explicit design constraints -- never merged into core `mallory-math`, since patching a built-in prototype is a process-wide, global-realm effect (every module in the process observes it), categorically riskier than adding a method to `ComplexNumber` itself.

- `patchNumberPrototype()` / `unpatchNumberPrototype()` / `isNumberPrototypePatched()`: adds `ComplexNumber`'s fluent arithmetic/trig surface (`add`, `subtract`, `multiply`, `divide`, `power`, `conjugate`, `reciprocal`, `magnitude`, `angle`, `neg`, `sine`, `cosine`, `tangent`, `squareRoot`, `logarithm`, `toComplexNumber`) to `Number.prototype`, as non-enumerable properties. **Nothing runs on import** -- the mutation only happens inside an explicit `patchNumberPrototype()` call.
- **Collision-checked**, per the issue's own requirement: refuses to patch (throws `NumberPrototypeCollisionError` naming every colliding member) if *any* target name already exists as an own property of `Number.prototype` -- all-or-nothing, never a silent partial patch or overwrite.
- A separate `"./global"` export carries the ambient TypeScript augmentation (`declare global { interface Number {...} }`), deliberately kept apart from the main entry point since a global type augmentation is a whole-program effect the instant any file imports it, independent of whether the runtime patch was ever applied.
- README leads with the explicit "only call this if you understand the global side effect" warning the issue calls for.

## Test plan

- [x] `npm run typecheck` (all workspaces) clean
- [x] `npm test` (all workspaces) -- 12/12 new tests passing, 507/514 passing repo-wide (pre-existing unrelated skips), including a genuine end-to-end proof that `(2).power(i)` matches the hand-computed Euler form `e^(i·ln2)`
- [x] `npm run check` (Biome, repo-wide) clean
- [x] `npm run build` (all workspaces) succeeds
- [x] Manually verified the `./global` ambient types actually type-check a real consumer call with no cast, via a direct `tsc --strict` run against the test file (this monorepo's own `typecheck` script only covers `src/`, matching its established convention, so this was a manual double-check beyond the standard gate)