### PR TITLE
math: add Rotor4.exp/log

### DIFF
--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mallory-math",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Advanced college-level mathematics library \u2014 a modern TypeScript port of the Mallory ActionScript 3 library.",
   "type": "module",
   "exports": {

--- a/packages/math/src/Rotor4.ts
+++ b/packages/math/src/Rotor4.ts
@@ -133,6 +133,33 @@ export class Rotor4 {
   }
 
   /**
+   * `exp(B)`: the rotor for a rotation of `|B|` radians in `B`'s plane --
+   * a convenience over {@link fromBivectorAngle} for the common case of an
+   * already-scaled generator (e.g. `angularVelocity * dt` in a physics
+   * integrator, where the bivector's magnitude *is* the rotation angle and
+   * its direction *is* the plane). Returns {@link Identity} for the zero
+   * bivector rather than throwing (unlike `fromBivectorAngle`, whose
+   * `plane.normalize()` would throw on a zero plane).
+   */
+  static exp(bivector: Bivector4): Rotor4 {
+    const angle = bivector.magnitude;
+    if (angle === 0) return Rotor4.Identity;
+    return Rotor4.fromBivectorAngle(bivector, angle);
+  }
+
+  /**
+   * `log()`: the bivector `B` such that `exp(B) = this`, for a *simple*
+   * rotor -- the inverse of {@link exp}. Throws for a compound
+   * (double-rotation) rotor, same as {@link toBivectorAngle} (which this is
+   * built on): decomposing a general rotor's log is the Perwass-factorization
+   * work deferred to the physics layer.
+   */
+  log(epsilon = 1e-9): Bivector4 {
+    const { plane, angle } = this.toBivectorAngle(epsilon);
+    return plane.scale(angle);
+  }
+
+  /**
    * Recover `(plane, angle)` for a *simple* rotor (pseudoscalar ≈ 0). Throws
    * for a compound (double-rotation) rotor — see the class-level doc comment;
    * decomposing a general rotor's log is the Perwass-factorization work

--- a/packages/math/test/Rotor4.test.ts
+++ b/packages/math/test/Rotor4.test.ts
@@ -174,3 +174,32 @@ test("toString renders scalar, bivector, and pseudoscalar parts", () => {
   const r = new Rotor4(1, Bivector4.Zero, 0);
   assert.match(r.toString(), /^1 \+ \(.*\) \+ 0e1234$/);
 });
+
+test("exp(B) round-trips with fromBivectorAngle: exp(plane*angle) == fromBivectorAngle(plane, angle)", () => {
+  const angle = 1.234;
+  const scaled = XY.normalize().scale(angle);
+  assert.ok(Rotor4.exp(scaled).equals(Rotor4.fromBivectorAngle(XY, angle), 1e-9));
+});
+
+test("exp(zero bivector) is Identity, without throwing", () => {
+  assert.ok(Rotor4.exp(Bivector4.Zero).equals(Rotor4.Identity, 1e-9));
+});
+
+test("log() inverts exp() for a simple rotor", () => {
+  const angle = 0.87;
+  const r = Rotor4.fromBivectorAngle(ZW, angle);
+  const recovered = r.log();
+  assert.ok(Rotor4.exp(recovered).equals(r, 1e-9));
+  assert.ok(Math.abs(recovered.magnitude - angle) < 1e-9);
+});
+
+test("log() throws for a compound (double-rotation) rotor, same as toBivectorAngle", () => {
+  const r1 = Rotor4.fromBivectorAngle(XY, 0.5);
+  const r2 = Rotor4.fromBivectorAngle(ZW, 0.9);
+  const compound = r2.multiply(r1);
+  assert.throws(() => compound.log());
+});
+
+test("exp is the identity's own log-exp round trip too: exp(Identity.log()) == Identity", () => {
+  assert.ok(Rotor4.exp(Rotor4.Identity.log()).equals(Rotor4.Identity, 1e-9));
+});


### PR DESCRIPTION
Closes #61.

Convenience wrappers over `fromBivectorAngle`/`toBivectorAngle` for the common physics-integrator case of an already-scaled generator bivector (magnitude = angle, direction = plane) — exactly what a rigid-body integrator's `deltaRotor = exp(angularVelocity * dt)` step needs, matching the terminology the Miegakure physics integrator issue (johnhenry/miegakure-archive#20) already uses in its own pseudocode.

`exp()` returns `Identity` for the zero bivector rather than throwing. `log()` is `exp()`'s inverse for simple rotors, same compound-rotor limitation as `toBivectorAngle`.

5 new tests, 100% line/function coverage on `Rotor4.ts`, 642 tests passing across the monorepo.