### PR TITLE
Fix teeAsync race between concurrent first next() calls

### DIFF
--- a/packages/iteration/src/tee.ts
+++ b/packages/iteration/src/tee.ts
@@ -67,21 +67,53 @@ export const teeAsync =
     const source = iterable[Symbol.asyncIterator]();
     const buffers: T[][] = new Array(num).fill(null).map(() => []);
 
+    // Guards against the check-then-act race between "is my buffer empty"
+    // and "pull from source": if two branches both call next() while their
+    // buffers are empty in the same logical turn, only the first should
+    // actually call source.next(); the rest must ride along on that single
+    // in-flight pull and then re-check their (now-populated) buffer, rather
+    // than each independently issuing their own source.next() call.
+    let inFlight: Promise<T | typeof DONE> | null = null;
+    let sourceDone = false;
+
     const next = async (i: number): Promise<T | typeof DONE> => {
       const buffer = buffers[i] as T[];
       if (buffer.length !== 0) {
         return buffer.shift() as T;
       }
-      const x = await source.next();
 
-      if (x.done) {
+      if (sourceDone) {
         return DONE;
       }
 
-      for (let j = 0; j < buffers.length; j++) {
-        if (j !== i) (buffers[j] as T[]).push(x.value);
+      if (inFlight) {
+        // Someone else is already pulling for this turn -- wait for it, then
+        // re-evaluate: our buffer will have been fed by the puller (unless
+        // the source is now exhausted).
+        await inFlight;
+        return next(i);
       }
-      return x.value;
+
+      const pull = (async (): Promise<T | typeof DONE> => {
+        const x = await source.next();
+
+        if (x.done) {
+          sourceDone = true;
+          return DONE;
+        }
+
+        for (let j = 0; j < buffers.length; j++) {
+          if (j !== i) (buffers[j] as T[]).push(x.value);
+        }
+        return x.value;
+      })();
+
+      inFlight = pull;
+      try {
+        return await pull;
+      } finally {
+        inFlight = null;
+      }
     };
 
     return buffers.map(async function* (_, i) {

--- a/packages/iteration/test/tee.test.ts
+++ b/packages/iteration/test/tee.test.ts
@@ -111,7 +111,11 @@ test("teeAsync: concurrent first next() calls on both branches must not desync",
   // still-empty shared buffer -- this is the race window.
   const [r0, r1] = await Promise.all([it0!.next(), it1!.next()]);
 
-  assert.strictEqual(calls, 1, "source.next() must be called exactly once for one logical pull turn, not once per branch");
+  assert.strictEqual(
+    calls,
+    1,
+    "source.next() must be called exactly once for one logical pull turn, not once per branch",
+  );
   assert.strictEqual(r0.value, r1.value, "both branches' first item must be the same underlying source item");
   assert.strictEqual(r0.value, "a", "the shared first item must be the source's first value");
 

--- a/packages/iteration/test/tee.test.ts
+++ b/packages/iteration/test/tee.test.ts
@@ -83,3 +83,43 @@ test("teeAsync calls source.return() when a consumer exits early", async () => {
   }
   assert.strictEqual(returnCalls, 1, "breaking out of async iteration early must call source.return()");
 });
+
+// Regression (#54): both branches' *first* .next() call landed on a still-empty
+// shared buffer at essentially the same instant. There was no atomicity between
+// "check if my buffer has a pending item" and "decide to pull from source", so
+// both branches independently pulled from `source`, each got a *different*
+// underlying item, and the two output streams desynced instead of one branch
+// pulling-and-forwarding while the other read from its buffer.
+test("teeAsync: concurrent first next() calls on both branches must not desync", async () => {
+  const original = ["a", "b", "c", "d"];
+  let calls = 0;
+  const source: AsyncIterator<string> = {
+    next: async () => {
+      if (calls >= original.length) {
+        return { value: undefined, done: true };
+      }
+      const value = original[calls] as string;
+      calls++;
+      return { value, done: false };
+    },
+  };
+  const iterable: AsyncIterable<string> = { [Symbol.asyncIterator]: () => source };
+
+  const [it0, it1] = teeAsync(2)(iterable);
+
+  // Fire both branches' first `.next()` in the same microtask tick, against a
+  // still-empty shared buffer -- this is the race window.
+  const [r0, r1] = await Promise.all([it0!.next(), it1!.next()]);
+
+  assert.strictEqual(calls, 1, "source.next() must be called exactly once for one logical pull turn, not once per branch");
+  assert.strictEqual(r0.value, r1.value, "both branches' first item must be the same underlying source item");
+  assert.strictEqual(r0.value, "a", "the shared first item must be the source's first value");
+
+  // Continue draining both branches normally and confirm they stay paired.
+  const [r2, r3] = await Promise.all([it0!.next(), it1!.next()]);
+  assert.strictEqual(r2.value, r3.value, "both branches' second item must also match");
+  assert.strictEqual(r2.value, "b");
+
+  await eventualEqual(it0!, ["c", "d"], "1st branch should mirror remaining items");
+  await eventualEqual(it1!, ["c", "d"], "2nd branch should mirror remaining items");
+});


### PR DESCRIPTION
## Summary

Fixes #54: `teeAsync` had a race when two branches both called `.next()` while their shared buffer was still empty. There was a check-then-act gap between "is my buffer empty" and "pull from source" — both branches could independently call `source.next()` for what should have been the same logical turn, each getting a *different* underlying item and desyncing the two output streams' order/content relative to each other.

## Fix

Add a single-flight guard around the pull decision in `packages/iteration/src/tee.ts`:
- The first branch to find its buffer empty becomes the puller: it kicks off `source.next()` and stores the resulting promise in a shared `inFlight` variable (assigned synchronously, before any `await`, so no other branch invoked in the same synchronous turn can slip past the check).
- Any other branch that also finds its buffer empty during that same turn sees `inFlight` set, awaits that same promise instead of calling `source.next()` itself, then re-checks its own (now buffer-fed) buffer.
- Also caches source exhaustion (`sourceDone`) so branches don't keep issuing extra `source.next()` calls after a shared pull already observed the source is done.

The existing #43 fix (calling `source.return()` on early exit) is untouched — its regression tests (`teeSync`/`teeAsync calls source.return() when a consumer exits early`) still pass unmodified.

## Test plan

- [x] Added a regression test that fires both branches' first `.next()` in the same microtask tick (`Promise.all([it0.next(), it1.next()])`) against an empty shared buffer, asserting `source.next()` is called exactly once per logical turn and both branches receive the same underlying item — confirmed it **fails** against the pre-fix code (`source.next()` called twice, branches got different items) and **passes** after the fix.
- [x] Full package test suite: `npm test` in `packages/iteration` — 88/88 passing.
- [x] Typecheck: `npm run typecheck` in `packages/iteration` — clean.
- [x] Verified the #43 `source.return()`-on-early-exit regression tests still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)