### PR TITLE
Fix VectorUtils perf bugs and flattenSDLevels depth bug

### DIFF
--- a/packages/math/src/VectorUtils.ts
+++ b/packages/math/src/VectorUtils.ts
@@ -180,7 +180,12 @@ export class VectorUtils {
   ): Vector<T> {
     const out = Vector.fromArray(seeds);
     if (keep) {
-      while (!endCondition(out)) out.push(formula([...out]));
+      // Pass the accumulator directly (not a fresh copy each time): the
+      // "caller's seeds untouched" guarantee only needs to protect the
+      // original `seeds` array (already copied into `out` above), not this
+      // internal accumulator. Spreading `out` on every push made this loop
+      // quadratic for large results.
+      while (!endCondition(out)) out.push(formula(out));
     } else {
       const window = [...seeds];
       while (!endCondition(window)) {
@@ -314,62 +319,82 @@ export class VectorUtils {
     const modes = new Vector<T>();
     if (list.length === 0) return modes;
 
-    const counted: T[] = [];
-    const counts: Array<{ value: T; occurences: number }> = [];
+    // Single linear pass with a Map (SameValueZero equality, matching the old
+    // Array#includes-based lookup) instead of an O(n) `includes` scan plus an
+    // O(n) `count` rescan per unique value.
+    const counts = new Map<T, number>();
+    const order: T[] = [];
     for (const value of list) {
-      if (!counted.includes(value)) {
-        counts.push({ value, occurences: VectorUtils.count(list, value) });
-        counted.push(value);
+      const occurences = counts.get(value);
+      if (occurences === undefined) {
+        counts.set(value, 1);
+        order.push(value);
+      } else {
+        counts.set(value, occurences + 1);
       }
     }
-    counts.sort((a, b) => b.occurences - a.occurences);
 
-    const highCount = counts[0].occurences;
-    for (const c of counts) {
-      if (c.occurences < highCount) break;
-      modes.push(c.value);
+    let highCount = 0;
+    for (const value of order) {
+      const occurences = counts.get(value) as number;
+      if (occurences > highCount) highCount = occurences;
+    }
+    for (const value of order) {
+      if (counts.get(value) === highCount) modes.push(value);
     }
     return modes;
   }
 
   /** Fully flatten a nested vector of arbitrary, possibly ragged depth. */
   static flatten(vector: Vector<unknown>): Vector<unknown> {
-    const out = vector.clone();
-    while (!VectorUtils.isFlat(out)) {
-      for (let i = 0; i < out.length; i++) {
-        const el = out[i];
+    // A single depth-first pass into a fresh output vector. The previous
+    // implementation repeatedly spliced elements into/out of a shared vector
+    // in place (`removeElement`/`addElement` are O(n) each), making it
+    // severely superlinear; this walk visits each leaf exactly once.
+    const out = new Vector<unknown>();
+    const walk = (v: Vector<unknown>): void => {
+      for (const el of v) {
         if (el instanceof Vector) {
-          const temp = el.clone();
-          out.removeElement(i);
-          for (const e of temp) {
-            out.addElement(e, i);
-            i++;
-          }
-          i--;
+          walk(el);
+        } else {
+          out.push(el);
         }
       }
-    }
+    };
+    walk(vector);
     return out;
   }
 
   /** Flatten one level of a vector whose elements share the same depth. */
   static flattenSD(vector: Vector<unknown>): Vector<unknown> {
-    const out = vector.clone();
-    if (out.length === 0) return new Vector<unknown>();
-    if (!(out[0] instanceof Vector)) return out;
+    if (vector.length === 0) return new Vector<unknown>();
+    if (!(vector[0] instanceof Vector)) return vector.clone();
 
-    while (out.length > 1) {
-      out[0] = VectorUtils.merge(out[0], out[1]).clone();
-      out.removeElement(1);
+    // One linear pass, spreading each vector element's own elements straight
+    // into a fresh output vector (matching `merge`'s vector+scalar behavior
+    // for any non-vector siblings). The previous implementation repeatedly
+    // called `merge` + deep `clone` on the ever-growing accumulator, an O(n)
+    // operation per element, making the whole pass quadratic.
+    const out = new Vector<unknown>();
+    for (const el of vector) {
+      if (el instanceof Vector) {
+        for (const e of el) out.push(e);
+      } else {
+        out.push(el);
+      }
     }
-    return out[0] as Vector<unknown>;
+    return out;
   }
 
   /** Flatten a same-depth vector by `depth` levels (fully if `depth` is 0). */
   static flattenSDLevels(vector: Vector<unknown>, depth = 0): Vector<unknown> {
     let out = vector.clone();
     const level = depth > 0 ? depth : VectorUtils.nestedDepthSD(vector);
-    for (let i = 0; i < level; i++) out = VectorUtils.flatten(out);
+    // Bug fix: this called `flatten` (unlimited, fully recursive), which made
+    // every `depth >= 1` produce the same fully-flat result on the first
+    // iteration — silently ignoring `depth`. `flattenSD` only peels one level
+    // per call, which is what "by `depth` levels" actually requires.
+    for (let i = 0; i < level; i++) out = VectorUtils.flattenSD(out);
     return out;
   }
 

--- a/packages/math/test/VectorUtils.test.ts
+++ b/packages/math/test/VectorUtils.test.ts
@@ -120,9 +120,95 @@ test("modes handles single, multi and empty", () => {
   assert.deepEqual([...VU.modes(v<number>())], []);
 });
 
+test("perf regression: modes/flatten/flattenSD/recursiveSequence stay roughly linear at scale", () => {
+  // Guards against reintroducing the quadratic-or-worse patterns fixed for
+  // issue #37 (Array#includes rescans, splice-heavy in-place edits, repeated
+  // merge+clone, and spreading the whole accumulator on every push). These
+  // were measured at 1-25+ seconds for n in the low thousands before the fix;
+  // a generous bound here still catches a regression to that complexity class.
+  const n = 6000;
+
+  const modesInput = Vector.fromArray(Array.from({ length: n }, (_, i) => i % 1500));
+  let t0 = performance.now();
+  const modesResult = VU.modes(modesInput);
+  assert.ok(performance.now() - t0 < 1000, "modes should be roughly linear");
+  assert.deepEqual([...modesResult].sort((a, b) => a - b), Array.from({ length: 1500 }, (_, i) => i));
+
+  const nested = Vector.fromArray(Array.from({ length: n }, (_, i) => v(i, i + 1)));
+  t0 = performance.now();
+  const flatResult = VU.flatten(nested);
+  assert.ok(performance.now() - t0 < 1000, "flatten should be roughly linear");
+  assert.equal(flatResult.length, n * 2);
+  assert.equal(flatResult[0], 0);
+  assert.equal(flatResult[flatResult.length - 1], n);
+
+  t0 = performance.now();
+  const flattenSDResult = VU.flattenSD(nested);
+  assert.ok(performance.now() - t0 < 1000, "flattenSD should be roughly linear");
+  assert.deepEqual([...flattenSDResult], [...flatResult]);
+
+  t0 = performance.now();
+  const seq = VU.recursiveSequence<number>(
+    [0, 1],
+    (s) => s.length,
+    (s) => (s as ArrayLike<number>).length >= n,
+    true,
+  );
+  assert.ok(performance.now() - t0 < 1000, "recursiveSequence(keep=true) should be roughly linear");
+  assert.equal(seq.length, n);
+});
+
 test("flatten ragged / flattenSD", () => {
   const ragged = Vector.fromArray<unknown>([1, v(2, v(3, 4)), 5]);
   assert.deepEqual([...VU.flatten(ragged)], [1, 2, 3, 4, 5]);
+
+  const sameDepth = mat([
+    [1, 2],
+    [3, 4],
+    [5, 6],
+  ]);
+  assert.deepEqual([...VU.flattenSD(sameDepth)], [1, 2, 3, 4, 5, 6]);
+
+  // Vector-first-element check: a flat (already non-nested) vector passes through unchanged.
+  assert.deepEqual([...VU.flattenSD(v(1, 2, 3))], [1, 2, 3]);
+  assert.deepEqual([...VU.flattenSD(v<number>())], []);
+});
+
+test("flattenSDLevels honors `depth` (bug fix: was calling flatten, ignoring depth)", () => {
+  // A depth-2 same-depth nested vector: each leaf pair is wrapped one extra level,
+  // e.g. outer[0] = [[1,2]] rather than [1,2].
+  const outer = Vector.fromArray<unknown>([
+    Vector.fromArray<unknown>([v(1, 2)]),
+    Vector.fromArray<unknown>([v(3, 4)]),
+    Vector.fromArray<unknown>([v(5, 6)]),
+    Vector.fromArray<unknown>([v(7, 8)]),
+  ]);
+  assert.equal(VU.nestedDepthSD(outer), 2);
+
+  // Peeling only 1 level must NOT fully flatten — this is exactly what the
+  // bug broke: calling `flatten` (unlimited) instead of `flattenSD` (one
+  // level) made every depth >= 1 produce the fully-flat result.
+  const peeled = VU.flattenSDLevels(outer, 1);
+  assert.deepEqual(deep(peeled), [
+    [1, 2],
+    [3, 4],
+    [5, 6],
+    [7, 8],
+  ]);
+
+  // Peeling all the way (depth omitted -> uses nestedDepthSD) does fully flatten.
+  const full = VU.flattenSDLevels(outer);
+  assert.deepEqual([...full], [1, 2, 3, 4, 5, 6, 7, 8]);
+
+  // Real-usage shape (kroneckerProduct style): a depth-1 structure flattened
+  // with an over-specified depth=2 must still fully flatten (the second,
+  // extra call to flattenSD on an already-flat vector is a no-op).
+  const depth1 = mat([
+    [0, 1],
+    [10, 11],
+    [20, 21],
+  ]);
+  assert.deepEqual([...VU.flattenSDLevels(depth1, 2)], [0, 1, 10, 11, 20, 21]);
 });
 
 test("collapse (sum) and count/matches", () => {

--- a/packages/math/test/VectorUtils.test.ts
+++ b/packages/math/test/VectorUtils.test.ts
@@ -132,7 +132,10 @@ test("perf regression: modes/flatten/flattenSD/recursiveSequence stay roughly li
   let t0 = performance.now();
   const modesResult = VU.modes(modesInput);
   assert.ok(performance.now() - t0 < 1000, "modes should be roughly linear");
-  assert.deepEqual([...modesResult].sort((a, b) => a - b), Array.from({ length: 1500 }, (_, i) => i));
+  assert.deepEqual(
+    [...modesResult].sort((a, b) => a - b),
+    Array.from({ length: 1500 }, (_, i) => i),
+  );
 
   const nested = Vector.fromArray(Array.from({ length: n }, (_, i) => v(i, i + 1)));
   t0 = performance.now();


### PR DESCRIPTION
## Summary

Fixes #37 — five bugs in `packages/math/src/VectorUtils.ts`:

- **`flattenSDLevels`** (real bug): called `flatten` (unlimited, fully recursive) instead of the sibling `flattenSD` (one-level-only), so every `depth >= 1` silently collapsed to the fully-flat result regardless of the requested depth. Now calls `flattenSD` per level, as the doc comment always said it should.
- **`recursiveSequence(..., keep=true)`**: was spreading the entire accumulator (`[...out]`) into `formula` on every push, making the loop O(n^2). Now passes the accumulator directly — the "caller's seeds array isn't mutated" guarantee only ever needed to protect the original `seeds` array, not this internal accumulator.
- **`modes`**: replaced an O(n) `Array#includes` scan plus an O(n) `count` rescan per unique value with a single linear pass through a `Map` (same SameValueZero equality as `includes`).
- **`flatten`**: replaced repeated in-place `removeElement`/`addElement` (each `Array.splice`-backed, O(n)) with a single depth-first walk into a fresh output vector.
- **`flattenSD`**: replaced repeated `merge` + deep `clone` on a growing accumulator with a single linear pass spreading each element's contents into a fresh output vector.

All measured superlinear before/near-linear after (see test plan). Confirmed real call sites (`kroneckerProduct` in `RealMath`/`ComplexMath`/`Structure`, which pass an over-specified `depth=2` for an actual depth-1 structure) still produce identical, fully-flat output after the `flattenSDLevels` fix — the extra iteration on an already-flat vector is a no-op.

## Test plan

- [x] Added a regression test asserting `flattenSDLevels(v, 1)` peels exactly one level (`[[1,2],[3,4],...]`) rather than fully flattening, plus a real-usage-shape check mirroring `kroneckerProduct`'s `depth=2` call.
- [x] Added correctness coverage for `flattenSD` (same-depth nesting, passthrough on non-nested input, empty input).
- [x] Added a perf smoke test (n=6000) asserting `modes`/`flatten`/`flattenSD`/`recursiveSequence(keep=true)` complete well under a generous time bound and produce correct output, to guard against reintroducing the quadratic patterns.
- [x] Full `packages/math` test suite passes (560/567, 7 pre-existing skips, 0 failures) in a clean clone of this branch.
- [x] `npm run typecheck` passes in `packages/math`.
- [x] Manual before/after timing: `flatten` n=4000 went from ~2.9s to ~2ms; `flattenSD` n=2000 from ~1.2s to ~1ms; `modes` n=4000 from ~120ms to ~1ms; `recursiveSequence` n=8000 from ~3.7s to <1ms.