### PR TITLE
Interval: outward-round non-exact ops; Rotor4: add inverse() and slerp()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -547,7 +547,7 @@
     },
     "packages/math": {
       "name": "mallory-math",
-      "version": "0.11.0",
+      "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.5.1",
@@ -572,6 +572,15 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "packages/math-prototype-patch/node_modules/mallory-math": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/mallory-math/-/mallory-math-0.11.0.tgz",
+      "integrity": "sha512-u8kp9N8j/L4rjZDXYGiv6sN5f9HWXUASEIjaNTg52ycyb4fwHilx9E8RA1Y7No2nQodkUMBxwyvrYbutz9cCkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.6.0"
       }
     }
   }

--- a/packages/math/src/Interval.ts
+++ b/packages/math/src/Interval.ts
@@ -1,8 +1,45 @@
+const F64 = new Float64Array(1);
+const U64 = new BigUint64Array(F64.buffer);
+
+/** The next representable double strictly greater than `value` (IEEE-754 nextafter toward +Infinity) -- JS has no built-in `Math.nextafter`, so this steps the raw 64-bit pattern by one ULP via a shared scratch buffer. */
+function nextUp(value: number): number {
+  if (Number.isNaN(value) || value === Infinity) return value;
+  if (value === 0) return Number.MIN_VALUE;
+  F64[0] = value;
+  U64[0] = (U64[0] as bigint) + (value > 0 ? 1n : -1n);
+  return F64[0] as number;
+}
+
+/** The next representable double strictly less than `value` -- `-nextUp(-value)`, since stepping toward -Infinity from `x` is the mirror of stepping toward +Infinity from `-x`. */
+function nextDown(value: number): number {
+  return -nextUp(-value);
+}
+
+/**
+ * Widens `x` by one ULP on each side -- the outward-rounding every non-exact
+ * `Interval` operation below applies to its result. `Math.*` computes to
+ * the *nearest* representable double (`Math.sqrt` is correctly rounded to
+ * 0.5 ULP per IEEE-754; the other transcendentals/arithmetic are within
+ * ~1 ULP on every mainstream engine), which breaks the containment
+ * guarantee interval arithmetic exists to provide: `Interval.point(2).sqrt()`
+ * would otherwise return a degenerate `[s, s]` that provably does NOT
+ * contain the irrational `sqrt(2)`. One ULP of outward slack restores
+ * rigor, at the cost of a deliberately loose bound when a result happens
+ * to be exactly representable (e.g. `sqrt(4)` reports a width-2-ULP
+ * interval around 2 instead of the point `[2, 2]`).
+ */
+function outward(x: Interval): Interval {
+  return new Interval(nextDown(x.lo), nextUp(x.hi));
+}
+
 /**
  * Interval — rigorous interval arithmetic `[lo, hi]`. Operations return an
  * interval guaranteed to contain every result of the corresponding operation on
  * any pair of members, so a final interval bounds the true answer despite
- * rounding — useful for reliable numerics and error tracking.
+ * rounding — useful for reliable numerics and error tracking. Every
+ * operation that isn't provably exact (`negate`/`abs`/`hull`/`intersect`
+ * only move or compare existing endpoints) outward-rounds its result by
+ * one ULP per side via `outward()` above.
  */
 export class Interval {
   readonly lo: number;
@@ -41,23 +78,29 @@ export class Interval {
   }
 
   add(o: Interval): Interval {
-    return new Interval(this.lo + o.lo, this.hi + o.hi);
+    return outward(new Interval(this.lo + o.lo, this.hi + o.hi));
   }
   subtract(o: Interval): Interval {
-    return new Interval(this.lo - o.hi, this.hi - o.lo);
+    return outward(new Interval(this.lo - o.hi, this.hi - o.lo));
   }
+  /** Exact: IEEE-754 negation only flips the sign bit, no rounding. */
   negate(): Interval {
     return new Interval(-this.hi, -this.lo);
   }
 
   multiply(o: Interval): Interval {
     const p = [this.lo * o.lo, this.lo * o.hi, this.hi * o.lo, this.hi * o.hi];
-    return new Interval(Math.min(...p), Math.max(...p));
+    return outward(new Interval(Math.min(...p), Math.max(...p)));
   }
 
   divide(o: Interval): Interval {
     if (o.contains(0)) throw new Error("Interval division by an interval containing zero.");
-    return this.multiply(new Interval(1 / o.hi, 1 / o.lo));
+    // The reciprocal bounds are themselves a rounded operation -- outward
+    // it before feeding into `multiply` (which outward-rounds its own
+    // result too), so neither step's rounding can silently eat the other's
+    // slack.
+    const reciprocal = outward(new Interval(1 / o.hi, 1 / o.lo));
+    return this.multiply(reciprocal);
   }
 
   /** The tightest interval containing both (the convex hull / union). */
@@ -80,24 +123,24 @@ export class Interval {
 
   sqrt(): Interval {
     if (this.lo < 0) throw new Error("sqrt of an interval with negative values.");
-    return new Interval(Math.sqrt(this.lo), Math.sqrt(this.hi));
+    return outward(new Interval(Math.sqrt(this.lo), Math.sqrt(this.hi)));
   }
   exp(): Interval {
-    return new Interval(Math.exp(this.lo), Math.exp(this.hi));
+    return outward(new Interval(Math.exp(this.lo), Math.exp(this.hi)));
   }
   log(): Interval {
     if (this.lo <= 0) throw new Error("log of an interval with non-positive values.");
-    return new Interval(Math.log(this.lo), Math.log(this.hi));
+    return outward(new Interval(Math.log(this.lo), Math.log(this.hi)));
   }
 
-  /** Integer power (handles even powers of intervals straddling zero). */
+  /** Integer power (handles even powers of intervals straddling zero). Exact when `n === 0` (every interval to the 0th power is the exact point 1). */
   pow(n: number): Interval {
     if (!Number.isInteger(n) || n < 0) throw new Error("Interval.pow requires a non-negative integer.");
     if (n === 0) return Interval.point(1);
     const a = this.lo ** n;
     const b = this.hi ** n;
-    if (n % 2 === 0 && this.contains(0)) return new Interval(0, Math.max(a, b));
-    return new Interval(Math.min(a, b), Math.max(a, b));
+    if (n % 2 === 0 && this.contains(0)) return outward(new Interval(0, Math.max(a, b)));
+    return outward(new Interval(Math.min(a, b), Math.max(a, b)));
   }
 
   private extrema(f: (x: number) => number, criticalPeriodStart: number, period: number): Interval {
@@ -106,7 +149,7 @@ export class Interval {
     const kStart = Math.ceil((this.lo - criticalPeriodStart) / period);
     const kEnd = Math.floor((this.hi - criticalPeriodStart) / period);
     for (let k = kStart; k <= kEnd; k++) candidates.push(f(criticalPeriodStart + k * period));
-    return new Interval(Math.min(...candidates), Math.max(...candidates));
+    return outward(new Interval(Math.min(...candidates), Math.max(...candidates)));
   }
 
   sin(): Interval {

--- a/packages/math/src/Rotor4.ts
+++ b/packages/math/src/Rotor4.ts
@@ -60,8 +60,21 @@ export class Rotor4 {
     return new Rotor4(this.scalar + r.scalar, this.bivector.add(r.bivector), this.pseudoscalar + r.pseudoscalar);
   }
 
+  subtract(r: Rotor4): Rotor4 {
+    return new Rotor4(this.scalar - r.scalar, this.bivector.subtract(r.bivector), this.pseudoscalar - r.pseudoscalar);
+  }
+
+  negate(): Rotor4 {
+    return new Rotor4(-this.scalar, this.bivector.negate(), -this.pseudoscalar);
+  }
+
   scale(s: number): Rotor4 {
     return new Rotor4(this.scalar * s, this.bivector.scale(s), this.pseudoscalar * s);
+  }
+
+  /** Component-wise inner product over all 8 components (scalar, 6 bivector, pseudoscalar) -- treats a Rotor4 as an 8-vector, exactly {@link Quaternion.dot}'s role in that class's own `slerp`. */
+  dot(r: Rotor4): number {
+    return this.scalar * r.scalar + this.bivector.dot(r.bivector) + this.pseudoscalar * r.pseudoscalar;
   }
 
   /** The geometric product `this * r` — composes two rotations (apply `r` first, then `this`). */
@@ -73,10 +86,28 @@ export class Rotor4 {
    * The reverse `R~`: reverses the order of vector factors, which negates the
    * bivector (grade 2, picks up (-1)^1) but leaves the scalar (grade 0) and
    * pseudoscalar (grade 4, picks up (-1)^6 = +1) unchanged. For a unit rotor,
-   * this is also the inverse — the 4D analogue of a quaternion's conjugate.
+   * this is also the inverse — the 4D analogue of a quaternion's conjugate
+   * ({@link Quaternion.conjugate}). **Not** the inverse for a non-unit rotor
+   * (see {@link inverse}): a rotor that has drifted off the unit manifold
+   * during repeated composition (e.g. per-timestep physics integration,
+   * before renormalization runs) will silently produce a wrong,
+   * `|R|²`-scaled result from `reverse()` where an inverse was intended.
    */
   reverse(): Rotor4 {
     return new Rotor4(this.scalar, this.bivector.negate(), this.pseudoscalar);
+  }
+
+  /**
+   * Multiplicative inverse `R⁻¹ = R~ / |R|²`, distinct from {@link reverse}
+   * for a non-unit rotor — the 4D analogue of {@link Quaternion.inverse}.
+   * `this.multiply(this.inverse())` is `Identity` regardless of `this`'s
+   * magnitude; `this.multiply(this.reverse())` only is when `this` is
+   * already a unit rotor.
+   */
+  inverse(): Rotor4 {
+    const m2 = this.magnitudeSquared;
+    if (m2 === 0) throw new Error("The zero rotor has no inverse.");
+    return this.reverse().scale(1 / m2);
   }
 
   get magnitudeSquared(): number {
@@ -362,6 +393,37 @@ export class Rotor4 {
     const angle = 2 * Math.atan2(bMag, this.scalar);
     if (bMag === 0) return { plane: Bivector4.Zero, angle: 0 };
     return { plane: this.bivector.normalize(), angle };
+  }
+
+  /**
+   * Spherical linear interpolation between two rotors, `t` in `[0, 1]` --
+   * the 4D analogue of {@link Quaternion.slerp}, same component-wise
+   * treatment (an 8-vector of scalar/bivector(6)/pseudoscalar, via
+   * {@link dot}) and the same near-parallel fallback to a normalized
+   * linear interpolation to avoid dividing by a near-zero `sin(theta0)`.
+   *
+   * **Same manifold caveat as {@link normalize}**: this is only exactly
+   * correct for interpolating between *simple* rotors (single rotation
+   * plane) — a compound double rotation doesn't lie on the sphere this
+   * construction assumes, so slerping one is an approximation, not a
+   * geodesic. For a double rotation, {@link factor} each endpoint into its
+   * two orthogonal simple rotors and slerp each pair independently instead.
+   */
+  static slerp(a: Rotor4, b: Rotor4, t: number): Rotor4 {
+    const ra = a.normalize();
+    let rb = b.normalize();
+    let cos = ra.dot(rb);
+    if (cos < 0) {
+      rb = rb.scale(-1);
+      cos = -cos;
+    }
+    if (cos > 0.9995) return ra.add(rb.subtract(ra).scale(t)).normalize();
+    const theta0 = Math.acos(cos);
+    const theta = theta0 * t;
+    const sinTheta0 = Math.sin(theta0);
+    const s0 = Math.sin(theta0 - theta) / sinTheta0;
+    const s1 = Math.sin(theta) / sinTheta0;
+    return ra.scale(s0).add(rb.scale(s1));
   }
 
   equals(r: Rotor4, epsilon = 0): boolean {

--- a/packages/math/test/NumberTypes.test.ts
+++ b/packages/math/test/NumberTypes.test.ts
@@ -83,13 +83,41 @@ test("DualNumber gradient", () => {
 
 // --- Interval ---
 
+// Every non-exact Interval op now outward-rounds its result by ~1 ULP per
+// side (see Interval.ts's own `outward` doc comment), so an exact result
+// like [4, 6] comes back as a hair WIDER than [4, 6], not equal to it --
+// checking containment of the mathematically exact bounds is the correct
+// assertion here, not `.equals()`.
+function containsExactly(interval: Interval, lo: number, hi: number): boolean {
+  return interval.lo <= lo && interval.hi >= hi;
+}
+
 test("Interval arithmetic bounds results", () => {
   const a = new Interval(1, 2);
   const b = new Interval(3, 4);
-  assert.ok(a.add(b).equals(new Interval(4, 6)));
-  assert.ok(a.subtract(b).equals(new Interval(-3, -1)));
-  assert.ok(a.multiply(b).equals(new Interval(3, 8)));
-  assert.ok(new Interval(-2, 3).pow(2).equals(new Interval(0, 9)), "even power straddling zero");
+  assert.ok(containsExactly(a.add(b), 4, 6));
+  assert.ok(containsExactly(a.subtract(b), -3, -1));
+  assert.ok(containsExactly(a.multiply(b), 3, 8));
+  assert.ok(containsExactly(new Interval(-2, 3).pow(2), 0, 9), "even power straddling zero");
+});
+
+test("Interval outward rounding: a point input to a transcendental function returns an interval that actually CONTAINS the true irrational result, not a degenerate point excluding it", () => {
+  // Interval.point(2).sqrt() used to return the exact (rounded-to-nearest)
+  // double for sqrt(2) as BOTH endpoints -- a degenerate interval that
+  // provably does not contain the true irrational value.
+  const s = Interval.point(2).sqrt();
+  assert.ok(s.lo < s.hi, "expected outward rounding to produce a non-degenerate interval");
+  // Math.sqrt(2) itself (the nearest double) must lie strictly inside,
+  // with room on both sides for the true value's rounding error.
+  assert.ok(s.lo < Math.sqrt(2) && Math.sqrt(2) < s.hi);
+});
+
+test("Interval outward rounding: exact operations (negate, pow(0), hull, intersect) stay exact, not widened", () => {
+  const a = new Interval(1, 5);
+  assert.ok(a.negate().equals(new Interval(-5, -1)), "negation is exact (sign flip only)");
+  assert.ok(a.pow(0).equals(Interval.point(1)), "n=0 is exactly 1 for any interval");
+  const b = new Interval(3, 8);
+  assert.ok(a.hull(b).equals(new Interval(1, 8)), "hull only compares existing exact endpoints");
 });
 
 test("Interval intersect / hull / contains", () => {

--- a/packages/math/test/Rotor4.test.ts
+++ b/packages/math/test/Rotor4.test.ts
@@ -170,6 +170,90 @@ test("normalize divides every component by the magnitude, and rejects the zero r
   assert.throws(() => new Rotor4(0, Bivector4.Zero, 0).normalize());
 });
 
+test("subtract/negate are component-wise, dot is the 8-component Euclidean inner product", () => {
+  const a = new Rotor4(1, new Bivector4(2, 0, 0, 0, 0, 0), 3);
+  const b = new Rotor4(4, new Bivector4(5, 0, 0, 0, 0, 0), 6);
+  const diff = a.subtract(b);
+  assert.equal(diff.scalar, -3);
+  assert.ok(diff.bivector.equals(new Bivector4(-3, 0, 0, 0, 0, 0)));
+  assert.equal(diff.pseudoscalar, -3);
+  assert.ok(a.negate().equals(new Rotor4(-1, new Bivector4(-2, 0, 0, 0, 0, 0), -3)));
+  assert.equal(a.dot(b), 1 * 4 + 2 * 5 + 3 * 6);
+});
+
+// --- Rotor4.inverse() (#60): distinct from reverse() for a non-unit rotor ---
+
+test("inverse() equals reverse() for a unit rotor (they only diverge once |R| != 1)", () => {
+  const r = Rotor4.fromBivectorAngle(XY, 0.77);
+  assert.ok(r.inverse().equals(r.reverse(), 1e-9));
+});
+
+test("R * R.inverse() == Identity even for a non-unit rotor, unlike R * R.reverse()", () => {
+  // A rotor that's drifted off the unit manifold (e.g. mid floating-point
+  // integration, before renormalization) -- exactly the scenario #60 flags.
+  const drifted = Rotor4.fromBivectorAngle(XY, 0.9).scale(1.4);
+  assert.ok(Math.abs(drifted.magnitude - 1) > 0.1, "sanity check: this rotor is genuinely non-unit");
+
+  assert.ok(drifted.multiply(drifted.inverse()).equals(Rotor4.Identity, 1e-9));
+
+  // reverse() alone does NOT recover the identity here: R * R~ = |R|^2 * Identity.
+  const viaReverse = drifted.multiply(drifted.reverse());
+  assert.ok(Math.abs(viaReverse.scalar - drifted.magnitudeSquared) < 1e-9, "R * R~ scales Identity by |R|^2, not the true inverse");
+  assert.ok(!viaReverse.equals(Rotor4.Identity, 1e-9), "confirms reverse() alone was the wrong operation for a non-unit rotor");
+});
+
+test("inverse() also holds for a compound (double-rotation) rotor", () => {
+  const r1 = Rotor4.fromBivectorAngle(XY, 0.6);
+  const r2 = Rotor4.fromBivectorAngle(ZW, 1.3);
+  const composed = r2.multiply(r1).scale(0.6);
+  assert.ok(composed.multiply(composed.inverse()).equals(Rotor4.Identity, 1e-9));
+});
+
+test("inverse() rejects the zero rotor", () => {
+  assert.throws(() => new Rotor4(0, Bivector4.Zero, 0).inverse());
+});
+
+// --- Rotor4.slerp() (#62): mirrors Quaternion.slerp ---
+
+test("slerp(a, a, t) is a for every t (interpolating a rotor with itself)", () => {
+  const r = Rotor4.fromBivectorAngle(XY, 0.9);
+  for (const t of [0, 0.25, 0.5, 0.75, 1]) {
+    assert.ok(Rotor4.slerp(r, r, t).equals(r, 1e-9));
+  }
+});
+
+test("slerp endpoints: slerp(a, b, 0) == a, slerp(a, b, 1) == b (up to double-cover sign)", () => {
+  const a = Rotor4.Identity;
+  const b = Rotor4.fromBivectorAngle(XY, Math.PI / 2);
+  assert.ok(Rotor4.slerp(a, b, 0).equals(a, 1e-9));
+  const end = Rotor4.slerp(a, b, 1);
+  assert.ok(end.equals(b, 1e-6) || end.equals(b.scale(-1), 1e-6));
+});
+
+test("slerp midpoint of a simple rotation is the half-angle rotation", () => {
+  const a = Rotor4.Identity;
+  const b = Rotor4.fromBivectorAngle(XY, Math.PI / 2);
+  const mid = Rotor4.slerp(a, b, 0.5);
+  const expected = Rotor4.fromBivectorAngle(XY, Math.PI / 4);
+  assert.ok(mid.equals(expected, 1e-9));
+});
+
+test("slerp stays on the unit rotor manifold throughout (magnitude 1 at every t)", () => {
+  const a = Rotor4.fromBivectorAngle(XY, 0.1);
+  const b = Rotor4.fromBivectorAngle(XY, 2.3);
+  for (const t of [0, 0.1, 0.3, 0.5, 0.7, 0.9, 1]) {
+    assert.ok(Math.abs(Rotor4.slerp(a, b, t).magnitude - 1) < 1e-9);
+  }
+});
+
+test("slerp falls back to normalized lerp for near-parallel rotors without dividing by ~zero", () => {
+  const a = Rotor4.fromBivectorAngle(XY, 0.5);
+  const b = Rotor4.fromBivectorAngle(XY, 0.5001);
+  assert.doesNotThrow(() => Rotor4.slerp(a, b, 0.5));
+  const mid = Rotor4.slerp(a, b, 0.5);
+  assert.ok(Math.abs(mid.magnitude - 1) < 1e-9);
+});
+
 test("toString renders scalar, bivector, and pseudoscalar parts", () => {
   const r = new Rotor4(1, Bivector4.Zero, 0);
   assert.match(r.toString(), /^1 \+ \(.*\) \+ 0e1234$/);

--- a/packages/math/test/Rotor4.test.ts
+++ b/packages/math/test/Rotor4.test.ts
@@ -198,8 +198,14 @@ test("R * R.inverse() == Identity even for a non-unit rotor, unlike R * R.revers
 
   // reverse() alone does NOT recover the identity here: R * R~ = |R|^2 * Identity.
   const viaReverse = drifted.multiply(drifted.reverse());
-  assert.ok(Math.abs(viaReverse.scalar - drifted.magnitudeSquared) < 1e-9, "R * R~ scales Identity by |R|^2, not the true inverse");
-  assert.ok(!viaReverse.equals(Rotor4.Identity, 1e-9), "confirms reverse() alone was the wrong operation for a non-unit rotor");
+  assert.ok(
+    Math.abs(viaReverse.scalar - drifted.magnitudeSquared) < 1e-9,
+    "R * R~ scales Identity by |R|^2, not the true inverse",
+  );
+  assert.ok(
+    !viaReverse.equals(Rotor4.Identity, 1e-9),
+    "confirms reverse() alone was the wrong operation for a non-unit rotor",
+  );
 });
 
 test("inverse() also holds for a compound (double-rotation) rotor", () => {


### PR DESCRIPTION
## Summary
Closes #57, #60, #62.

**Interval (#57)** — elementary functions and arithmetic ops rounded to nearest, no directed rounding, breaking interval arithmetic's own containment guarantee (`Interval.point(2).sqrt()` returned a degenerate `[s, s]` that provably excludes the irrational `sqrt(2)`). Every non-exact op (`add`/`subtract`/`multiply`/`divide`/`pow`/`sqrt`/`exp`/`log`/`sin`/`cos`) now outward-rounds its result by one ULP per side via `nextUp`/`nextDown` (IEEE-754 nextafter via Float64 bit manipulation) — the same scheme mallory-graph already carries as a local workaround in `interval-eval.ts`; that workaround is now redundant and can be deleted once this ships. `negate`/`abs`/`hull`/`intersect` are left untouched since they're exact (no floating-point rounding occurs). Existing exact-equality tests are updated to containment checks, since e.g. `[1,2].add([3,4])` now returns something a hair wider than `[4, 6]`, not equal to it.

**Rotor4 (#60)** — `reverse()` is only the inverse for a *unit* rotor; a rotor that's drifted off the unit manifold (e.g. mid floating-point physics integration, before renormalization) silently gets `|R|² · Identity` back instead of the true inverse from anything calling `reverse()` expecting one. Added `inverse() = R~ / |R|²`, mirroring `Quaternion.inverse()`.

**Rotor4 (#62)** — added `slerp()`, mirroring `Quaternion.slerp()`'s component-wise treatment (8-vector dot product, near-parallel lerp fallback). Same manifold caveat as `normalize()`: exact for simple (single-plane) rotors, an approximation for a genuine double rotation. Added `subtract()`/`negate()`/`dot()` as the primitives `slerp` needs.

## Test plan
- [x] `npm test` (math package: 667/674, 7 pre-existing skips, 0 failures)
- [x] `npm run typecheck`
- [x] `npm run lint` (biome, clean)
- [x] New tests: `Interval` outward-rounding containment + exact-op preservation; `Rotor4.inverse()` unit/non-unit/compound/zero cases; `Rotor4.slerp()` self/endpoints/midpoint/manifold/near-parallel cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)