### PR TITLE
Fix infinite loop in NumberTheory.factorize/pollardRho on degenerate inputs

### DIFF
--- a/packages/math/src/NumberTheory.ts
+++ b/packages/math/src/NumberTheory.ts
@@ -144,6 +144,10 @@ export class NumberTheory {
   /** A single non-trivial factor of composite `n` via Pollard's rho (Brent). */
   static pollardRho(n: bigint | number): bigint {
     const num = big(n);
+    // n <= 1 has no non-trivial factor to find: `f(v) = (v*v+c) % 1n` collapses
+    // to 0 for every c, so `d = gcd(0, 1) = 1n` forever and the loop below never
+    // terminates. Reject degenerate inputs up front instead of hanging.
+    if (num <= 1n) throw new RangeError("NumberTheory.pollardRho: n must be greater than 1");
     if (num % 2n === 0n) return 2n;
     for (let c = 1n; ; c++) {
       let x = 2n;
@@ -162,6 +166,11 @@ export class NumberTheory {
   /** Full prime factorisation as sorted `[prime, exponent]` pairs. */
   static factorize(n: bigint | number): Array<[bigint, number]> {
     let num = babs(big(n));
+    // 0 has no well-defined prime factorization (every prime divides it, with
+    // no finite exponent) -- unlike 1, whose factorization is the empty
+    // product. Without this guard `0n % p === 0n` and `0n / p === 0n` forever,
+    // so the trial-division loop below never terminates.
+    if (num === 0n) throw new RangeError("NumberTheory.factorize: n must be non-zero");
     const counts = new Map<bigint, number>();
     const add = (p: bigint) => counts.set(p, (counts.get(p) ?? 0) + 1);
 

--- a/packages/math/test/NumberTheory.test.ts
+++ b/packages/math/test/NumberTheory.test.ts
@@ -56,6 +56,38 @@ test("factorize (Pollard rho) and eulerPhi", () => {
   assert.equal(NT.eulerPhi(36), 12n);
 });
 
+test("factorize/pollardRho on degenerate inputs terminate (regression for #36)", () => {
+  // 1's factorization is the empty product -- no factors, not a hang.
+  assert.deepEqual(NT.factorize(1), []);
+  assert.deepEqual(NT.factorize(1n), []);
+  // 0 has no well-defined prime factorization: every prime "divides" it with
+  // no finite exponent. Previously this hung forever (0n % p === 0n and
+  // 0n / p === 0n loop endlessly); it must now throw instead of hanging.
+  assert.throws(() => NT.factorize(0), RangeError);
+  assert.throws(() => NT.factorize(0n), RangeError);
+  // Negative numbers factor by absolute value.
+  assert.deepEqual(NT.factorize(-1), []);
+  assert.deepEqual(NT.factorize(-12), [
+    [2n, 2],
+    [3n, 1],
+  ]);
+  // A lone prime factor.
+  assert.deepEqual(NT.factorize(2), [[2n, 1]]);
+  assert.deepEqual(NT.factorize(17), [[17n, 1]]);
+
+  // pollardRho has no non-trivial factor to find for n <= 1 -- previously
+  // pollardRho(1n) hung forever (gcd collapses to 1 for every c); it must
+  // now throw instead of hanging.
+  assert.throws(() => NT.pollardRho(1n), RangeError);
+  assert.throws(() => NT.pollardRho(0n), RangeError);
+  assert.throws(() => NT.pollardRho(-5n), RangeError);
+  // Normal composite input still works.
+  assert.equal(NT.pollardRho(91n) === 7n || NT.pollardRho(91n) === 13n, true);
+
+  // eulerPhi(0) shares factorize's root cause and must also throw, not hang.
+  assert.throws(() => NT.eulerPhi(0), RangeError);
+});
+
 test("Legendre and Jacobi symbols", () => {
   assert.equal(NT.legendreSymbol(2, 7), 1); // 2 is a QR mod 7 (3^2=2)
   assert.equal(NT.legendreSymbol(3, 7), -1);


### PR DESCRIPTION
## Summary

Fixes #36 — `NumberTheory.factorize` and `NumberTheory.pollardRho` hung indefinitely on certain degenerate inputs.

- **`factorize(0n)` never terminated.** The small-prime trial-division loop (`while (num % p === 0n) { add(p); num /= p; }`) never exits for `num === 0n`, since `0n % p === 0n` and `0n / p === 0n` hold forever. `eulerPhi(0)` shared the same root cause since it delegates to `factorize`. 0 has no well-defined prime factorization (unlike 1, whose factorization is the empty product), so `factorize` now throws a `RangeError` for `n === 0` instead of looping — consistent with how `NumberTheory.mod` already throws for a zero modulus.
- **`pollardRho(1n)` (and 0, negative n) never terminated.** For `n <= 1`, `f(v) = (v*v+c) % n` collapses every value to 0, so `d = gcd(0, n)` never advances past 1 and both the inner `while (d === 1n)` loop and outer `for (c = 1n; ;)` loop run forever. `pollardRho` now throws a `RangeError` up front for `n <= 1`. This path isn't reachable through `factorize()` (which already guards `num > 1n` before pushing onto the stack), but `pollardRho` is a public static method and a directly-callable degenerate input.

Both hangs were reproduced and confirmed before the fix via:
```
timeout 5 node --experimental-strip-types -e '...'   # exit 124 (timeout killed it)
```
and confirmed terminating correctly (throwing `RangeError`) after the fix.

## Changes

- `packages/math/src/NumberTheory.ts` — guard `factorize` for `n === 0` and `pollardRho` for `n <= 1`, each throwing `RangeError` with an explanatory message.
- `packages/math/test/NumberTheory.test.ts` — new regression test covering `factorize`/`pollardRho`/`eulerPhi` on 0, 1, negative numbers, and a couple of normal prime/composite inputs to confirm the normal path is unaffected.

## Test plan

- [x] Reproduced both hangs pre-fix with a 5s `timeout` (exit 124)
- [x] Confirmed post-fix both throw `RangeError` instead of hanging
- [x] `npm test` in `packages/math`: 552 passed, 7 skipped (pre-existing/unrelated), 0 failed
- [x] `npm test` at the monorepo root (all workspaces): all passing
- [x] `npm run typecheck` in `packages/math` and at the monorepo root: clean