### PR TITLE
math: fix 3 redundant-recomputation perf bugs (Graph3DUtils, Distributions, PolynomialRing)

### DIFF
--- a/packages/math/src/Distributions.ts
+++ b/packages/math/src/Distributions.ts
@@ -139,14 +139,15 @@ export class Distributions {
 
   static binomial(n: number, p: number, rng: () => number = Math.random): DiscreteDistribution {
     const logChoose = (k: number) => SF.lnGamma(n + 1) - SF.lnGamma(k + 1) - SF.lnGamma(n - k + 1);
+    const pmf = (k: number): number =>
+      k < 0 || k > n || !Number.isInteger(k) ? 0 : Math.exp(logChoose(k) + k * Math.log(p) + (n - k) * Math.log(1 - p));
     return {
-      pmf: (k) =>
-        k < 0 || k > n || !Number.isInteger(k)
-          ? 0
-          : Math.exp(logChoose(k) + k * Math.log(p) + (n - k) * Math.log(1 - p)),
+      pmf,
       cdf: (k) => {
+        // Reuse the single pmf closure above instead of rebuilding a whole new
+        // binomial distribution (and its logChoose closure) on every step.
         let s = 0;
-        for (let i = 0; i <= Math.floor(k); i++) s += Distributions.binomial(n, p).pmf(i);
+        for (let i = 0; i <= Math.floor(k); i++) s += pmf(i);
         return Math.min(1, s);
       },
       mean: () => n * p,

--- a/packages/math/src/Graph3DUtils.ts
+++ b/packages/math/src/Graph3DUtils.ts
@@ -72,10 +72,9 @@ export class Graph3DUtils {
     yStep = 1,
   ): Vector<Vector<T>> {
     const xValues = VectorUtils.arithmeticSequence(xMin, xMax, xStep);
-    return VectorUtils.transform(xValues, (x) => {
-      const yValues = VectorUtils.arithmeticSequence(yMin, yMax, yStep);
-      return VectorUtils.transform(yValues, (y) => binaryOperation(x, y));
-    });
+    // yValues is loop-invariant across the x loop — compute it once, not per x.
+    const yValues = VectorUtils.arithmeticSequence(yMin, yMax, yStep);
+    return VectorUtils.transform(xValues, (x) => VectorUtils.transform(yValues, (y) => binaryOperation(x, y)));
   }
 
   /**
@@ -89,10 +88,15 @@ export class Graph3DUtils {
     maxes: readonly number[],
     steps: readonly number[],
   ): Vector<unknown> {
+    // Each dimension's sequence of values is loop-invariant across the recursion
+    // (it depends only on `dim`, not on `prefix`) — compute all of them once
+    // up front instead of recomputing per recursive call.
+    const dimValues = mins.map((min, dim) =>
+      VectorUtils.arithmeticSequence(min, maxes[dim] as number, steps[dim] as number),
+    );
     const recurse = (dim: number, prefix: number[]): unknown => {
       if (dim >= mins.length) return nOperation(prefix);
-      const values = VectorUtils.arithmeticSequence(mins[dim] as number, maxes[dim] as number, steps[dim] as number);
-      return VectorUtils.transform(values, (v) => recurse(dim + 1, [...prefix, v]));
+      return VectorUtils.transform(dimValues[dim] as Vector<number>, (v) => recurse(dim + 1, [...prefix, v]));
     };
     return recurse(0, []) as Vector<unknown>;
   }

--- a/packages/math/src/PolynomialRing.ts
+++ b/packages/math/src/PolynomialRing.ts
@@ -130,34 +130,36 @@ export class PolynomialRing<T> {
     return this.makeMonic(x);
   }
 
-  /** `n` copies of the structure's `one`, added together (`n` as an element of the structure). */
-  private natural(n: number): T {
-    let result = this.structure.zero;
-    for (let k = 0; k < n; k++) result = this.structure.add(result, this.structure.one);
-    return result;
-  }
-
-  /** The derivative polynomial (`i·c_i`, via repeated addition — well-defined over any ring). */
+  /**
+   * The derivative polynomial (`i·c_i`, well-defined over any ring: `i` is
+   * built up as a running "`n` copies of the structure's `one`, added
+   * together" accumulator rather than being reconstructed from scratch for
+   * each coefficient — that would cost O(i) additions per coefficient, i.e.
+   * O(n²) additions overall for a degree-n polynomial).
+   */
   derivative(p: T[]): T[] {
     const trimmed = this.trim(p);
     const out: T[] = [];
+    let n = this.structure.zero; // accumulates to `i` as an element of the structure
     for (let i = 1; i < trimmed.length; i++) {
-      let term = this.structure.zero;
-      for (let k = 0; k < i; k++) term = this.structure.add(term, trimmed[i] as T);
-      out.push(term);
+      n = this.structure.add(n, this.structure.one);
+      out.push(this.structure.multiply(n, trimmed[i] as T));
     }
     return this.trim(out);
   }
 
   /**
    * An antiderivative with zero constant of integration (`c_i / (i+1)`, via the
-   * structure's `reciprocal`).
+   * structure's `reciprocal`). `i+1` is built up as a running accumulator (see
+   * {@link derivative}) instead of being reconstructed from scratch per term.
    */
   antiderivative(p: T[]): T[] {
     const trimmed = this.trim(p);
     const out: T[] = [this.structure.zero];
+    let n = this.structure.zero; // accumulates to `i+1` as an element of the structure
     for (let i = 0; i < trimmed.length; i++) {
-      out.push(this.structure.multiply(trimmed[i] as T, this.structure.reciprocal(this.natural(i + 1))));
+      n = this.structure.add(n, this.structure.one);
+      out.push(this.structure.multiply(trimmed[i] as T, this.structure.reciprocal(n)));
     }
     return this.trim(out);
   }

--- a/packages/math/test/Graph.test.ts
+++ b/packages/math/test/Graph.test.ts
@@ -4,6 +4,7 @@ import { Graph3DUtils } from "../src/Graph3DUtils.ts";
 import { GraphUtils } from "../src/GraphUtils.ts";
 import { Polygon } from "../src/Polygon.ts";
 import { Vector } from "../src/Vector.ts";
+import { VectorUtils } from "../src/VectorUtils.ts";
 
 const pt = (...xs: number[]) => Vector.fromArray(xs);
 const mat = <T>(rows: T[][]) => Vector.fromArray(rows.map((r) => Vector.fromArray(r)));
@@ -79,6 +80,42 @@ test("polygonToMesh3D fan-triangulates", () => {
 test("create3DPrism produces a 12-face tube", () => {
   const mesh = Graph3DUtils.create3DPrism(pt(0, 0, 0), pt(1, 0, 0));
   assert.equal(mesh.faces.length, 12);
+});
+
+test("dualRangeVector computes its arithmetic sequences once each (perf regression)", () => {
+  // Regression test for issue #41: dualRangeVector used to recompute the
+  // yValues sequence inside the x loop instead of hoisting it out, so a
+  // single call did xCount+1 arithmeticSequence calls instead of 2.
+  let calls = 0;
+  const original = VectorUtils.arithmeticSequence;
+  VectorUtils.arithmeticSequence = ((...args: Parameters<typeof original>) => {
+    calls++;
+    return original(...args);
+  }) as typeof VectorUtils.arithmeticSequence;
+  try {
+    Graph3DUtils.dualRangeVector((x, y) => x + y, 0, 50, 1, 0, 50, 1);
+  } finally {
+    VectorUtils.arithmeticSequence = original;
+  }
+  assert.equal(calls, 2, "exactly one call for xValues and one for yValues, regardless of grid size");
+});
+
+test("nRangeVector computes each dimension's sequence once (perf regression)", () => {
+  // Regression test for issue #41: nRangeVector used to recompute each
+  // dimension's arithmeticSequence inside the recursion (once per sibling
+  // branch) instead of once per dimension up front.
+  let calls = 0;
+  const original = VectorUtils.arithmeticSequence;
+  VectorUtils.arithmeticSequence = ((...args: Parameters<typeof original>) => {
+    calls++;
+    return original(...args);
+  }) as typeof VectorUtils.arithmeticSequence;
+  try {
+    Graph3DUtils.nRangeVector((coords) => coords.reduce((a, b) => a + b, 0), [0, 0, 0], [10, 10, 10], [1, 1, 1]);
+  } finally {
+    VectorUtils.arithmeticSequence = original;
+  }
+  assert.equal(calls, 3, "exactly one call per dimension, regardless of how many grid points that produces");
 });
 
 test("pointMatrixToMesh3D uses alpha1 for the first sweep (bug fix)", () => {

--- a/packages/math/test/Numerical.test.ts
+++ b/packages/math/test/Numerical.test.ts
@@ -98,6 +98,28 @@ test("chi-square and student-t cdfs", () => {
   assert.ok(close(Distributions.studentT(5).cdf(0), 0.5, 1e-9));
 });
 
+test("binomial cdf doesn't rebuild the distribution per summation step (perf regression)", () => {
+  // Regression test for issue #41: cdf used to call Distributions.binomial(n, p)
+  // (rebuilding the whole distribution object, including its logChoose closure)
+  // once per step of its summation instead of reusing the pmf computed once
+  // when the distribution was created.
+  const originalBinomial = Distributions.binomial;
+  let factoryCalls = 0;
+  Distributions.binomial = ((...args: Parameters<typeof originalBinomial>) => {
+    factoryCalls++;
+    return originalBinomial(...args);
+  }) as typeof Distributions.binomial;
+  try {
+    const b = Distributions.binomial(50, 0.5);
+    factoryCalls = 0; // only count calls made while summing the cdf below
+    const result = b.cdf(50);
+    assert.ok(close(result, 1, 1e-6));
+    assert.equal(factoryCalls, 0, "cdf must not call Distributions.binomial again per summation step");
+  } finally {
+    Distributions.binomial = originalBinomial;
+  }
+});
+
 test("hypothesis tests", () => {
   // one-sample t-test: sample clearly above 0
   const r = HypothesisTests.tTestOneSample([2, 3, 4, 5, 6], 0);

--- a/packages/math/test/PolynomialRing.test.ts
+++ b/packages/math/test/PolynomialRing.test.ts
@@ -56,3 +56,36 @@ test("PolynomialRing.equal ignores trailing zero padding", () => {
   assert.ok(R.equal([1, 2], [1, 2, 0, 0]));
   assert.ok(!R.equal([1, 2], [1, 3]));
 });
+
+test("derivative/antiderivative stay linear-time on large degree (perf regression)", () => {
+  // Regression test for issue #41: derivative/antiderivative used to compute
+  // each coefficient's `i` factor via a fresh repeated-addition loop from
+  // scratch (O(i) work per coefficient => O(n^2) total for a degree-n
+  // polynomial) instead of an O(1)-per-coefficient running accumulator.
+  //
+  // Measured locally: degree 30000 took ~650-800ms pre-fix (quadratic) vs.
+  // a few ms post-fix (linear). The 300ms bound below has generous headroom
+  // over the fixed implementation even on much slower CI hardware, while
+  // still being far below what the quadratic implementation would take.
+  const R = new PolynomialRing(Structure.realField());
+  const degree = 30000;
+  const p = Array.from({ length: degree + 1 }, (_, i) => i + 1);
+
+  const t0 = performance.now();
+  const d = R.derivative(p);
+  const derivativeMs = performance.now() - t0;
+  assert.ok(derivativeMs < 300, `derivative(degree ${degree}) took ${derivativeMs.toFixed(1)}ms, expected < 300ms`);
+  assert.equal(d.length, degree);
+  assert.equal(d[0], 2); // d/dx of c0 + c1 x + ... at x^0 term is 1*c1 = 1*2 = 2
+
+  const t1 = performance.now();
+  const a = R.antiderivative(p);
+  const antiderivativeMs = performance.now() - t1;
+  assert.ok(
+    antiderivativeMs < 300,
+    `antiderivative(degree ${degree}) took ${antiderivativeMs.toFixed(1)}ms, expected < 300ms`,
+  );
+  assert.equal(a.length, degree + 2);
+  assert.equal(a[0], 0); // zero constant of integration
+  assert.equal(a[1], p[0]); // c0 / 1 = c0
+});


### PR DESCRIPTION
## Summary

Fixes #41 — three loop-invariant recomputation bugs in `packages/math`:

- **`Graph3DUtils.dualRangeVector`/`nRangeVector`**: `arithmeticSequence` was recomputed inside the loop/recursion (once per outer iteration or per recursive branch) instead of once per axis. Hoisted the calls out so each is computed exactly once.
- **`Distributions.binomial(...).cdf`**: rebuilt an entire new binomial distribution object (and its `logChoose` closure) on every step of the summation instead of reusing the already-computed `pmf`. Now a single `pmf` closure is built once and reused in the loop.
- **`PolynomialRing.derivative`/`antiderivative`**: computed each coefficient's integer scalar (`i`) via a fresh repeated-addition loop from scratch — O(i) work per coefficient, O(n²) total for a degree-n polynomial. Replaced with a running accumulator that's incremented once per coefficient, making both O(n).

## Evidence (measured locally, before → after)

- `dualRangeVector`: 12 → 2 `arithmeticSequence` calls for an 11×11-ish grid
- `nRangeVector` (3 dims): 13 → 3 `arithmeticSequence` calls
- `PolynomialRing.derivative`/`antiderivative` at degree 30000 (using `Structure.realField()`): ~650-800ms → ~3-8ms (quadratic → linear)

All three fixes preserve identical output to the previous implementations — verified against the existing test suite (no behavioral changes, only call-count/complexity reductions).

## Test plan

- [x] Added call-count regression tests for `dualRangeVector`/`nRangeVector` (assert `arithmeticSequence` is called exactly once per axis, regardless of grid size)
- [x] Added a call-count regression test for `binomial.cdf` (assert `Distributions.binomial` isn't re-invoked during summation)
- [x] Added a timing regression test for `PolynomialRing.derivative`/`antiderivative` at degree 30000 with a generous 300ms bound (well above fixed-implementation timing, well below what quadratic behavior would take)
- [x] Full existing test suite passes unchanged (`npm test` in `packages/math`, 569 passing)
- [x] `npm run typecheck` and `npm run check` (biome) pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)