### PR TITLE
fix(iteration): 5 async/state bugs (FIFO put order, unhandled rejections, NaN poisoning, tee leak, accumulate state leak)

### DIFF
--- a/packages/iteration/src/async-channel.ts
+++ b/packages/iteration/src/async-channel.ts
@@ -57,6 +57,14 @@ export class AsyncChannel<T = unknown> {
     value: T | typeof CHANNEL_END | Error;
     release: () => void;
   }> = [];
+  /**
+   * Serializes delivery of concurrent put() calls into call order. Each
+   * put() grabs the current tail synchronously (before any `await`, so
+   * position is fixed by call order rather than by how long e.g.
+   * `transform()` happens to take) and only commits its value once its
+   * predecessor has committed.
+   */
+  private putOrder: Promise<void> = Promise.resolve();
 
   /**
    * Asynchronous Channel constructor
@@ -95,18 +103,31 @@ export class AsyncChannel<T = unknown> {
    */
   async put(item: T, ...debug: unknown[]): Promise<void> {
     this.debug?.("put", item, ...debug);
-    const value = await this.transform(item);
-    if (this.promise) {
-      this.resolve?.(value);
-      return;
-    }
-    if (this.cache.length < this.limit) {
-      this.cache.push(value);
-      return;
-    }
-    await new Promise<void>((release) => {
-      this.putters.push({ value, release });
+    // Reserve this call's delivery slot synchronously, in call order,
+    // before doing any async work (transform() may resolve at a different
+    // speed for different items -- see class doc on putOrder).
+    const myTurn = this.putOrder;
+    let advance!: () => void;
+    this.putOrder = new Promise<void>((resolve) => {
+      advance = resolve;
     });
+    try {
+      const value = await this.transform(item);
+      await myTurn;
+      if (this.promise) {
+        this.resolve?.(value);
+        return;
+      }
+      if (this.cache.length < this.limit) {
+        this.cache.push(value);
+        return;
+      }
+      await new Promise<void>((release) => {
+        this.putters.push({ value, release });
+      });
+    } finally {
+      advance();
+    }
   }
   /**
    * Take item off of Asynchronous Channel

--- a/packages/iteration/src/channel-decorators.ts
+++ b/packages/iteration/src/channel-decorators.ts
@@ -22,7 +22,11 @@ export const withEmitter = <T, C extends AsyncChannel<T>>(
   end = "end",
   error = "error",
 ): C => {
-  emitter.addListener(data, channel.put.bind(channel));
+  emitter.addListener(data, (...args: never[]) => {
+    void channel.put(...(args as unknown as Parameters<typeof channel.put>)).catch((reason: unknown) => {
+      void channel.throw(reason instanceof Error ? reason.message : String(reason));
+    });
+  });
   emitter.addListener(end, channel.break.bind(channel));
   emitter.addListener(error, channel.throw.bind(channel));
   return channel;
@@ -34,7 +38,11 @@ export const withEmitter = <T, C extends AsyncChannel<T>>(
  * @name withWebSocket
  */
 export const withWebSocket = <T, C extends AsyncChannel<T>>(channel: C, websocket: WebSocketLike): C => {
-  websocket.onmessage = channel.put.bind(channel) as (event: unknown) => unknown;
+  websocket.onmessage = (event: unknown) => {
+    void channel.put(event as T).catch((reason: unknown) => {
+      void channel.throw(reason instanceof Error ? reason.message : String(reason));
+    });
+  };
   websocket.onclose = channel.break.bind(channel);
   websocket.onerror = channel.throw.bind(channel) as (event?: unknown) => unknown;
   return channel;

--- a/packages/iteration/src/consumers.ts
+++ b/packages/iteration/src/consumers.ts
@@ -43,6 +43,14 @@ const maybeAbortable = <T>(iterable: AnyAsyncIterable<T>, signal?: AbortSignal):
   signal ? abortable(iterable, signal) : iterable;
 
 /**
+ * True for a numeric NaN key. `NaN < x` and `NaN > x` are always false, so
+ * without an explicit check a NaN key silently falls out of every
+ * comparison instead of poisoning the result -- see minSync/maxSync.
+ * @ignore
+ */
+const isNaNKey = (key: unknown): boolean => typeof key === "number" && Number.isNaN(key);
+
+/**
  * True if any item satisfies predicate. Short-circuits on the first match.
  * @kind function
  * @name someSync
@@ -304,6 +312,9 @@ export const quantifyAsync = async <T>(
  * if the iterable is empty. Necessarily consumes the entire iterable.
  * Mirrors Python's builtin min(iterable, key=..., default=...), but
  * returns undefined rather than throwing when empty and no default is given.
+ * A NaN key anywhere in the iterable poisons the result to NaN, matching
+ * `Math.min`'s own NaN-poisoning convention (rather than silently dropping
+ * out of every comparison and returning an unrelated wrong item).
  * @kind function
  * @name minSync
  */
@@ -314,19 +325,23 @@ export const minSync = <T, D = undefined>(
 ): T | D => {
   let best: T | undefined, bestKey: unknown;
   let found = false;
+  let sawNaN = false;
   for (const item of iterable) {
     const key = keyFn(item);
+    if (isNaNKey(key)) sawNaN = true;
     if (!found || (key as number) < (bestKey as number)) {
       best = item;
       bestKey = key;
       found = true;
     }
   }
+  if (sawNaN) return NaN as unknown as T | D;
   return found ? (best as T) : (defaultValue as D);
 };
 
 /**
- * Asynchronous dual of minSync; keyFn may be async.
+ * Asynchronous dual of minSync; keyFn may be async. Same NaN-poisoning
+ * convention as minSync.
  * @kind function
  * @name minAsync
  */
@@ -338,14 +353,17 @@ export const minAsync = async <T, D = undefined>(
 ): Promise<T | D> => {
   let best: T | undefined, bestKey: unknown;
   let found = false;
+  let sawNaN = false;
   for await (const item of maybeAbortable(iterable, signal)) {
     const key = await keyFn(item);
+    if (isNaNKey(key)) sawNaN = true;
     if (!found || (key as number) < (bestKey as number)) {
       best = item;
       bestKey = key;
       found = true;
     }
   }
+  if (sawNaN) return NaN as unknown as T | D;
   return found ? (best as T) : (defaultValue as D);
 };
 
@@ -353,7 +371,7 @@ export const minAsync = async <T, D = undefined>(
  * The item with the maximum key (default: the item itself), or defaultValue
  * if the iterable is empty. Mirrors Python's builtin
  * max(iterable, key=..., default=...); see minSync for the
- * undefined-vs-throw divergence.
+ * undefined-vs-throw divergence and the NaN-poisoning convention.
  * @kind function
  * @name maxSync
  */
@@ -364,19 +382,23 @@ export const maxSync = <T, D = undefined>(
 ): T | D => {
   let best: T | undefined, bestKey: unknown;
   let found = false;
+  let sawNaN = false;
   for (const item of iterable) {
     const key = keyFn(item);
+    if (isNaNKey(key)) sawNaN = true;
     if (!found || (key as number) > (bestKey as number)) {
       best = item;
       bestKey = key;
       found = true;
     }
   }
+  if (sawNaN) return NaN as unknown as T | D;
   return found ? (best as T) : (defaultValue as D);
 };
 
 /**
- * Asynchronous dual of maxSync; keyFn may be async.
+ * Asynchronous dual of maxSync; keyFn may be async. Same NaN-poisoning
+ * convention as minSync.
  * @kind function
  * @name maxAsync
  */
@@ -388,13 +410,16 @@ export const maxAsync = async <T, D = undefined>(
 ): Promise<T | D> => {
   let best: T | undefined, bestKey: unknown;
   let found = false;
+  let sawNaN = false;
   for await (const item of maybeAbortable(iterable, signal)) {
     const key = await keyFn(item);
+    if (isNaNKey(key)) sawNaN = true;
     if (!found || (key as number) > (bestKey as number)) {
       best = item;
       bestKey = key;
       found = true;
     }
   }
+  if (sawNaN) return NaN as unknown as T | D;
   return found ? (best as T) : (defaultValue as D);
 };

--- a/packages/iteration/src/tee.ts
+++ b/packages/iteration/src/tee.ts
@@ -40,14 +40,23 @@ export const teeSync =
     };
 
     return buffers.map(function* (_, i) {
-      for (;;) {
-        const x = next(i);
+      try {
+        for (;;) {
+          const x = next(i);
 
-        if (x === DONE) {
-          break;
+          if (x === DONE) {
+            break;
+          }
+
+          yield x;
         }
-
-        yield x;
+      } finally {
+        // Runs on natural completion *and* on early exit (e.g. a consumer
+        // `break`s out of a `for...of`, which calls this generator's own
+        // .return(), which runs this finally block) -- without it, an
+        // early-exiting consumer left the shared source iterator (and
+        // whatever resource it holds) never closed.
+        source.return?.();
       }
     });
   };
@@ -76,14 +85,20 @@ export const teeAsync =
     };
 
     return buffers.map(async function* (_, i) {
-      for (;;) {
-        const x = await next(i);
+      try {
+        for (;;) {
+          const x = await next(i);
 
-        if (x === DONE) {
-          break;
+          if (x === DONE) {
+            break;
+          }
+
+          yield x;
         }
-
-        yield x;
+      } finally {
+        // See teeSync's matching finally: runs on natural completion *and*
+        // on early exit, so the shared source iterator is always closed.
+        await source.return?.();
       }
     });
   };

--- a/packages/iteration/src/transducers.ts
+++ b/packages/iteration/src/transducers.ts
@@ -127,10 +127,17 @@ export const accumulate =
       ((a as unknown as number) + (b as unknown as number)) as unknown as Acc,
     initial: Acc = 0 as unknown as Acc,
   ): Transducer<In, Acc> =>
-  (conjoin) =>
-  (init, item) => {
-    initial = func(initial, item);
-    return conjoin(init, initial);
+  (conjoin) => {
+    // Fresh per (conjoin) invocation -- i.e. per transduce run, matching
+    // every other stateful transducer in this file (take's `amount`,
+    // group's `partition`, etc). Mutating the outer `initial` parameter
+    // directly here would carry accumulated state over into the *next*
+    // transduce run that reuses this same accumulate(...) instance.
+    let accumulated = initial;
+    return (init, item) => {
+      accumulated = func(accumulated, item);
+      return conjoin(init, accumulated);
+    };
   };
 
 /**

--- a/packages/iteration/test/async-channel.test.ts
+++ b/packages/iteration/test/async-channel.test.ts
@@ -107,6 +107,31 @@ test("break does not overtake blocked producers", async () => {
   assert.deepStrictEqual(seen, [1, 2], "blocked item must arrive before CHANNEL_END");
 });
 
+// Regression: put() awaited `transform(item)` before reserving its place in
+// the channel, so whichever concurrent put() call's transform happened to
+// resolve first won the race to land in the cache -- even if it was called
+// *after* another put() whose transform simply took longer. Delivery order
+// must track call order, not transform-resolution order.
+test("concurrent put() calls with varying transform delays deliver in call order (FIFO)", async () => {
+  const channel = new AsyncChannel<number>({
+    // The first-called item (1) has the slowest transform, and the
+    // last-called item (3) resolves instantly -- a race-prone
+    // implementation would let 3 land in the cache before 1 or 2.
+    transform: async (item: number) => {
+      await pause(item === 1 ? 30 : item === 2 ? 15 : 0);
+      return item;
+    },
+  });
+  const puts = [channel.put(1), channel.put(2), channel.put(3)];
+  await Promise.all(puts);
+
+  const seen: number[] = [];
+  seen.push((await channel.take()) as number);
+  seen.push((await channel.take()) as number);
+  seen.push((await channel.take()) as number);
+  assert.deepStrictEqual(seen, [1, 2, 3], "values must land in put() call order, not transform-resolution order");
+});
+
 test("CHANNEL_END is exposed and take() surfaces it after break()", async () => {
   const channel = new AsyncChannel<number>();
   await channel.break();

--- a/packages/iteration/test/channel-decorators.test.ts
+++ b/packages/iteration/test/channel-decorators.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { AsyncChannel, CHANNEL_END, channelDecorators } from "../src/index.ts";
+
+const { withEmitter, withWebSocket } = channelDecorators;
+
+class FakeEmitter {
+  private listeners = new Map<string, Array<(...args: unknown[]) => unknown>>();
+  addListener(event: string, listener: (...args: unknown[]) => unknown): this {
+    const list = this.listeners.get(event) ?? [];
+    list.push(listener);
+    this.listeners.set(event, list);
+    return this;
+  }
+  emit(event: string, ...args: unknown[]): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+interface FakeWebSocket {
+  onmessage: ((event: unknown) => unknown) | null;
+  onclose: ((event?: unknown) => unknown) | null;
+  onerror: ((event?: unknown) => unknown) | null;
+}
+
+const withUnhandledRejectionTracking = async (run: () => Promise<void>): Promise<unknown[]> => {
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandled.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    await run();
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+  return unhandled;
+};
+
+test("withEmitter: put/break/error listeners wire up and deliver normally", async () => {
+  const channel = new AsyncChannel<number>();
+  const emitter = new FakeEmitter();
+  withEmitter(channel, emitter);
+
+  // put() is async (it awaits transform() and, per the FIFO fix, its own
+  // delivery turn), so give the fire-and-forget put()s a beat to land
+  // before reading them back, and only break() once they've settled --
+  // otherwise break()'s synchronous cache push could race ahead of them.
+  emitter.emit("data", 1);
+  emitter.emit("data", 2);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.strictEqual(await channel.take(), 1, "first emitted item should be delivered to the channel");
+  assert.strictEqual(await channel.take(), 2, "second emitted item should be delivered to the channel");
+
+  emitter.emit("end");
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.strictEqual(await channel.take(), CHANNEL_END, "end event should break() the channel");
+});
+
+// Regression: withEmitter registered `channel.put.bind(channel)` directly
+// as the listener. put() is async, and its returned promise was never
+// observed by the emitter -- a rejection (e.g. a throwing transform) became
+// an unhandled promise rejection instead of surfacing through the
+// channel's own error path.
+test("withEmitter: a put() rejection must not become an unhandled promise rejection", async () => {
+  const channel = new AsyncChannel<number>({
+    transform: () => {
+      throw new Error("boom");
+    },
+  });
+  const emitter = new FakeEmitter();
+  withEmitter(channel, emitter);
+
+  const unhandled = await withUnhandledRejectionTracking(async () => {
+    emitter.emit("data", 1);
+    // Give the rejected put() promise a couple of turns to surface as an
+    // unhandled rejection if it weren't caught.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  });
+
+  assert.deepStrictEqual(unhandled, [], "put() rejection must be handled, not left unhandled");
+
+  const taken = await channel.take();
+  assert.ok(taken instanceof Error, "the rejection should be routed through the channel's own throw()/take() path");
+  assert.strictEqual((taken as Error).message, "boom");
+});
+
+// Same regression as above, for the websocket decorator (bug's other line).
+test("withWebSocket: a put() rejection must not become an unhandled promise rejection", async () => {
+  const channel = new AsyncChannel<number>({
+    transform: () => {
+      throw new Error("ws boom");
+    },
+  });
+  const websocket: FakeWebSocket = { onmessage: null, onclose: null, onerror: null };
+  withWebSocket(channel, websocket);
+
+  const unhandled = await withUnhandledRejectionTracking(async () => {
+    websocket.onmessage?.({ data: 1 });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  });
+
+  assert.deepStrictEqual(unhandled, [], "put() rejection must be handled, not left unhandled");
+
+  const taken = await channel.take();
+  assert.ok(taken instanceof Error, "the rejection should be routed through the channel's own throw()/take() path");
+  assert.strictEqual((taken as Error).message, "ws boom");
+});

--- a/packages/iteration/test/consumers.test.ts
+++ b/packages/iteration/test/consumers.test.ts
@@ -178,3 +178,34 @@ test("minSync/maxSync/minAsync/maxAsync", async () => {
   assert.strictEqual(await minAsync(asyncFromArray([3, 1, 2])), 1, "async: minimum item");
   assert.strictEqual(await maxAsync(asyncFromArray([3, 1, 2])), 3, "async: maximum item");
 });
+
+// Regression: `NaN < x`/`NaN > x` are always false, so a NaN key silently
+// fell out of every comparison instead of poisoning the result -- and
+// whether it got silently dropped or (if it happened to be the *first*
+// item) accidentally "won" depended on its position in the sequence.
+// min/max must now consistently poison to NaN, matching Math.min/Math.max.
+test("minSync/maxSync/minAsync/maxAsync: a NaN key poisons the result regardless of position", async () => {
+  assert.ok(Number.isNaN(minSync([3, Number.NaN, 1])), "a mid-sequence NaN must poison minSync's result");
+  assert.ok(Number.isNaN(maxSync([3, Number.NaN, 1])), "a mid-sequence NaN must poison maxSync's result");
+  assert.ok(Number.isNaN(minSync([Number.NaN, 3, 1])), "a leading NaN must also poison minSync's result");
+  assert.ok(Number.isNaN(maxSync([Number.NaN, 3, 1])), "a leading NaN must also poison maxSync's result");
+  assert.ok(Number.isNaN(minSync([3, 1, Number.NaN])), "a trailing NaN must also poison minSync's result");
+  assert.ok(Number.isNaN(maxSync([3, 1, Number.NaN])), "a trailing NaN must also poison maxSync's result");
+  assert.ok(
+    Number.isNaN(minSync(["ab", "NaN", "a"], (s) => (s === "NaN" ? Number.NaN : s.length))),
+    "a NaN produced by a custom keyFn must also poison the result",
+  );
+
+  assert.ok(
+    Number.isNaN(await minAsync(asyncFromArray([3, Number.NaN, 1]))),
+    "async: a mid-sequence NaN must poison minAsync's result",
+  );
+  assert.ok(
+    Number.isNaN(await maxAsync(asyncFromArray([3, Number.NaN, 1]))),
+    "async: a mid-sequence NaN must poison maxAsync's result",
+  );
+
+  // No NaN present: unaffected.
+  assert.strictEqual(minSync([3, 1, 2]), 1, "no-NaN inputs must be unaffected");
+  assert.strictEqual(maxSync([3, 1, 2]), 3, "no-NaN inputs must be unaffected");
+});

--- a/packages/iteration/test/tee.test.ts
+++ b/packages/iteration/test/tee.test.ts
@@ -41,3 +41,45 @@ test("teeSync/teeAsync should support more than 2 outputs", async () => {
   await eventualEqual(ab!, original, "teeAsync 3-way: 2nd output");
   await eventualEqual(ac!, original, "teeAsync 3-way: 3rd output");
 });
+
+// Regression: neither generator called source.return() when a consumer
+// stopped iterating early (e.g. `break`), leaking the underlying
+// iterator/resource. A `for...of`/`for await...of` `break` calls the
+// generator's own .return(), which must now propagate to the shared source.
+test("teeSync calls source.return() when a consumer exits early", () => {
+  let returnCalls = 0;
+  let pulled = 0;
+  const source: Iterator<number> = {
+    next: () => (pulled < 5 ? { value: pulled++, done: false } : { value: undefined, done: true }),
+    return(value?: unknown) {
+      returnCalls++;
+      return { value, done: true } as IteratorResult<number>;
+    },
+  };
+  const iterable: Iterable<number> = { [Symbol.iterator]: () => source };
+
+  const [stream] = teeSync(1)(iterable);
+  for (const item of stream!) {
+    if (item === 1) break; // exit before the source is exhausted
+  }
+  assert.strictEqual(returnCalls, 1, "breaking out of iteration early must call source.return()");
+});
+
+test("teeAsync calls source.return() when a consumer exits early", async () => {
+  let returnCalls = 0;
+  let pulled = 0;
+  const source: AsyncIterator<number> = {
+    next: async () => (pulled < 5 ? { value: pulled++, done: false } : { value: undefined, done: true }),
+    return: async (value?: unknown) => {
+      returnCalls++;
+      return { value, done: true } as IteratorResult<number>;
+    },
+  };
+  const iterable: AsyncIterable<number> = { [Symbol.asyncIterator]: () => source };
+
+  const [stream] = teeAsync(1)(iterable);
+  for await (const item of stream!) {
+    if (item === 1) break; // exit before the source is exhausted
+  }
+  assert.strictEqual(returnCalls, 1, "breaking out of async iteration early must call source.return()");
+});

--- a/packages/iteration/test/transduce.test.ts
+++ b/packages/iteration/test/transduce.test.ts
@@ -57,6 +57,30 @@ test("transducer:accumulate", () => {
   assert.deepStrictEqual([...sum(original)], [10], "should accumulate changes in successive items");
 });
 
+// Regression: accumulate() mutated its outer `initial` parameter directly,
+// so that state carried over into the *next* transduce run reusing the
+// same accumulate(...) instance -- unlike every other stateful transducer
+// in this file (take/drop/group/etc), whose state resets per run.
+test("transducer:accumulate resets its running total on each separate transduce run (regression)", () => {
+  const runningSum = accumulate((a: number, b: number) => a + b, 0);
+  const pipeline = transduceSync(runningSum);
+
+  assert.deepStrictEqual([...pipeline([1, 2, 3])], [1, 3, 6], "first run should accumulate from a clean slate");
+  assert.deepStrictEqual(
+    [...pipeline([1, 2, 3])],
+    [1, 3, 6],
+    "second run reusing the same accumulate(...) instance must also start fresh, not continue from 6",
+  );
+
+  // Also true across two independently-built pipelines sharing one instance.
+  const secondPipeline = transduceSync(runningSum);
+  assert.deepStrictEqual(
+    [...secondPipeline([10, 20])],
+    [10, 30],
+    "a freshly-built pipeline reusing the same accumulate(...) instance must also start fresh",
+  );
+});
+
 // Regression: the old numeric `reject(limit)` (skip first N items) was
 // renamed to `drop(limit)` to free up `reject` for a predicate-based
 // complement to `filter`, matching Python's itertools.filterfalse.


### PR DESCRIPTION
## Summary

Fixes five independent bugs in `packages/iteration/src`, all reported in #43:

- **`async-channel.ts` (`put()`)** — FIFO-order violation: concurrent `put()` calls could deliver values out of order relative to call order, because the value's place in the channel was only reserved *after* `await this.transform(item)` resolved. Fixed by having each `put()` synchronously reserve its position in a delivery queue *before* awaiting `transform()`, then wait for its predecessor's turn before committing to the cache/waiting-taker/putters-queue.
- **`channel-decorators.ts` (`withEmitter`/`withWebSocket`)** — the emitter/websocket listeners called `channel.put(...)` fire-and-forget; a rejected `put()` (e.g. a throwing `transform`) became an unhandled promise rejection. Now the listener wraps the call and `.catch()`es any rejection, routing it through the channel's own `throw()` error path.
- **`consumers.ts` (`minSync`/`maxSync`/`minAsync`/`maxAsync`)** — a single `NaN` key silently fell out of every comparison (`NaN < x`/`NaN > x` are always false), so the result depended on the NaN's *position*: dropped mid-sequence, but accidentally "won" if it was the first item. Now consistently poisons the result to `NaN`, matching `Math.min`/`Math.max`'s own convention.
- **`tee.ts` (`teeSync`/`teeAsync`)** — the tee'd generators never called `source.return()`, so a consumer breaking out of iteration early leaked the underlying source iterator/resource. Fixed with a `try/finally` around each generator's loop that calls `source.return()`.
- **`transducers.ts` (`accumulate`)** — mutated its outer `initial` parameter directly, so state leaked across separate `transduce` runs that reused the same `accumulate(...)` instance. Fixed by moving the running total into the per-run `(conjoin) => {...}` closure, matching every sibling stateful transducer (`take`, `drop`, `group`, `dedupe`, `partitionBy`).

## Test plan

- [x] Added regression tests for each bug (`async-channel.test.ts`, new `channel-decorators.test.ts`, `consumers.test.ts`, `tee.test.ts`, `transduce.test.ts`), each verified to fail against the pre-fix logic and pass against the fix.
- [x] `npm test` (87/87 passing) from `packages/iteration`
- [x] `npm run typecheck` clean
- [x] `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)