### PR TITLE
math: extract func-derivative rules into a data table

### DIFF
--- a/packages/math/src/Symbolic.ts
+++ b/packages/math/src/Symbolic.ts
@@ -4,6 +4,7 @@
  * integration, Taylor expansion, polynomial equation solving/factoring,
  * limits, LaTeX rendering, and numeric evaluation.
  */
+import { FUNC_DERIVATIVE_RULES } from "./differentiation-rules.ts";
 import { MatrixMath } from "./MatrixMath.ts";
 import { Numerical } from "./Numerical.ts";
 import { Rational } from "./Rational.ts";
@@ -1214,123 +1215,7 @@ function diffTraced(e: Expr, x: string, steps: DifferentiationStep[]): Expr {
       rule = `Chain Rule (${e.name})`;
       const u = e.arg;
       const du = diffTraced(u, x, steps);
-      switch (e.name) {
-        case "sin":
-          result = mul(fn("cos", u), du);
-          break;
-        case "cos":
-          result = neg(mul(fn("sin", u), du));
-          break;
-        case "tan":
-          result = div(du, pow(fn("cos", u), num(2)));
-          break;
-        case "exp":
-          result = mul(fn("exp", u), du);
-          break;
-        case "ln":
-          result = div(du, u);
-          break;
-        case "sqrt":
-          result = div(du, mul(num(2), fn("sqrt", u)));
-          break;
-        case "asin":
-          result = div(du, fn("sqrt", sub(num(1), pow(u, num(2)))));
-          break;
-        case "acos":
-          result = neg(div(du, fn("sqrt", sub(num(1), pow(u, num(2))))));
-          break;
-        case "atan":
-          result = div(du, add(num(1), pow(u, num(2))));
-          break;
-        case "sinh":
-          result = mul(fn("cosh", u), du);
-          break;
-        case "cosh":
-          result = mul(fn("sinh", u), du);
-          break;
-        case "tanh":
-          result = div(du, pow(fn("cosh", u), num(2)));
-          break;
-        case "cot":
-          result = neg(mul(pow(fn("csc", u), num(2)), du));
-          break;
-        case "sec":
-          result = mul(mul(fn("sec", u), fn("tan", u)), du);
-          break;
-        case "csc":
-          result = neg(mul(mul(fn("csc", u), fn("cot", u)), du));
-          break;
-        case "asinh":
-          result = div(du, fn("sqrt", add(pow(u, num(2)), num(1))));
-          break;
-        case "acosh":
-          result = div(du, fn("sqrt", sub(pow(u, num(2)), num(1))));
-          break;
-        case "atanh":
-          result = div(du, sub(num(1), pow(u, num(2))));
-          break;
-        case "coth":
-          result = neg(mul(pow(fn("csch", u), num(2)), du));
-          break;
-        case "sech":
-          result = neg(mul(mul(fn("sech", u), fn("tanh", u)), du));
-          break;
-        case "csch":
-          result = neg(mul(mul(fn("csch", u), fn("coth", u)), du));
-          break;
-        case "acot":
-          result = neg(div(du, add(num(1), pow(u, num(2)))));
-          break;
-        case "asec":
-          result = div(du, mul(fn("abs", u), fn("sqrt", sub(pow(u, num(2)), num(1)))));
-          break;
-        case "acsc":
-          result = neg(div(du, mul(fn("abs", u), fn("sqrt", sub(pow(u, num(2)), num(1))))));
-          break;
-        case "acoth":
-          result = div(du, sub(num(1), pow(u, num(2))));
-          break;
-        case "asech":
-          result = neg(div(du, mul(u, fn("sqrt", sub(num(1), pow(u, num(2)))))));
-          break;
-        case "acsch":
-          result = neg(div(du, mul(fn("abs", u), fn("sqrt", add(num(1), pow(u, num(2)))))));
-          break;
-        case "abs":
-          result = mul(fn("sign", u), du);
-          break;
-        case "log10":
-          result = div(du, mul(u, fn("ln", num(10))));
-          break;
-        case "log2":
-          result = div(du, mul(u, fn("ln", num(2))));
-          break;
-        case "cbrt":
-          result = div(du, mul(num(3), pow(fn("cbrt", u), num(2))));
-          break;
-        case "floor":
-        case "ceil":
-        case "round":
-        case "sign":
-        case "trunc":
-          result = num(0);
-          break;
-        case "expm1":
-          result = mul(fn("exp", u), du);
-          break;
-        case "log1p":
-          result = div(du, add(num(1), u));
-          break;
-        case "sigmoid":
-          result = mul(mul(fn("sigmoid", u), sub(num(1), fn("sigmoid", u))), du);
-          break;
-        case "erf":
-          result = mul(mul(div(num(2), fn("sqrt", num(Math.PI))), fn("exp", neg(pow(u, num(2))))), du);
-          break;
-        case "relu":
-          result = mul(div(add(num(1), fn("sign", u)), num(2)), du);
-          break;
-      }
+      result = FUNC_DERIVATIVE_RULES[e.name](u, du);
       break;
     }
     case "call2": {
@@ -1424,88 +1309,7 @@ function diff(e: Expr, x: string): Expr {
     case "func": {
       const u = e.arg;
       const du = diff(u, x);
-      const name = e.name;
-      switch (name) {
-        case "sin":
-          return mul(fn("cos", u), du);
-        case "cos":
-          return neg(mul(fn("sin", u), du));
-        case "tan":
-          return div(du, pow(fn("cos", u), num(2)));
-        case "exp":
-          return mul(fn("exp", u), du);
-        case "ln":
-          return div(du, u);
-        case "sqrt":
-          return div(du, mul(num(2), fn("sqrt", u)));
-        case "asin":
-          return div(du, fn("sqrt", sub(num(1), pow(u, num(2)))));
-        case "acos":
-          return neg(div(du, fn("sqrt", sub(num(1), pow(u, num(2))))));
-        case "atan":
-          return div(du, add(num(1), pow(u, num(2))));
-        case "sinh":
-          return mul(fn("cosh", u), du);
-        case "cosh":
-          return mul(fn("sinh", u), du);
-        case "tanh":
-          return div(du, pow(fn("cosh", u), num(2)));
-        case "cot":
-          return neg(mul(pow(fn("csc", u), num(2)), du));
-        case "sec":
-          return mul(mul(fn("sec", u), fn("tan", u)), du);
-        case "csc":
-          return neg(mul(mul(fn("csc", u), fn("cot", u)), du));
-        case "asinh":
-          return div(du, fn("sqrt", add(pow(u, num(2)), num(1))));
-        case "acosh":
-          return div(du, fn("sqrt", sub(pow(u, num(2)), num(1))));
-        case "atanh":
-          return div(du, sub(num(1), pow(u, num(2))));
-        case "coth":
-          return neg(mul(pow(fn("csch", u), num(2)), du));
-        case "sech":
-          return neg(mul(mul(fn("sech", u), fn("tanh", u)), du));
-        case "csch":
-          return neg(mul(mul(fn("csch", u), fn("coth", u)), du));
-        case "acot":
-          return neg(div(du, add(num(1), pow(u, num(2)))));
-        case "asec":
-          return div(du, mul(fn("abs", u), fn("sqrt", sub(pow(u, num(2)), num(1)))));
-        case "acsc":
-          return neg(div(du, mul(fn("abs", u), fn("sqrt", sub(pow(u, num(2)), num(1))))));
-        case "acoth":
-          return div(du, sub(num(1), pow(u, num(2))));
-        case "asech":
-          return neg(div(du, mul(u, fn("sqrt", sub(num(1), pow(u, num(2)))))));
-        case "acsch":
-          return neg(div(du, mul(fn("abs", u), fn("sqrt", add(num(1), pow(u, num(2)))))));
-        case "abs":
-          return mul(fn("sign", u), du);
-        case "log10":
-          return div(du, mul(u, fn("ln", num(10))));
-        case "log2":
-          return div(du, mul(u, fn("ln", num(2))));
-        case "cbrt":
-          return div(du, mul(num(3), pow(fn("cbrt", u), num(2))));
-        case "floor":
-        case "ceil":
-        case "round":
-        case "sign":
-        case "trunc":
-          return num(0);
-        case "expm1":
-          return mul(fn("exp", u), du);
-        case "log1p":
-          return div(du, add(num(1), u));
-        case "sigmoid":
-          return mul(mul(fn("sigmoid", u), sub(num(1), fn("sigmoid", u))), du);
-        case "erf":
-          return mul(mul(div(num(2), fn("sqrt", num(Math.PI))), fn("exp", neg(pow(u, num(2))))), du);
-        case "relu":
-          return mul(div(add(num(1), fn("sign", u)), num(2)), du);
-      }
-      throw new Error(`Unhandled function: ${name}`);
+      return FUNC_DERIVATIVE_RULES[e.name](u, du);
     }
     case "call2": {
       const l = e.left;

--- a/packages/math/src/differentiation-rules.ts
+++ b/packages/math/src/differentiation-rules.ts
@@ -1,0 +1,73 @@
+/**
+ * Data-driven derivative rules for single-argument elementary functions --
+ * the `func` `Expr` variant (`sin`, `exp`, `asinh`, etc.). This is the
+ * "declarative rewrite-rule table" from the Woxi-study design note
+ * (github.com/johnhenry/mallory#15): each `FuncName` maps to a pure function
+ * from (the function's argument `u`, its already-differentiated form `du`)
+ * to d/dx[f(u)]. The chain-rule wrapping itself (computing `du` and
+ * dispatching on `e.name`) stays in Symbolic.ts, since that's structural
+ * recursion over the `Expr` union, not a per-function identity.
+ *
+ * Keeping this as a `Record<FuncName, ...>` rather than a `switch` means:
+ * adding/fixing one function's derivative touches one line here, not the
+ * differentiation engine; TypeScript enforces every `FuncName` has an entry
+ * (no `throw new Error("Unhandled function")` needed); and each rule is
+ * independently unit-testable (see differentiation-rules.test.ts).
+ */
+import type { Expr, FuncName } from "./Symbolic.ts";
+
+const num = (value: number): Expr => ({ type: "const", value });
+const add = (left: Expr, right: Expr): Expr => ({ type: "add", left, right });
+const sub = (left: Expr, right: Expr): Expr => ({ type: "sub", left, right });
+const mul = (left: Expr, right: Expr): Expr => ({ type: "mul", left, right });
+const div = (left: Expr, right: Expr): Expr => ({ type: "div", left, right });
+const pow = (base: Expr, exp: Expr): Expr => ({ type: "pow", base, exp });
+const neg = (arg: Expr): Expr => ({ type: "neg", arg });
+const fn = (name: FuncName, arg: Expr): Expr => ({ type: "func", name, arg });
+
+/** d/dx[f(u)] given `u` and `du` (= du/dx, already computed by the caller). */
+export type FuncDerivativeRule = (u: Expr, du: Expr) => Expr;
+
+export const FUNC_DERIVATIVE_RULES: Record<FuncName, FuncDerivativeRule> = {
+  sin: (u, du) => mul(fn("cos", u), du),
+  cos: (u, du) => neg(mul(fn("sin", u), du)),
+  tan: (u, du) => div(du, pow(fn("cos", u), num(2))),
+  exp: (u, du) => mul(fn("exp", u), du),
+  ln: (u, du) => div(du, u),
+  sqrt: (u, du) => div(du, mul(num(2), fn("sqrt", u))),
+  asin: (u, du) => div(du, fn("sqrt", sub(num(1), pow(u, num(2))))),
+  acos: (u, du) => neg(div(du, fn("sqrt", sub(num(1), pow(u, num(2)))))),
+  atan: (u, du) => div(du, add(num(1), pow(u, num(2)))),
+  sinh: (u, du) => mul(fn("cosh", u), du),
+  cosh: (u, du) => mul(fn("sinh", u), du),
+  tanh: (u, du) => div(du, pow(fn("cosh", u), num(2))),
+  cot: (u, du) => neg(mul(pow(fn("csc", u), num(2)), du)),
+  sec: (u, du) => mul(mul(fn("sec", u), fn("tan", u)), du),
+  csc: (u, du) => neg(mul(mul(fn("csc", u), fn("cot", u)), du)),
+  asinh: (u, du) => div(du, fn("sqrt", add(pow(u, num(2)), num(1)))),
+  acosh: (u, du) => div(du, fn("sqrt", sub(pow(u, num(2)), num(1)))),
+  atanh: (u, du) => div(du, sub(num(1), pow(u, num(2)))),
+  coth: (u, du) => neg(mul(pow(fn("csch", u), num(2)), du)),
+  sech: (u, du) => neg(mul(mul(fn("sech", u), fn("tanh", u)), du)),
+  csch: (u, du) => neg(mul(mul(fn("csch", u), fn("coth", u)), du)),
+  acot: (u, du) => neg(div(du, add(num(1), pow(u, num(2))))),
+  asec: (u, du) => div(du, mul(fn("abs", u), fn("sqrt", sub(pow(u, num(2)), num(1))))),
+  acsc: (u, du) => neg(div(du, mul(fn("abs", u), fn("sqrt", sub(pow(u, num(2)), num(1)))))),
+  acoth: (u, du) => div(du, sub(num(1), pow(u, num(2)))),
+  asech: (u, du) => neg(div(du, mul(u, fn("sqrt", sub(num(1), pow(u, num(2))))))),
+  acsch: (u, du) => neg(div(du, mul(fn("abs", u), fn("sqrt", add(num(1), pow(u, num(2))))))),
+  abs: (u, du) => mul(fn("sign", u), du),
+  log10: (u, du) => div(du, mul(u, fn("ln", num(10)))),
+  log2: (u, du) => div(du, mul(u, fn("ln", num(2)))),
+  cbrt: (u, du) => div(du, mul(num(3), pow(fn("cbrt", u), num(2)))),
+  floor: () => num(0),
+  ceil: () => num(0),
+  round: () => num(0),
+  sign: () => num(0),
+  trunc: () => num(0),
+  expm1: (u, du) => mul(fn("exp", u), du),
+  log1p: (u, du) => div(du, add(num(1), u)),
+  sigmoid: (u, du) => mul(mul(fn("sigmoid", u), sub(num(1), fn("sigmoid", u))), du),
+  erf: (u, du) => mul(mul(div(num(2), fn("sqrt", num(Math.PI))), fn("exp", neg(pow(u, num(2))))), du),
+  relu: (u, du) => mul(div(add(num(1), fn("sign", u)), num(2)), du),
+};

--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -24,6 +24,7 @@ export {
   type TestResult,
 } from "./Distributions.ts";
 export { DualNumber } from "./DualNumber.ts";
+export { FUNC_DERIVATIVE_RULES, type FuncDerivativeRule } from "./differentiation-rules.ts";
 // Expression evaluation
 export { Environment } from "./Environment.ts";
 export { Expression } from "./Expression.ts";

--- a/packages/math/test/differentiation-rules.test.ts
+++ b/packages/math/test/differentiation-rules.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { FUNC_DERIVATIVE_RULES } from "../src/differentiation-rules.ts";
+import type { Expr, FuncName } from "../src/Symbolic.ts";
+import { FUNCTION_NAMES, Symbolic } from "../src/Symbolic.ts";
+
+const x: Expr = { type: "var", name: "x" };
+const dxdx: Expr = { type: "const", value: 1 };
+
+const evalFuncAt = (name: FuncName, point: number): number =>
+  Symbolic.evaluate({ type: "func", name, arg: x }, { x: point }) as number;
+
+/** A domain-safe evaluation point for each `FuncName`, away from singularities/kinks. */
+const SAFE_POINT: Record<FuncName, number> = {
+  sin: 0.6,
+  cos: 0.6,
+  tan: 0.6,
+  exp: 0.6,
+  ln: 2,
+  sqrt: 4,
+  asin: 0.3,
+  acos: 0.3,
+  atan: 0.6,
+  sinh: 0.6,
+  cosh: 0.6,
+  tanh: 0.6,
+  cot: 0.6,
+  sec: 0.6,
+  csc: 0.6,
+  asinh: 0.6,
+  acosh: 2,
+  atanh: 0.3,
+  coth: 0.6,
+  sech: 0.6,
+  csch: 0.6,
+  acot: 0.6,
+  asec: 2,
+  acsc: 2,
+  acoth: 2,
+  asech: 0.5,
+  acsch: 0.6,
+  abs: 0.6,
+  log10: 2,
+  log2: 2,
+  cbrt: 2,
+  floor: 0.37,
+  ceil: 0.37,
+  round: 0.37,
+  sign: 0.6,
+  trunc: 0.37,
+  expm1: 0.6,
+  log1p: 0.6,
+  sigmoid: 0.6,
+  erf: 0.6,
+  relu: 0.6,
+};
+
+test("FUNC_DERIVATIVE_RULES has exactly one entry per FuncName", () => {
+  const declaredNames = new Set(FUNCTION_NAMES);
+  const tableNames = Object.keys(FUNC_DERIVATIVE_RULES);
+  assert.equal(tableNames.length, new Set(tableNames).size, "no duplicate keys");
+  for (const name of tableNames) {
+    assert.ok(declaredNames.has(name), `${name} should be a recognized function name`);
+  }
+});
+
+for (const name of Object.keys(FUNC_DERIVATIVE_RULES) as FuncName[]) {
+  test(`FUNC_DERIVATIVE_RULES.${name} matches a central-difference numerical derivative`, () => {
+    const point = SAFE_POINT[name];
+    const symbolic = Symbolic.evaluate(FUNC_DERIVATIVE_RULES[name](x, dxdx), { x: point }) as number;
+    const h = 1e-5;
+    const numeric = (evalFuncAt(name, point + h) - evalFuncAt(name, point - h)) / (2 * h);
+    assert.ok(Math.abs(symbolic - numeric) < 1e-4, `${name}'(${point}): symbolic=${symbolic} numeric=${numeric}`);
+  });
+}
+
+test("FUNC_DERIVATIVE_RULES applies the chain rule via the du parameter", () => {
+  // d/dx sin(2x) = cos(2x) * 2, so passing du=2 should scale the result.
+  const withDu2 = Symbolic.evaluate(FUNC_DERIVATIVE_RULES.sin(x, { type: "const", value: 2 }), { x: 0.6 });
+  const withDu1 = Symbolic.evaluate(FUNC_DERIVATIVE_RULES.sin(x, dxdx), { x: 0.6 });
+  assert.ok(Math.abs((withDu2 as number) - 2 * (withDu1 as number)) < 1e-9);
+});
+
+test("piecewise-constant functions (floor/ceil/round/sign/trunc) differentiate to 0 regardless of du", () => {
+  for (const name of ["floor", "ceil", "round", "sign", "trunc"] as const) {
+    const result = FUNC_DERIVATIVE_RULES[name](x, { type: "const", value: 42 });
+    assert.deepEqual(result, { type: "const", value: 0 });
+  }
+});


### PR DESCRIPTION
Closes #15.

## What

`packages/math/src/differentiation-rules.ts` introduces `FUNC_DERIVATIVE_RULES: Record<FuncName, (u: Expr, du: Expr) => Expr>` -- one entry per single-argument elementary function (`sin`, `exp`, `asinh`, ...). `Symbolic.ts`'s `diff()` and `diffTraced()` both had an identical 84-case `switch` for this exact dispatch (down to the runtime `throw new Error("Unhandled function")` fallback); both now do `FUNC_DERIVATIVE_RULES[e.name](u, du)`.

This is the scoped-down version of the issue's "declarative rewrite-rule table" idea: data-driven derivative rules for the mechanical, per-function leaf identities, while structural recursion (`add`/`mul`/`pow`/`piecewise`/`sum`/`product`/...) stays engine code in `Symbolic.ts` -- not a full pattern-matching rewrite engine, per the issue's own explicit "NOT rules-all-the-way-down" framing.

## Why now (vs. staying "someday")

Working through it, this wasn't purely speculative: the two switches were an exact, unnoticed 84-line duplication (identical case bodies, `diffTraced` adds a `steps` trace string), and TypeScript's `Record<FuncName, ...>` gets static exhaustiveness for free -- the `throw new Error` fallback that existed only because a `switch` over a union isn't statically checked for completeness is gone entirely.

## Benefits (per the issue)

- **Individually testable**: `differentiation-rules.test.ts` unit-tests every table entry directly (numerically, via central difference, against `Symbolic.evaluate`) rather than only end-to-end through `Symbolic.differentiate`.
- **Contributable without touching engine code**: fixing/adding one function's derivative is now a one-line table edit.
- **Reusable by downstream consumers**: exported from `index.ts` (`FUNC_DERIVATIVE_RULES`, `type FuncDerivativeRule`) -- e.g. mallory-graph's `differentiateSteps`-driven UI could introspect it.

## Testing

- New `differentiation-rules.test.ts`: 44 tests (one per `FuncName` + a du-chain-rule check + a piecewise-constant check), all passing.
- Full `packages/math` suite: 551 pass / 7 pre-existing skips (up from 507 pass before this change).
- `npm run typecheck` clean.
- `npx biome check packages/math` clean.
- `npm run build --workspace=mallory-math` succeeds.