### PR TITLE
Promote CellGraph into mallory-math (step 1/3, #56)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -547,7 +547,7 @@
     },
     "packages/math": {
       "name": "mallory-math",
-      "version": "0.11.0",
+      "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.5.1",
@@ -572,6 +572,15 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "packages/math-prototype-patch/node_modules/mallory-math": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/mallory-math/-/mallory-math-0.11.0.tgz",
+      "integrity": "sha512-u8kp9N8j/L4rjZDXYGiv6sN5f9HWXUASEIjaNTg52ycyb4fwHilx9E8RA1Y7No2nQodkUMBxwyvrYbutz9cCkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.6.0"
       }
     }
   }

--- a/packages/math/src/CellGraph.ts
+++ b/packages/math/src/CellGraph.ts
@@ -1,0 +1,669 @@
+/**
+ * CellGraph — a reactive, pull-based dependency graph. Cells hold typed
+ * values (numbers, points, curves, whatever) rather than flattened
+ * primitives; a derived cell's `compute` reads other cells via `graph.get`,
+ * and the graph records the resulting edges automatically (no manual tag
+ * declarations, unlike mcp-query's cache).
+ *
+ * Writes (`set`) mark transitive dependents dirty and bump their version
+ * counters immediately — cheap, no recompute. Recomputation happens lazily,
+ * the next time a dirty cell is `get`, and a structural-equality check skips
+ * the version bump (and further propagation) when a recompute produces a
+ * value that's deep-equal to what was already cached, so unaffected
+ * downstream consumers don't re-render.
+ *
+ * Promoted here from johnhenry/mallory-graph (originally `src/lib/cell-
+ * graph.ts`, powering every panel there via `useCell`/`useSyncExternalStore`)
+ * once johnhenry/mallory-grapher became a second consumer of a frozen
+ * vendored copy — two consumers is this monorepo's own extract-to-a-package
+ * trigger. See johnhenry/mallory#56. UI-framework-agnostic and dependency-
+ * free by design: nothing here references React or any host application.
+ */
+
+type Listener = () => void;
+type ComputeFn<T> = () => T;
+
+interface CellRecord<T = unknown> {
+  value: T | undefined;
+  hasValue: boolean;
+  version: number;
+  dirty: boolean;
+  compute?: ComputeFn<T>;
+  dependencies: Set<string>;
+  dependents: Set<string>;
+  auxiliary: boolean;
+  /**
+   * Set when `compute` most recently threw, so a failing (possibly
+   * expensive) compute doesn't get re-run on every subsequent `get()` --
+   * see {@link CellGraph.get} and {@link CellGraph.recomputeAndEmit}.
+   * Cleared by anything that also clears `dirty`'s stale-value equivalent:
+   * a fresh `set()`/successful recompute.
+   */
+  hasError: boolean;
+  error?: unknown;
+}
+
+export type CellRole = "free" | "dependent" | "unknown";
+
+export class CircularDependencyError extends Error {
+  constructor(path: string[]) {
+    super(`Circular dependency detected in cell graph: ${path.join(" -> ")}`);
+    this.name = "CircularDependencyError";
+  }
+}
+
+export class CellGraph {
+  private cells = new Map<string, CellRecord>();
+  private listeners = new Map<string, Set<Listener>>();
+  private globalListeners = new Set<Listener>();
+  private writeListeners = new Set<(id: string, value: unknown) => void>();
+  private stack: string[] = [];
+  private emitting = new Set<string>();
+  /**
+   * Nesting depth of the current "logical write" -- incremented around the
+   * body of every top-level mutating entry point ({@link set}, {@link
+   * define}, {@link delete}) and decremented in a `finally` when it returns.
+   * A single `set()` on a root of a diamond-shaped dependency graph cascades
+   * through `propagateDirty` and calls `emit()` once per cell it reaches
+   * (root, then each newly-dirtied dependent) -- all of those belong to the
+   * SAME logical write and must produce exactly one `subscribeAll`
+   * notification, not one per cell. While this is above zero, a request to
+   * notify global listeners (see {@link scheduleGlobalNotify}) is deferred
+   * instead of firing immediately; it only actually fires once depth
+   * unwinds back to zero, i.e. once the outermost `set`/`define`/`delete`
+   * call (including any cells it transitively dirtied) has fully finished.
+   */
+  private globalNotifyDepth = 0;
+  /** Set by {@link scheduleGlobalNotify} while `globalNotifyDepth > 0`, so the deferred notification isn't lost once depth returns to zero. */
+  private globalNotifyPending = false;
+  /**
+   * Guards the global-listener-invocation loop itself against being
+   * re-entered while it's already running -- e.g. a global listener that
+   * synchronously calls `set()` on a DIFFERENT cell from inside its own
+   * callback. Unlike the shared boolean this replaces, a reentrant request
+   * that arrives while this is `true` is NOT dropped: it re-arms {@link
+   * globalNotifyPending}, which is drained (fired again) right after the
+   * in-progress loop finishes -- see {@link flushGlobalNotify}. This is what
+   * keeps a reentrant write to a different cell from being silently
+   * swallowed (issue #234), while still bounding recursion depth to one
+   * extra level per reentrant write, the same way `emitting` bounds it for
+   * same-id reentrancy on local listeners.
+   */
+  private notifyingGlobalListeners = false;
+
+  /**
+   * Write a raw source-of-truth value (e.g. a slider drag or text input).
+   * Structurally, a cell written via `set` (no `compute` fn) is what makes
+   * it "free" -- see {@link role}.
+   *
+   * @param options.auxiliary Marks this cell hidden-by-default in an
+   * Algebra-view-style listing (see {@link list}) -- e.g. an internal
+   * sampling parameter that isn't itself meaningful to show the user,
+   * distinct from a top-level named object. Only applied when the cell
+   * doesn't already exist, or is transitioning from a compute-backed
+   * (dependent) cell to a free one; an existing free cell's auxiliary flag
+   * is left as originally set.
+   */
+  set<T>(id: string, value: T, options?: { auxiliary?: boolean }): void {
+    this.runBatched(() => {
+      const cell = this.ensure<T>(id);
+      const wasCompute = cell.compute !== undefined;
+      cell.compute = undefined;
+      if (wasCompute) {
+        // This cell is transitioning from dependent (had a compute fn) to
+        // free -- detach its recorded dependency edges the same way
+        // recomputeAndEmit() and delete() already do, so former upstream
+        // cells stop spuriously dirtying/emitting a cell they no longer feed
+        // into.
+        for (const depId of cell.dependencies) this.cells.get(depId)?.dependents.delete(id);
+        cell.dependencies = new Set();
+      }
+      if (options?.auxiliary !== undefined && (wasCompute || !cell.hasValue)) cell.auxiliary = options.auxiliary;
+      cell.hasError = false;
+      cell.error = undefined;
+      const unchanged = cell.hasValue && structuralEqual(cell.value, value);
+      cell.dirty = false;
+      if (unchanged) return;
+      // Only replace the cached reference on a real change, so a write that's
+      // structurally equal to the old value never disturbs downstream identity.
+      cell.value = value;
+      cell.hasValue = true;
+      cell.version++;
+      this.emitWrite(id, value);
+      this.emit(id);
+      this.propagateDirty(id);
+    });
+  }
+
+  /**
+   * Subscribe to raw `set()` writes -- id plus the new value -- across
+   * every cell in the graph (issue #47's live-collaboration groundwork).
+   * Deliberately narrower than `subscribeAll`: it fires ONLY for an actual
+   * `set()` call with a real (structurally-different) value, never for a
+   * `define()`-driven recompute cascade. That's the exact shape a
+   * broadcast-to-other-peers use case needs -- each peer re-derives its
+   * own dependent cells locally once a base write arrives over the wire
+   * and gets applied via `set()` there too, so only the raw user-initiated
+   * writes need to cross the network, not every recomputed cell downstream
+   * of them.
+   */
+  subscribeWrites(fn: (id: string, value: unknown) => void): () => void {
+    this.writeListeners.add(fn);
+    return () => this.writeListeners.delete(fn);
+  }
+
+  private emitWrite(id: string, value: unknown): void {
+    for (const fn of this.writeListeners) fn(id, value);
+  }
+
+  /**
+   * Define (or redefine) a derived cell computed from other cells.
+   * Structurally, a cell written via `define` (has a `compute` fn) is what
+   * makes it "dependent" -- see {@link role}.
+   *
+   * @param options.auxiliary See {@link set}'s equivalent option; applied
+   * the same way (only on first definition, or a transition from free to
+   * dependent).
+   */
+  define<T>(id: string, compute: ComputeFn<T>, options?: { auxiliary?: boolean }): void {
+    this.runBatched(() => this.defineImpl(id, compute, options));
+  }
+
+  private defineImpl<T>(id: string, compute: ComputeFn<T>, options?: { auxiliary?: boolean }): void {
+    const cell = this.ensure<T>(id);
+    const wasFree = cell.compute === undefined && cell.hasValue;
+    const isRedefine = cell.hasValue;
+    if (options?.auxiliary !== undefined && (wasFree || cell.compute === undefined)) cell.auxiliary = options.auxiliary;
+    cell.compute = compute;
+    cell.dirty = true;
+    cell.hasError = false;
+    cell.error = undefined;
+    // A cell being defined for the first time (no prior value) is
+    // guaranteed to change once computed -- hasValue flips false -> true
+    // regardless of what the compute returns -- so it's safe to eagerly
+    // bump its version and notify its own subscribers now, same as before,
+    // with no need to actually run the compute early.
+    //
+    // A cell that already has a value is being *redefined*: unlike set(),
+    // define() doesn't have the new value in hand to structuralEqual-check
+    // synchronously -- only a function. The fix for #15 is NOT "defer the
+    // notification to some future get()": nothing guarantees a future
+    // get() ever happens. useSyncExternalStore's subscribe callback (see
+    // use-cell.ts) is what schedules a component's next render in the
+    // first place, and that callback only fires from emit() -- so an
+    // un-emitted genuine change would sit invisible until something
+    // UNRELATED happens to re-render the same subscribed component. That's
+    // a missed update, strictly worse than the unwanted-churn bug #15 set
+    // out to fix. Instead, resolve it the same way set() does: eagerly,
+    // synchronously, right here -- via recomputeAndEmit, which already
+    // implements exactly the "recompute, structuralEqual-gate the version
+    // bump/emit" logic this needs (and already detaches/rebuilds
+    // `dependencies` correctly as part of that). A throwing new compute is
+    // swallowed here (recomputeAndEmit already cached it on the cell via
+    // #14's hasError/error fields before rethrowing) so define() keeps its
+    // pre-existing never-throws-synchronously contract; the cached error
+    // surfaces through the normal get()-throws path on the next read.
+    if (isRedefine) {
+      try {
+        this.recomputeAndEmit(id, cell);
+      } catch {
+        // Cached on the cell already; surfaced via get(), not here.
+      }
+    } else {
+      cell.version++;
+      this.emit(id);
+    }
+    this.propagateDirty(id);
+  }
+
+  /**
+   * Whether `id` is "free" (writable directly via `set`, no `compute` fn --
+   * e.g. a slider or text input), "dependent" (computed via `define` from
+   * other cells), or "unknown" (`id` has never been `set`/`define`d, only
+   * read, or doesn't exist at all).
+   */
+  role(id: string): CellRole {
+    const cell = this.cells.get(id);
+    if (!cell?.hasValue) return "unknown";
+    return cell.compute ? "dependent" : "free";
+  }
+
+  /** Whether `id` was marked `auxiliary` (hidden-by-default in an Algebra-view-style listing) -- see {@link set}/{@link define}. */
+  isAuxiliary(id: string): boolean {
+    return this.cells.get(id)?.auxiliary ?? false;
+  }
+
+  /**
+   * Every cell currently in the graph, with its role and auxiliary flag --
+   * the basis for an Algebra-view-style listing (GeoGebra's free/dependent/
+   * auxiliary object model). Includes cells with no value yet (role
+   * "unknown") since a caller may still want to know such an id exists
+   * (e.g. was read but never written).
+   */
+  list(): Array<{ id: string; role: CellRole; auxiliary: boolean; hasValue: boolean }> {
+    return [...this.cells.entries()].map(([id, cell]) => ({
+      id,
+      role: this.role(id),
+      auxiliary: cell.auxiliary,
+      hasValue: cell.hasValue,
+    }));
+  }
+
+  /** Read a cell's current value, recomputing if stale. Auto-tracks dependency edges. */
+  get<T>(id: string): T {
+    const cell = this.ensure<T>(id);
+
+    // The cell currently being computed (if any) reads `id` — record the edge.
+    const caller = this.stack.at(-1);
+    if (caller !== undefined) {
+      this.cells.get(caller)?.dependencies.add(id);
+      cell.dependents.add(caller);
+    }
+
+    if (cell.dirty && cell.compute) {
+      if (this.stack.includes(id)) throw new CircularDependencyError([...this.stack, id]);
+
+      this.recomputeAndEmit(id, cell);
+    }
+
+    // A cached compute failure (see recomputeAndEmit's catch) is rethrown
+    // here on every subsequent get() -- without re-running the compute --
+    // until the same conditions that would invalidate a cached value (a
+    // fresh set()/define(), or a real upstream change marking this cell
+    // dirty again) clear it.
+    if (cell.hasError) throw cell.error;
+
+    return cell.value as T;
+  }
+
+  private recomputeAndEmit<T>(id: string, cell: CellRecord<T>): void {
+    // Dependencies may differ between evaluations (e.g. a conditional
+    // expression) — detach from the old set before recomputing fresh.
+    for (const depId of cell.dependencies) this.cells.get(depId)?.dependents.delete(id);
+    cell.dependencies = new Set();
+
+    this.stack.push(id);
+    let next: T;
+    try {
+      next = cell.compute!() as T;
+    } catch (err) {
+      // Cache the failure so a subsequent get() (another render pass, a
+      // sibling compute reading this cell again, etc.) rethrows the same
+      // cached error instead of re-running a compute that's going to fail
+      // identically. `dirty` is still cleared here: this recompute attempt
+      // did happen and did resolve (to a failure), and staying dirty would
+      // otherwise force every future get() back through the compute anyway.
+      cell.dirty = false;
+      cell.hasError = true;
+      cell.error = err;
+      throw err;
+    } finally {
+      this.stack.pop();
+    }
+
+    cell.dirty = false;
+    cell.hasError = false;
+    cell.error = undefined;
+
+    const unchanged = cell.hasValue && structuralEqual(cell.value, next);
+
+    if (!unchanged) {
+      // Reassign only on a real change, preserving the old reference on a
+      // no-op recompute — this is what lets a downstream Object.is check
+      // (e.g. React's useSyncExternalStore, or React.memo) bail out.
+      cell.value = next;
+      cell.hasValue = true;
+      cell.version++;
+      this.emit(id);
+    }
+  }
+
+  /** The value useSyncExternalStore observes for this cell. */
+  getVersion(id: string): number {
+    return this.cells.get(id)?.version ?? 0;
+  }
+
+  /** Subscribe to changes on one cell. Returns an unsubscribe function. */
+  subscribe(id: string, fn: Listener): () => void {
+    let set = this.listeners.get(id);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(id, set);
+    }
+    set.add(fn);
+    this.ensure(id);
+    return () => {
+      set.delete(fn);
+      if (set.size !== 0) return;
+      // Last subscriber for this id gone -- drop the now-empty Set instead
+      // of leaving it behind forever (an id that's subscribed-to-then-
+      // unsubscribed-from many times over a session, e.g. a dynamically
+      // created/destroyed notebook row, would otherwise accumulate one dead
+      // empty Set per id in `listeners`).
+      this.listeners.delete(id);
+      // If this cell was never actually given a value or a compute (i.e.
+      // the only reason it exists in `cells` at all is the ensure() call a
+      // few lines up) and nothing else in the graph references it (no
+      // dependents, no recorded dependencies), there's nothing left to
+      // justify keeping that phantom record around either -- clean it up
+      // too. A genuinely "live" cell (has a real value, is define()d, or
+      // participates in the dependency graph as someone's dependency/
+      // dependent) is untouched here; only explicit delete() removes those,
+      // per its own documented semantics -- this is deliberately narrower
+      // than delete() and never fires the "former dependents" notification
+      // delete() does, since there's no real removal of live state here.
+      const cell = this.cells.get(id);
+      if (
+        cell &&
+        !cell.hasValue &&
+        cell.compute === undefined &&
+        cell.dependents.size === 0 &&
+        cell.dependencies.size === 0
+      ) {
+        this.cells.delete(id);
+      }
+    };
+  }
+
+  /** Subscribe to changes on any cell (e.g. to drive a canvas render loop). */
+  subscribeAll(fn: Listener): () => void {
+    this.globalListeners.add(fn);
+    return () => this.globalListeners.delete(fn);
+  }
+
+  /**
+   * Subscribe to changes on a fixed, known set of specific cells -- e.g.
+   * every cell a serialized URL fragment reads. Narrower than
+   * `subscribeAll`: `fn` fires only for a write on one of `ids`, not for
+   * literally any cell in the graph (issue #235 -- several panels' URL-sync
+   * effects used `subscribeAll` for exactly this "a handful of specific
+   * cells" shape, so they also fired on unrelated high-frequency writes
+   * elsewhere in the same graph -- an RAF-driven playback clock, a live
+   * drag preview, a per-epoch training metric -- that the listener's own
+   * output never actually depended on). Just sugar over one `subscribe`
+   * call per id; not appropriate when the relevant id set is itself dynamic
+   * (e.g. "every currently-visible row's cells", where the row list can
+   * grow/shrink) -- that shape still needs `subscribeAll` (ideally
+   * debounced) or per-id `subscribe` calls re-issued as the id set changes.
+   */
+  subscribeMany(ids: string[], fn: Listener): () => void {
+    const unsubscribes = ids.map((id) => this.subscribe(id, fn));
+    return () => {
+      for (const unsubscribe of unsubscribes) unsubscribe();
+    };
+  }
+
+  has(id: string): boolean {
+    return this.cells.has(id);
+  }
+
+  /**
+   * Whether `id` has a real value yet, as opposed to merely existing as an
+   * empty record (`has()` returns true for a cell the instant anything reads
+   * it via `get`, even before it's ever been `set` or `define`d -- not a
+   * reliable "should I seed this?" check from a post-render effect that runs
+   * after a sibling compute has already read-and-thus-created it).
+   */
+  hasValue(id: string): boolean {
+    return this.cells.get(id)?.hasValue ?? false;
+  }
+
+  /**
+   * Remove a cell entirely. Former *dependents* are marked dirty and
+   * notified (same as a `set()` would), so a compute that read the deleted
+   * cell re-runs and can fall back to whatever "this cell doesn't exist"
+   * means for it -- without this, a dependent kept its stale cached value
+   * forever, AND (because its dependency edges only rebuild during a
+   * recompute that never came) writes to its other dependencies stopped
+   * reaching it too. The notification happens *after* the cell is gone, so
+   * the reentrant recompute a listener may trigger sees the post-delete
+   * world: a `get()` on the deleted id re-creates an empty record
+   * (`hasValue: false`), exactly the "never existed" semantics callers
+   * like ExpressionRow's params compute already handle.
+   */
+  delete(id: string): void {
+    this.runBatched(() => {
+      const cell = this.cells.get(id);
+      if (!cell) return;
+      const formerDependents = [...cell.dependents];
+      for (const depId of cell.dependencies) this.cells.get(depId)?.dependents.delete(id);
+      for (const depId of cell.dependents) this.cells.get(depId)?.dependencies.delete(id);
+      this.cells.delete(id);
+      this.listeners.delete(id);
+      for (const depId of formerDependents) {
+        const dep = this.cells.get(depId);
+        if (!dep || dep.dirty) continue;
+        dep.dirty = true;
+        this.emit(depId);
+        this.propagateDirty(depId);
+      }
+    });
+  }
+
+  private ensure<T>(id: string): CellRecord<T> {
+    let cell = this.cells.get(id) as CellRecord<T> | undefined;
+    if (!cell) {
+      cell = {
+        value: undefined,
+        hasValue: false,
+        version: 0,
+        dirty: true,
+        dependencies: new Set(),
+        dependents: new Set(),
+        auxiliary: false,
+        hasError: false,
+        error: undefined,
+      };
+      this.cells.set(id, cell);
+    }
+    return cell;
+  }
+
+  private propagateDirty(id: string): void {
+    const cell = this.cells.get(id);
+    if (!cell) return;
+    // Snapshot before iterating: `emit` below can synchronously trigger a
+    // nested recompute (via useSyncExternalStore's listener) that detaches
+    // and re-adds an entry to this very `dependents` set. Iterating the live
+    // Set would then revisit that re-added entry within the same pass,
+    // looping forever between cells that share this dependency.
+    for (const depId of [...cell.dependents]) {
+      const dep = this.cells.get(depId);
+      if (!dep || dep.dirty) continue; // already dirty -> already propagated past this point
+      dep.dirty = true;
+      // Notify listeners so a subscriber (e.g. useSyncExternalStore) re-reads
+      // via get(), which lazily recomputes. No version bump here — that only
+      // happens in get()/set() once a recompute confirms a real value change,
+      // which is what lets an unaffected downstream branch skip its redraw.
+      this.emit(depId);
+      this.propagateDirty(depId);
+    }
+  }
+
+  /**
+   * Notify `id`'s listeners that it may have changed. Guarded against
+   * reentrancy per-id: a `useSyncExternalStore` listener synchronously
+   * calls `getSnapshot` (React's own tearing check) as soon as it's
+   * notified, which re-enters `get()` and, on a real recompute, calls back
+   * into `emit(id)` for the very same id before this call has returned.
+   * Without the guard that nested call re-invokes every listener again
+   * (including the one currently on the stack), which re-triggers the same
+   * reentrant read, forever -- an unbounded synchronous storm that pins the
+   * CPU and eventually OOMs the JS heap. It's always safe to drop the
+   * nested notification: any consumer notified mid-flight still reads the
+   * freshest value the next time it calls `get()`, so no update is lost by
+   * collapsing repeat notifications for the same id into one.
+   *
+   * The global (`subscribeAll`) notification is requested here but not
+   * fired directly -- see {@link scheduleGlobalNotify}: a single logical
+   * write (e.g. one `set()` on the root of a diamond-shaped dependency
+   * graph) calls `emit()` once per cell it transitively dirties, but must
+   * still only produce ONE `subscribeAll` notification (issue #234).
+   */
+  private emit(id: string): void {
+    if (this.emitting.has(id)) return;
+    this.emitting.add(id);
+    try {
+      for (const fn of this.listeners.get(id) ?? []) fn();
+      this.scheduleGlobalNotify();
+    } finally {
+      this.emitting.delete(id);
+    }
+  }
+
+  /**
+   * Run `fn` as one "logical write" for the purposes of global-listener
+   * batching -- see {@link globalNotifyDepth}. Reentrant calls (e.g. a
+   * `subscribe()` listener triggered mid-cascade that synchronously calls
+   * `get()`, which recomputes and dirties further cells) nest transparently:
+   * only the outermost call's `finally` can bring the depth back to zero and
+   * trigger the deferred flush.
+   */
+  private runBatched<T>(fn: () => T): T {
+    this.globalNotifyDepth++;
+    try {
+      return fn();
+    } finally {
+      this.globalNotifyDepth--;
+      if (this.globalNotifyDepth === 0 && this.globalNotifyPending) this.flushGlobalNotify();
+    }
+  }
+
+  /**
+   * Run `fn`, a sequence of otherwise-independent `set`/`define`/`delete`
+   * calls, as a SINGLE logical write for `subscribeAll` purposes (see
+   * {@link runBatched}/{@link scheduleGlobalNotify}). Without this, a
+   * multi-step mutation like a clear-then-replay (#374/#375) fires a
+   * `subscribeAll` notification after each individual call, so a listener
+   * that reads back across multiple cells (e.g. a canvas redraw walking an
+   * object-list cell and dereferencing each entry's point cells) can
+   * observe a transient state mid-sequence -- e.g. an id still listed in
+   * one cell whose corresponding point cell has already been deleted by an
+   * earlier call in the same `fn`. Wrapping the whole sequence here defers
+   * every `subscribeAll` notification until `fn` fully returns, so
+   * listeners only ever see the state before or after, never in between.
+   */
+  transaction<T>(fn: () => T): T {
+    return this.runBatched(fn);
+  }
+
+  /**
+   * Request a `subscribeAll` notification. While a logical write is still
+   * in progress ({@link globalNotifyDepth} > 0), the request is only
+   * recorded ({@link globalNotifyPending}) -- {@link runBatched} flushes it
+   * once that write (including everything it cascaded into) fully unwinds.
+   * Outside of any write (e.g. a standalone `get()` that lazily recomputes a
+   * dirty cell with no `set`/`define`/`delete` on the stack), there's no
+   * outer call to flush later, so it fires immediately.
+   */
+  private scheduleGlobalNotify(): void {
+    this.globalNotifyPending = true;
+    if (this.globalNotifyDepth === 0) this.flushGlobalNotify();
+  }
+
+  /**
+   * Actually invoke every `subscribeAll` listener, once, for the batch of
+   * cell changes accumulated since the last flush.
+   *
+   * Guarded against reentering the listener-invocation loop itself --
+   * `notifyingGlobalListeners`, scoped to "is a global-listener loop
+   * currently on the stack" rather than per-cell-id, because by this point
+   * the notification is no longer about any single cell; it's "this batch
+   * of writes changed something." A listener that synchronously starts a
+   * NEW logical write (e.g. `set()` on a different cell) re-arms {@link
+   * globalNotifyPending} instead of recursing into a second, nested
+   * invocation of every listener -- that pending flag is drained in the
+   * `while` loop below once the in-progress loop returns, so that second
+   * write's notification still fires (once), it's just deferred to right
+   * after the first finishes rather than dropped. This is what fixes issue
+   * #234's bug 2: the previous shared `notifyingGlobal` boolean guard
+   * skipped (silently discarded) exactly this case instead of deferring it.
+   */
+  private flushGlobalNotify(): void {
+    if (this.notifyingGlobalListeners) return; // already mid-loop; that loop's own drain (below) will pick this up
+    this.notifyingGlobalListeners = true;
+    try {
+      while (this.globalNotifyPending) {
+        this.globalNotifyPending = false;
+        for (const fn of this.globalListeners) fn();
+      }
+    } finally {
+      this.notifyingGlobalListeners = false;
+    }
+  }
+}
+
+/** Deep structural equality, used to skip redraws when a recompute is a no-op. */
+export function structuralEqual(a: unknown, b: unknown): boolean {
+  return structuralEqualInner(a, b, []);
+}
+
+// `seen` is the stack of (a, b) pairs currently being compared by an
+// enclosing call on the stack -- used only as a cycle guard, see below.
+function structuralEqualInner(a: unknown, b: unknown, seen: Array<[object, object]>): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) return false;
+
+  // Cycle guard: if this exact (a, b) pair is already being compared by an
+  // enclosing (ancestor) call on the stack, it's a cycle -- stop recursing
+  // and treat it as equal here rather than looping forever. Any genuine
+  // difference elsewhere in the structure is still found by the other,
+  // non-cyclic branches of the comparison; this only prevents the recursion
+  // itself from being unbounded.
+  for (const [sa, sb] of seen) {
+    if (sa === a && sb === b) return true;
+  }
+
+  // Two objects of genuinely different types (Date vs plain object, Map vs
+  // Set, etc.) are never equal, regardless of their own-key shape below.
+  const aTag = Object.prototype.toString.call(a);
+  const bTag = Object.prototype.toString.call(b);
+  if (aTag !== bTag) return false;
+
+  seen = [...seen, [a, b]];
+
+  if (a instanceof Date) return a.getTime() === (b as Date).getTime();
+
+  if (a instanceof Map) {
+    const bm = b as Map<unknown, unknown>;
+    if (a.size !== bm.size) return false;
+    for (const [k, v] of a) {
+      if (!bm.has(k) || !structuralEqualInner(v, bm.get(k), seen)) return false;
+    }
+    return true;
+  }
+
+  if (a instanceof Set) {
+    // Set membership is by identity/SameValueZero, matching the Set's own
+    // semantics (not a structural comparison of elements) -- two elements
+    // that are merely structurally-equal-but-distinct objects are genuinely
+    // different members of a Set.
+    const bs = b as Set<unknown>;
+    if (a.size !== bs.size) return false;
+    for (const v of a) if (!bs.has(v)) return false;
+    return true;
+  }
+
+  if (Array.isArray(a)) {
+    const ba = b as unknown[];
+    if (a.length !== ba.length) return false;
+    return a.every((v, i) => structuralEqualInner(v, ba[i], seen));
+  }
+
+  // Any other exotic built-in (RegExp, DOM nodes, a real Path2D, etc.) that
+  // isn't a plain object falls through to here -- treat it as *not* equal
+  // by default rather than comparing (typically zero) own enumerable keys,
+  // which would otherwise silently treat any two distinct instances as
+  // identical. Safe default: this only means an extra recompute, never a
+  // missed update.
+  if (aTag !== "[object Object]") return false;
+
+  const aKeys = Object.keys(a as object);
+  const bKeys = Object.keys(b as object);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every(
+    (k) =>
+      Object.hasOwn(b, k) &&
+      structuralEqualInner((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k], seen),
+  );
+}

--- a/packages/math/src/Interval.ts
+++ b/packages/math/src/Interval.ts
@@ -1,8 +1,45 @@
+const F64 = new Float64Array(1);
+const U64 = new BigUint64Array(F64.buffer);
+
+/** The next representable double strictly greater than `value` (IEEE-754 nextafter toward +Infinity) -- JS has no built-in `Math.nextafter`, so this steps the raw 64-bit pattern by one ULP via a shared scratch buffer. */
+function nextUp(value: number): number {
+  if (Number.isNaN(value) || value === Infinity) return value;
+  if (value === 0) return Number.MIN_VALUE;
+  F64[0] = value;
+  U64[0] = (U64[0] as bigint) + (value > 0 ? 1n : -1n);
+  return F64[0] as number;
+}
+
+/** The next representable double strictly less than `value` -- `-nextUp(-value)`, since stepping toward -Infinity from `x` is the mirror of stepping toward +Infinity from `-x`. */
+function nextDown(value: number): number {
+  return -nextUp(-value);
+}
+
+/**
+ * Widens `x` by one ULP on each side -- the outward-rounding every non-exact
+ * `Interval` operation below applies to its result. `Math.*` computes to
+ * the *nearest* representable double (`Math.sqrt` is correctly rounded to
+ * 0.5 ULP per IEEE-754; the other transcendentals/arithmetic are within
+ * ~1 ULP on every mainstream engine), which breaks the containment
+ * guarantee interval arithmetic exists to provide: `Interval.point(2).sqrt()`
+ * would otherwise return a degenerate `[s, s]` that provably does NOT
+ * contain the irrational `sqrt(2)`. One ULP of outward slack restores
+ * rigor, at the cost of a deliberately loose bound when a result happens
+ * to be exactly representable (e.g. `sqrt(4)` reports a width-2-ULP
+ * interval around 2 instead of the point `[2, 2]`).
+ */
+function outward(x: Interval): Interval {
+  return new Interval(nextDown(x.lo), nextUp(x.hi));
+}
+
 /**
  * Interval — rigorous interval arithmetic `[lo, hi]`. Operations return an
  * interval guaranteed to contain every result of the corresponding operation on
  * any pair of members, so a final interval bounds the true answer despite
- * rounding — useful for reliable numerics and error tracking.
+ * rounding — useful for reliable numerics and error tracking. Every
+ * operation that isn't provably exact (`negate`/`abs`/`hull`/`intersect`
+ * only move or compare existing endpoints) outward-rounds its result by
+ * one ULP per side via `outward()` above.
  */
 export class Interval {
   readonly lo: number;
@@ -41,23 +78,29 @@ export class Interval {
   }
 
   add(o: Interval): Interval {
-    return new Interval(this.lo + o.lo, this.hi + o.hi);
+    return outward(new Interval(this.lo + o.lo, this.hi + o.hi));
   }
   subtract(o: Interval): Interval {
-    return new Interval(this.lo - o.hi, this.hi - o.lo);
+    return outward(new Interval(this.lo - o.hi, this.hi - o.lo));
   }
+  /** Exact: IEEE-754 negation only flips the sign bit, no rounding. */
   negate(): Interval {
     return new Interval(-this.hi, -this.lo);
   }
 
   multiply(o: Interval): Interval {
     const p = [this.lo * o.lo, this.lo * o.hi, this.hi * o.lo, this.hi * o.hi];
-    return new Interval(Math.min(...p), Math.max(...p));
+    return outward(new Interval(Math.min(...p), Math.max(...p)));
   }
 
   divide(o: Interval): Interval {
     if (o.contains(0)) throw new Error("Interval division by an interval containing zero.");
-    return this.multiply(new Interval(1 / o.hi, 1 / o.lo));
+    // The reciprocal bounds are themselves a rounded operation -- outward
+    // it before feeding into `multiply` (which outward-rounds its own
+    // result too), so neither step's rounding can silently eat the other's
+    // slack.
+    const reciprocal = outward(new Interval(1 / o.hi, 1 / o.lo));
+    return this.multiply(reciprocal);
   }
 
   /** The tightest interval containing both (the convex hull / union). */
@@ -80,24 +123,24 @@ export class Interval {
 
   sqrt(): Interval {
     if (this.lo < 0) throw new Error("sqrt of an interval with negative values.");
-    return new Interval(Math.sqrt(this.lo), Math.sqrt(this.hi));
+    return outward(new Interval(Math.sqrt(this.lo), Math.sqrt(this.hi)));
   }
   exp(): Interval {
-    return new Interval(Math.exp(this.lo), Math.exp(this.hi));
+    return outward(new Interval(Math.exp(this.lo), Math.exp(this.hi)));
   }
   log(): Interval {
     if (this.lo <= 0) throw new Error("log of an interval with non-positive values.");
-    return new Interval(Math.log(this.lo), Math.log(this.hi));
+    return outward(new Interval(Math.log(this.lo), Math.log(this.hi)));
   }
 
-  /** Integer power (handles even powers of intervals straddling zero). */
+  /** Integer power (handles even powers of intervals straddling zero). Exact when `n === 0` (every interval to the 0th power is the exact point 1). */
   pow(n: number): Interval {
     if (!Number.isInteger(n) || n < 0) throw new Error("Interval.pow requires a non-negative integer.");
     if (n === 0) return Interval.point(1);
     const a = this.lo ** n;
     const b = this.hi ** n;
-    if (n % 2 === 0 && this.contains(0)) return new Interval(0, Math.max(a, b));
-    return new Interval(Math.min(a, b), Math.max(a, b));
+    if (n % 2 === 0 && this.contains(0)) return outward(new Interval(0, Math.max(a, b)));
+    return outward(new Interval(Math.min(a, b), Math.max(a, b)));
   }
 
   private extrema(f: (x: number) => number, criticalPeriodStart: number, period: number): Interval {
@@ -106,7 +149,7 @@ export class Interval {
     const kStart = Math.ceil((this.lo - criticalPeriodStart) / period);
     const kEnd = Math.floor((this.hi - criticalPeriodStart) / period);
     for (let k = kStart; k <= kEnd; k++) candidates.push(f(criticalPeriodStart + k * period));
-    return new Interval(Math.min(...candidates), Math.max(...candidates));
+    return outward(new Interval(Math.min(...candidates), Math.max(...candidates)));
   }
 
   sin(): Interval {

--- a/packages/math/src/Rotor4.ts
+++ b/packages/math/src/Rotor4.ts
@@ -60,8 +60,21 @@ export class Rotor4 {
     return new Rotor4(this.scalar + r.scalar, this.bivector.add(r.bivector), this.pseudoscalar + r.pseudoscalar);
   }
 
+  subtract(r: Rotor4): Rotor4 {
+    return new Rotor4(this.scalar - r.scalar, this.bivector.subtract(r.bivector), this.pseudoscalar - r.pseudoscalar);
+  }
+
+  negate(): Rotor4 {
+    return new Rotor4(-this.scalar, this.bivector.negate(), -this.pseudoscalar);
+  }
+
   scale(s: number): Rotor4 {
     return new Rotor4(this.scalar * s, this.bivector.scale(s), this.pseudoscalar * s);
+  }
+
+  /** Component-wise inner product over all 8 components (scalar, 6 bivector, pseudoscalar) -- treats a Rotor4 as an 8-vector, exactly {@link Quaternion.dot}'s role in that class's own `slerp`. */
+  dot(r: Rotor4): number {
+    return this.scalar * r.scalar + this.bivector.dot(r.bivector) + this.pseudoscalar * r.pseudoscalar;
   }
 
   /** The geometric product `this * r` — composes two rotations (apply `r` first, then `this`). */
@@ -73,10 +86,28 @@ export class Rotor4 {
    * The reverse `R~`: reverses the order of vector factors, which negates the
    * bivector (grade 2, picks up (-1)^1) but leaves the scalar (grade 0) and
    * pseudoscalar (grade 4, picks up (-1)^6 = +1) unchanged. For a unit rotor,
-   * this is also the inverse — the 4D analogue of a quaternion's conjugate.
+   * this is also the inverse — the 4D analogue of a quaternion's conjugate
+   * ({@link Quaternion.conjugate}). **Not** the inverse for a non-unit rotor
+   * (see {@link inverse}): a rotor that has drifted off the unit manifold
+   * during repeated composition (e.g. per-timestep physics integration,
+   * before renormalization runs) will silently produce a wrong,
+   * `|R|²`-scaled result from `reverse()` where an inverse was intended.
    */
   reverse(): Rotor4 {
     return new Rotor4(this.scalar, this.bivector.negate(), this.pseudoscalar);
+  }
+
+  /**
+   * Multiplicative inverse `R⁻¹ = R~ / |R|²`, distinct from {@link reverse}
+   * for a non-unit rotor — the 4D analogue of {@link Quaternion.inverse}.
+   * `this.multiply(this.inverse())` is `Identity` regardless of `this`'s
+   * magnitude; `this.multiply(this.reverse())` only is when `this` is
+   * already a unit rotor.
+   */
+  inverse(): Rotor4 {
+    const m2 = this.magnitudeSquared;
+    if (m2 === 0) throw new Error("The zero rotor has no inverse.");
+    return this.reverse().scale(1 / m2);
   }
 
   get magnitudeSquared(): number {
@@ -362,6 +393,37 @@ export class Rotor4 {
     const angle = 2 * Math.atan2(bMag, this.scalar);
     if (bMag === 0) return { plane: Bivector4.Zero, angle: 0 };
     return { plane: this.bivector.normalize(), angle };
+  }
+
+  /**
+   * Spherical linear interpolation between two rotors, `t` in `[0, 1]` --
+   * the 4D analogue of {@link Quaternion.slerp}, same component-wise
+   * treatment (an 8-vector of scalar/bivector(6)/pseudoscalar, via
+   * {@link dot}) and the same near-parallel fallback to a normalized
+   * linear interpolation to avoid dividing by a near-zero `sin(theta0)`.
+   *
+   * **Same manifold caveat as {@link normalize}**: this is only exactly
+   * correct for interpolating between *simple* rotors (single rotation
+   * plane) — a compound double rotation doesn't lie on the sphere this
+   * construction assumes, so slerping one is an approximation, not a
+   * geodesic. For a double rotation, {@link factor} each endpoint into its
+   * two orthogonal simple rotors and slerp each pair independently instead.
+   */
+  static slerp(a: Rotor4, b: Rotor4, t: number): Rotor4 {
+    const ra = a.normalize();
+    let rb = b.normalize();
+    let cos = ra.dot(rb);
+    if (cos < 0) {
+      rb = rb.scale(-1);
+      cos = -cos;
+    }
+    if (cos > 0.9995) return ra.add(rb.subtract(ra).scale(t)).normalize();
+    const theta0 = Math.acos(cos);
+    const theta = theta0 * t;
+    const sinTheta0 = Math.sin(theta0);
+    const s0 = Math.sin(theta0 - theta) / sinTheta0;
+    const s1 = Math.sin(theta) / sinTheta0;
+    return ra.scale(s0).add(rb.scale(s1));
   }
 
   equals(r: Rotor4, epsilon = 0): boolean {

--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -7,6 +7,10 @@
 // 4D geometric algebra (vectors, bivectors, rotors) -- see report/MIEGAKURE_REPORT.md
 // in johnhenry/miegakure-archive for the design context this was built for.
 export { Bivector4 } from "./Bivector4.ts";
+// Reactive, pull-based dependency graph -- promoted from johnhenry/mallory-graph
+// (its src/lib/cell-graph.ts), which mallory-grapher also vendored a frozen
+// copy of; both now import it from here instead. See johnhenry/mallory#56.
+export { CellGraph, type CellRole, CircularDependencyError, structuralEqual } from "./CellGraph.ts";
 // Counting mathematics
 export { Combinatorics } from "./Combinatorics.ts";
 export {

--- a/packages/math/test/CellGraph.test.ts
+++ b/packages/math/test/CellGraph.test.ts
@@ -1,0 +1,823 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { CellGraph, CircularDependencyError, structuralEqual } from "../src/CellGraph.ts";
+
+test("set/get a raw source cell", () => {
+  const g = new CellGraph();
+  g.set("a", 5);
+  assert.equal(g.get("a"), 5);
+});
+
+test("has() returns true the instant a cell is merely read, even before it's ever been set/defined -- hasValue() does not", () => {
+  // This is the exact real-world footgun a production bug traced back to
+  // (ExpressionRow.tsx's init guard): a caller elsewhere in the app (e.g. a
+  // subscribeAll listener firing reentrant mid-render) reads a not-yet-
+  // initialized id via a bare get(), which silently ensure()s an empty
+  // record. A later "was this already initialized?" check that uses has()
+  // instead of hasValue() is fooled into skipping real initialization.
+  const g = new CellGraph();
+  assert.equal(g.has("never-touched"), false);
+  assert.equal(g.hasValue("never-touched"), false);
+  g.get("never-touched"); // a bare read, no set()/define() -- ensure()s an empty record as a side effect
+  assert.equal(g.has("never-touched"), true, "has() is fooled by the bare read");
+  assert.equal(g.hasValue("never-touched"), false, "hasValue() is not -- no real value was ever produced");
+});
+
+test("derived cell recomputes from its dependencies", () => {
+  const g = new CellGraph();
+  g.set("a", 2);
+  g.set("b", 3);
+  g.define("sum", () => g.get<number>("a") + g.get<number>("b"));
+  assert.equal(g.get("sum"), 5);
+  g.set("a", 10);
+  assert.equal(g.get("sum"), 13);
+});
+
+test("dirty propagates transitively through a chain", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  g.define("b", () => g.get<number>("a") * 2);
+  g.define("c", () => g.get<number>("b") + 1);
+  assert.equal(g.get("c"), 3);
+  g.set("a", 5);
+  assert.equal(g.get("c"), 11);
+});
+
+test("dependencies rebuild fresh on each recompute (conditional deps)", () => {
+  const g = new CellGraph();
+  g.set("useA", true);
+  g.set("a", 1);
+  g.set("b", 100);
+  g.define("out", () => (g.get<boolean>("useA") ? g.get<number>("a") : g.get<number>("b")));
+  assert.equal(g.get("out"), 1);
+
+  // Switch to depending on b instead of a; a's future writes must no longer affect out.
+  g.set("useA", false);
+  assert.equal(g.get("out"), 100);
+  g.set("a", 999);
+  assert.equal(g.get("out"), 100);
+  g.set("b", 200);
+  assert.equal(g.get("out"), 200);
+});
+
+test("structural sharing preserves object identity across a no-op recompute", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  g.define("parity", () => ({ label: g.get<number>("a") % 2 === 0 ? "even" : "odd" }));
+
+  const first = g.get("parity");
+  assert.deepEqual(first, { label: "odd" });
+  const versionAfterFirst = g.getVersion("parity");
+
+  // a: 1 -> 3 is a real change, but parity's *output* is structurally the
+  // same ("odd") -> the cached reference (and version) must be preserved,
+  // which is what lets a downstream Object.is check bail out of a redraw.
+  g.set("a", 3);
+  const second = g.get("parity");
+  assert.equal(second, first, "same reference preserved when recompute is structurally unchanged");
+  assert.equal(g.getVersion("parity"), versionAfterFirst);
+
+  // a: 3 -> 4 flips parity to "even" -> genuinely different, new reference.
+  g.set("a", 4);
+  const third = g.get("parity");
+  assert.notEqual(third, first);
+  assert.deepEqual(third, { label: "even" });
+  assert.ok(g.getVersion("parity") > versionAfterFirst);
+});
+
+test("subscribe fires on change, not on a structurally-equal no-op write", () => {
+  const g = new CellGraph();
+  g.set("a", { x: 1 });
+  let calls = 0;
+  const unsub = g.subscribe("a", () => calls++);
+  g.set("a", { x: 1 }); // structurally equal -> no emit
+  assert.equal(calls, 0);
+  g.set("a", { x: 2 });
+  assert.equal(calls, 1);
+  unsub();
+  g.set("a", { x: 3 });
+  assert.equal(calls, 1);
+});
+
+test("subscribeAll fires for changes on any cell", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  let calls = 0;
+  g.subscribeAll(() => calls++);
+  g.set("a", 2);
+  g.set("b", 3);
+  assert.equal(calls, 2);
+});
+
+// subscribeMany (issue #235): several panels' URL-sync/redraw effects used
+// subscribeAll purely as a shorthand for "any of these specific cells I
+// actually read", which meant they ALSO fired on unrelated high-frequency
+// writes elsewhere in the same graph -- a RAF-driven playback clock
+// (TIME_CELL), a live drag preview, a per-epoch training metric -- that the
+// listener's own output never depended on. These tests model that exact
+// shape: a "TIME_CELL"-like hot cell the listener does NOT watch.
+test("subscribeMany fires for a write to any watched cell", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  g.set("b", 1);
+  let calls = 0;
+  g.subscribeMany(["a", "b"], () => calls++);
+  g.set("a", 2);
+  g.set("b", 2);
+  assert.equal(calls, 2);
+});
+
+test("subscribeMany does NOT fire for a write to a cell outside the watched set -- e.g. a RAF-driven clock the listener doesn't read", () => {
+  const g = new CellGraph();
+  g.set("exprText", "x");
+  g.set("TIME_CELL", 0);
+  let calls = 0;
+  // Mirrors GraphTheoryPanel/ComplexPanel/MlPlaygroundPanel's writeUrl: only
+  // watches the cells its serialized output actually reads.
+  g.subscribeMany(["exprText"], () => calls++);
+  for (let frame = 1; frame <= 60; frame++) g.set("TIME_CELL", frame); // 60 "RAF ticks" of an unrelated clock
+  assert.equal(calls, 0, "60 writes to an unwatched cell must not fire a subscribeMany listener even once");
+  g.set("exprText", "x^2");
+  assert.equal(calls, 1, "a write to a watched cell still fires normally");
+});
+
+test("subscribeMany: the returned unsubscribe function detaches every watched id, not just the first", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  g.set("b", 1);
+  let calls = 0;
+  const unsubscribe = g.subscribeMany(["a", "b"], () => calls++);
+  unsubscribe();
+  g.set("a", 2);
+  g.set("b", 2);
+  assert.equal(calls, 0);
+});
+
+test("subscribeMany: a shared-graph multi-block scenario -- writes to a DIFFERENT block's cells don't fire this block's listener (NotebookGraphBlock's fix)", () => {
+  const g = new CellGraph();
+  // Two notebook blocks sharing one CellGraph, the way NotebookPanel wires
+  // every block onto a single document-wide graph.
+  g.set("blockA.path", "pathA-v1");
+  g.set("blockB.path", "pathB-v1");
+  let blockARedraws = 0;
+  g.subscribeMany(["blockA.path"], () => blockARedraws++);
+  // A slider drag, RAF tick, or training-loop write in block B...
+  for (let i = 0; i < 30; i++) g.set("blockB.path", `pathB-v${i}`);
+  assert.equal(blockARedraws, 0, "block A's redraw must not fire for block B's own writes");
+  // ...but block A's own write still redraws it.
+  g.set("blockA.path", "pathA-v2");
+  assert.equal(blockARedraws, 1);
+});
+
+test("throws on a circular dependency", () => {
+  const g = new CellGraph();
+  g.define("a", () => g.get<number>("b") + 1);
+  g.define("b", () => g.get<number>("a") + 1);
+  assert.throws(() => g.get("a"), CircularDependencyError);
+});
+
+// The four tests below investigate a specific concern raised while surveying
+// this repo for cross-repo interop opportunities (see the mallory-plus
+// FAMILY.md doc and this repo's own issue #18): could redefining a cell to
+// complete a cycle, at a moment when an INTERMEDIATE cell in that cycle is
+// clean/cached (not currently on the live call stack), let a genuine
+// circular dependency slip past `stack.includes(id)`'s live-call check?
+//
+// Empirically -- across every entry point tried below -- the answer is no.
+// `propagateDirty()` runs unconditionally at the end of every `set()`/
+// `define()` call, REGARDLESS of whether the triggering recompute's result
+// was structurally unchanged. The redefine that completes a cycle therefore
+// always ends its own call by transitively dirtying every cell reachable
+// through the (by-then fully-connected) cycle -- so the very next live
+// `get()` on ANY cycle member, no matter which one, forces a fresh walk
+// through every dirty member and correctly lands on `stack.includes(id)`.
+// These tests exist to lock that in as a regression guard, not to document
+// a bug -- see issue #18's closing comment for the full investigation.
+test("cycle completed by redefining an existing (previously clean/cached) cell is still caught, read from the cell that completed it", () => {
+  const g = new CellGraph();
+  g.define("c", () => 5);
+  assert.equal(g.get("c"), 5);
+  g.define("b", () => g.get<number>("c"));
+  assert.equal(g.get("b"), 5); // b reads c while c is a plain leaf -- no cycle yet
+  g.define("a", () => g.get<number>("b")); // deliberately not get()'d yet
+  g.define("c", () => g.get<number>("a")); // redefine c -- completes a -> b -> c -> a
+  assert.throws(() => g.get("c"), CircularDependencyError);
+});
+
+test("cycle completed by redefining an existing cell is caught reading the OTHER end (the cell that was clean at completion time)", () => {
+  const g = new CellGraph();
+  g.define("c", () => 5);
+  g.get("c");
+  g.define("b", () => g.get<number>("c"));
+  g.get("b"); // b clean, cached -- this is the cell that's clean when the cycle completes
+  g.define("a", () => g.get<number>("b"));
+  g.define("c", () => g.get<number>("a"));
+  assert.throws(() => g.get("b"), CircularDependencyError);
+});
+
+test("cycle completed by redefining an existing cell is caught reading a THIRD, previously-untouched cell", () => {
+  const g = new CellGraph();
+  g.define("c", () => 5);
+  g.get("c");
+  g.define("b", () => g.get<number>("c"));
+  g.get("b");
+  g.define("a", () => g.get<number>("b"));
+  g.define("c", () => g.get<number>("a"));
+  assert.throws(() => g.get("a"), CircularDependencyError);
+});
+
+test("cycle completed purely via define() (no cell ever computed before the cycle closes) is still caught on the first live get()", () => {
+  const g = new CellGraph();
+  g.define("b", () => g.get<number>("c"));
+  g.get("b"); // auto-vivifies "c" as an empty, compute-less record (not yet defined)
+  g.define("c", () => g.get<number>("a")); // "c"'s first REAL define -- completes half the cycle
+  g.define("a", () => g.get<number>("b")); // completes the other half
+  assert.throws(() => g.get("a"), CircularDependencyError);
+});
+
+test("delete detaches a cell from its dependents and dependencies", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  g.define("b", () => g.get<number>("a") + 1);
+  assert.equal(g.get("b"), 2);
+  g.delete("a");
+  assert.equal(g.has("a"), false);
+  g.set("a", 100);
+  // "b" was defined against the old "a" cell instance; a fresh "a" cell means
+  // "b" is no longer marked dirty by writes to the new one until re-defined.
+  g.define("b", () => g.get<number>("a") + 1);
+  assert.equal(g.get("b"), 101);
+});
+
+test("role reports free for a set cell, dependent for a define cell, unknown before any value exists", () => {
+  const g = new CellGraph();
+  assert.equal(g.role("never-touched"), "unknown");
+  g.set("a", 1);
+  assert.equal(g.role("a"), "free");
+  g.define("b", () => g.get<number>("a") + 1);
+  assert.equal(g.role("b"), "unknown"); // defined but not yet read/recomputed
+  g.get("b");
+  assert.equal(g.role("b"), "dependent");
+});
+
+test("role updates when a cell transitions between set and define", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  assert.equal(g.role("a"), "free");
+  g.define("a", () => 2);
+  g.get("a");
+  assert.equal(g.role("a"), "dependent");
+  g.set("a", 3);
+  assert.equal(g.role("a"), "free");
+});
+
+test("isAuxiliary defaults to false, and is set/preserved per the set/define auxiliary option", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  assert.equal(g.isAuxiliary("a"), false);
+  g.set("hidden", 1, { auxiliary: true });
+  assert.equal(g.isAuxiliary("hidden"), true);
+  // A later set() on the same still-free cell without an explicit option
+  // leaves the previously-set auxiliary flag alone rather than resetting it.
+  g.set("hidden", 2);
+  assert.equal(g.isAuxiliary("hidden"), true);
+});
+
+test("list enumerates every cell with its role and auxiliary flag", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  g.set("hidden", 2, { auxiliary: true });
+  g.define("b", () => g.get<number>("a") + 1);
+  g.get("b");
+  const entries = new Map(g.list().map((e) => [e.id, e]));
+  assert.deepEqual(entries.get("a"), { id: "a", role: "free", auxiliary: false, hasValue: true });
+  assert.deepEqual(entries.get("hidden"), { id: "hidden", role: "free", auxiliary: true, hasValue: true });
+  assert.deepEqual(entries.get("b"), { id: "b", role: "dependent", auxiliary: false, hasValue: true });
+});
+
+test("delete() marks former dependents dirty so their next get() recomputes without the deleted cell", () => {
+  // Mirrors ExpressionRow's params compute exactly: read an external cell
+  // unconditionally (registering the edge even before it exists), use it
+  // only if it has a real value, else fall back to a local cell.
+  const g = new CellGraph();
+  g.set("external", 5);
+  g.set("local", 1);
+  g.define("out", () => {
+    const ext = g.get<number | undefined>("external");
+    return g.hasValue("external") ? (ext as number) : g.get<number>("local");
+  });
+  assert.equal(g.get("out"), 5);
+  g.delete("external");
+  assert.equal(g.get("out"), 1, "recomputes and falls back to the local cell");
+  // The recompute above rebuilt out's dependency edges -- a later write to
+  // the fallback dependency must now reach it (before the delete() fix,
+  // the edge never rebuilt, so this write was silently lost too).
+  g.set("local", 42);
+  assert.equal(g.get("out"), 42);
+});
+
+test("delete() notifies subscribers of former dependents (not just marks dirty)", () => {
+  const g = new CellGraph();
+  g.set("source", 1);
+  g.define("derived", () => g.get<number>("source") * 2);
+  g.get("derived");
+  let notified = 0;
+  g.subscribe("derived", () => notified++);
+  g.delete("source");
+  assert.ok(notified >= 1, "the dependent's subscriber fired on delete of its dependency");
+});
+
+test("delete() of a nonexistent or never-touched id is a harmless no-op", () => {
+  const g = new CellGraph();
+  g.delete("never-existed"); // must not throw
+  g.set("a", 1);
+  g.delete("a");
+  g.delete("a"); // double delete is fine too
+  assert.equal(g.hasValue("a"), false);
+});
+
+test("get() on a deleted id re-creates an empty record with 'never existed' semantics", () => {
+  const g = new CellGraph();
+  g.set("a", 7);
+  g.delete("a");
+  assert.equal(g.get("a"), undefined);
+  assert.equal(g.hasValue("a"), false);
+});
+
+test("a compute that reads a sibling id before it's ever been set/defined sees undefined, then recomputes once that sibling is later defined (the mallory-graph#10 pattern)", () => {
+  const g = new CellGraph();
+  // Mirrors LinkedGraphPanes/Linked3DView's combinedDuration: defined before
+  // either "pane" has mounted and defined its own timelineDuration cell.
+  g.define("combined", () => {
+    const a = g.get<number>("pane-a-duration");
+    const b = g.get<number>("pane-b-duration");
+    return Math.max(Number.isFinite(a) ? a : 0, Number.isFinite(b) ? b : 0);
+  });
+  // First read, before either pane exists: get() on a never-set id returns
+  // undefined, not NaN -- the Number.isFinite guard is what keeps the
+  // compute's own result a real number despite that.
+  assert.equal(g.get("combined"), 0);
+
+  // "pane-a" mounts and defines its own duration cell with a real value --
+  // the dependency edge recorded during the first read above (get() on a
+  // not-yet-existing id still registers the edge) means this define() call
+  // marks "combined" dirty and notifies it, without "combined" having to be
+  // re-read to pick up the change.
+  let notified = 0;
+  g.subscribe("combined", () => notified++);
+  g.define("pane-a-duration", () => 5);
+  assert.equal(notified, 1);
+  assert.equal(g.get("combined"), 5);
+});
+
+// -----------------------------------------------------------------------
+// Regression tests for github.com/johnhenry/mallory-graph issues #12-#16
+// -----------------------------------------------------------------------
+
+// #12 -- set() on a dependent cell leaks stale dependency edges
+test("set() on a formerly-dependent cell actually empties its recorded dependency edges (not just stops acting on them)", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  g.define("b", () => g.get<number>("a") * 2);
+  assert.equal(g.get("b"), 2); // b.dependencies = {a}, a.dependents = {b}
+
+  g.set("b", 100); // b transitions dependent -> free
+
+  // Reach into the private `cells` map directly -- this is the most direct
+  // way to prove the edges are actually detached, not merely inert.
+  const cells = (g as unknown as { cells: Map<string, { dependencies: Set<string>; dependents: Set<string> }> }).cells;
+  assert.equal(cells.get("b")?.dependencies.size, 0, "b's own recorded dependencies are cleared");
+  assert.equal(cells.get("a")?.dependents.has("b"), false, "a no longer records b as one of its dependents");
+});
+
+test("set() on a formerly-dependent cell stops receiving dirty propagation/notifications from its former dependencies", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  g.define("b", () => g.get<number>("a") * 2);
+  assert.equal(g.get("b"), 2);
+
+  g.set("b", 100);
+  assert.equal(g.role("b"), "free");
+
+  let notified = 0;
+  g.subscribe("b", () => notified++);
+
+  // "a" no longer has "b" as a dependent (per the previous test) -- a write
+  // to "a" must not dirty or notify the now-free "b" at all.
+  g.set("a", 999);
+  assert.equal(notified, 0, "a write to the former dependency must not touch the now-free cell");
+  assert.equal(g.get("b"), 100, "b's value is untouched by a's write");
+});
+
+// #13 -- structuralEqual treats any two zero-own-key objects as equal
+test("structuralEqual distinguishes two distinct Dates instead of treating them as equal via zero-own-keys", () => {
+  const a = new Date("2020-01-01T00:00:00Z");
+  const b = new Date("2021-01-01T00:00:00Z");
+  assert.equal(structuralEqual(a, b), false);
+  assert.equal(structuralEqual(a, new Date(a.getTime())), true, "two Dates with the same time are still equal");
+});
+
+test("structuralEqual distinguishes two distinct Maps and Sets by content, not by their (zero) own enumerable keys", () => {
+  assert.equal(structuralEqual(new Map([["x", 1]]), new Map([["x", 2]])), false);
+  assert.equal(structuralEqual(new Map([["x", 1]]), new Map([["x", 1]])), true);
+  assert.equal(structuralEqual(new Map([["x", 1]]), new Map([["y", 1]])), false, "different keys");
+  assert.equal(structuralEqual(new Set([1, 2, 3]), new Set([1, 2, 4])), false);
+  assert.equal(structuralEqual(new Set([1, 2, 3]), new Set([1, 2, 3])), true);
+});
+
+test("structuralEqual treats a Date/Map/Set as not equal to a plain object even with matching own keys", () => {
+  assert.equal(structuralEqual(new Date(0), {}), false);
+  assert.equal(structuralEqual(new Map(), {}), false);
+});
+
+test("structuralEqual does not infinite-loop (stack overflow) on a cyclic value", () => {
+  const a: Record<string, unknown> = { n: 1 };
+  a.self = a;
+  const b: Record<string, unknown> = { n: 1 };
+  b.self = b;
+  assert.doesNotThrow(() => structuralEqual(a, b));
+  assert.equal(structuralEqual(a, b), true, "structurally identical cyclic shapes compare equal");
+
+  const c: Record<string, unknown> = { n: 2 };
+  c.self = c;
+  assert.equal(structuralEqual(a, c), false, "a genuine difference outside the cycle is still detected");
+});
+
+test("a cell holding a Date now correctly bumps version/notifies on a real Date change, instead of the change being silently swallowed", () => {
+  const g = new CellGraph();
+  g.set("d", new Date("2020-01-01T00:00:00Z"));
+  const v1 = g.getVersion("d");
+  let notified = 0;
+  g.subscribe("d", () => notified++);
+
+  g.set("d", new Date("2021-01-01T00:00:00Z")); // genuinely different Date
+  assert.ok(g.getVersion("d") > v1, "version bumps for a real Date change");
+  assert.equal(notified, 1);
+});
+
+// #14 -- failing computes rethrow on every get() with no error caching
+test("a throwing compute caches its error -- repeated get() calls rethrow without re-running the compute", () => {
+  const g = new CellGraph();
+  let calls = 0;
+  g.define("bad", () => {
+    calls++;
+    throw new Error("boom");
+  });
+  assert.throws(() => g.get("bad"), /boom/);
+  assert.equal(calls, 1);
+  assert.throws(() => g.get("bad"), /boom/);
+  assert.throws(() => g.get("bad"), /boom/);
+  assert.equal(calls, 1, "the compute must not re-run on subsequent get() calls -- the cached error is rethrown");
+});
+
+test("a cached compute error is invalidated once a real dependency change makes the cell dirty again", () => {
+  const g = new CellGraph();
+  g.set("shouldFail", true);
+  let calls = 0;
+  g.define("maybeFails", () => {
+    calls++;
+    if (g.get<boolean>("shouldFail")) throw new Error("nope");
+    return 42;
+  });
+  assert.throws(() => g.get("maybeFails"));
+  assert.equal(calls, 1);
+  assert.throws(() => g.get("maybeFails"));
+  assert.equal(calls, 1, "still cached -- no retry yet");
+
+  g.set("shouldFail", false); // dirties "maybeFails" via the normal propagateDirty cascade
+  assert.equal(g.get("maybeFails"), 42, "the next get() after a real dependency change retries the compute");
+  assert.equal(calls, 2);
+});
+
+test("set()ing a formerly-erroring dependent cell to free clears its cached error", () => {
+  const g = new CellGraph();
+  g.define("bad", () => {
+    throw new Error("boom");
+  });
+  assert.throws(() => g.get("bad"));
+  g.set("bad", 5);
+  assert.equal(g.get("bad"), 5, "no stale cached error survives the dependent -> free transition");
+});
+
+// #15 -- define() bumps the version unconditionally
+test("define() does not bump version/notify when redefining with a compute that yields a structurally-identical result", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  g.define("double", () => g.get<number>("a") * 2);
+  assert.equal(g.get("double"), 2);
+  const versionAfterFirst = g.getVersion("double");
+
+  let notified = 0;
+  g.subscribe("double", () => notified++);
+
+  // Redefine with a different compute fn that happens to produce the same
+  // value (e.g. a component remount or a config reapply) -- must not bump
+  // version or notify at all.
+  g.define("double", () => 1 + 1);
+  assert.equal(notified, 0, "the redefine resolved to no real change -- no notification");
+  assert.equal(g.get("double"), 2);
+  assert.equal(notified, 0, "reading again afterwards must not notify a second time either");
+  assert.equal(
+    g.getVersion("double"),
+    versionAfterFirst,
+    "version is unchanged since the recomputed value is structurally identical",
+  );
+});
+
+test("define() bumps version/notifies SYNCHRONOUSLY (not deferred to some later get()) when a redefine genuinely changes the value", () => {
+  // This is the guarantee that actually matters for the live app:
+  // useSyncExternalStore's re-render is scheduled by the subscribe
+  // callback firing (i.e. emit()), not by some future get() call that
+  // nothing guarantees will ever happen. A fix that deferred notification
+  // to the next get() would leave a subscribed component's UI stale
+  // indefinitely whenever nothing else happens to re-render it.
+  const g = new CellGraph();
+  g.set("a", 1);
+  g.define("double", () => g.get<number>("a") * 2);
+  assert.equal(g.get("double"), 2);
+  const versionAfterFirst = g.getVersion("double");
+
+  let notified = 0;
+  g.subscribe("double", () => notified++);
+
+  g.define("double", () => 100); // genuinely different result
+  assert.equal(notified, 1, "notified synchronously by define() itself -- no intervening get() call");
+  assert.ok(g.getVersion("double") > versionAfterFirst, "version already bumped synchronously too");
+  assert.equal(g.get("double"), 100, "and the cached value already reflects the new result");
+  assert.equal(notified, 1, "reading it afterwards must not notify a second time");
+});
+
+test("define() redefining with a throwing compute does not throw synchronously, and does not notify (error is cached for the next get(), per #14)", () => {
+  const g = new CellGraph();
+  g.define("risky", () => 1);
+  assert.equal(g.get("risky"), 1);
+
+  let notified = 0;
+  g.subscribe("risky", () => notified++);
+
+  assert.doesNotThrow(() => {
+    g.define("risky", () => {
+      throw new Error("boom");
+    });
+  });
+  assert.equal(notified, 0, "a failed redefine has no real value change to notify about");
+  assert.throws(() => g.get("risky"), /boom/);
+});
+
+test("define() still eagerly notifies dependents on a first-ever definition (no prior value to compare against)", () => {
+  // A first define() has no cached value to defer against -- hasValue flips
+  // false -> true unconditionally, so the existing eager-cascade behavior
+  // (relied on by the mallory-graph#10-pattern test above) must be
+  // untouched by the #15 fix.
+  const g = new CellGraph();
+  let notified = 0;
+  g.subscribe("fresh", () => notified++);
+  g.define("fresh", () => 1);
+  assert.equal(notified, 1);
+});
+
+// #16 -- listener and record cleanup gaps on delete
+test("subscribe(): the last unsubscribe removes the (now-empty) listener Set for a cell, not just the listener itself", () => {
+  const g = new CellGraph();
+  const unsub1 = g.subscribe("x", () => {});
+  const unsub2 = g.subscribe("x", () => {});
+
+  const listeners = (g as unknown as { listeners: Map<string, Set<unknown>> }).listeners;
+  assert.equal(listeners.has("x"), true);
+  unsub1();
+  assert.equal(listeners.has("x"), true, "one listener remains -- the Set itself must still be present");
+  unsub2();
+  assert.equal(
+    listeners.has("x"),
+    false,
+    "the last unsubscribe must remove the now-empty Set entirely, not leave an empty one behind",
+  );
+});
+
+test("subscribe()'s ensure()-created cell record does not outlive its subscribers when the cell was never actually set/defined", () => {
+  const g = new CellGraph();
+  assert.equal(g.has("phantom"), false);
+  const unsub = g.subscribe("phantom", () => {});
+  assert.equal(g.has("phantom"), true, "subscribe() materializes an empty record via ensure(), same as get() does");
+  unsub();
+  assert.equal(
+    g.has("phantom"),
+    false,
+    "with no subscribers left and no real value/definition, the phantom record is cleaned up instead of leaking forever",
+  );
+});
+
+test("a genuinely live cell (has a real value) is NOT removed just because its subscribers all go away", () => {
+  const g = new CellGraph();
+  g.set("real", 1);
+  const unsub = g.subscribe("real", () => {});
+  unsub();
+  assert.equal(g.has("real"), true, "a cell with a real value must survive its subscribers going away");
+  assert.equal(g.get("real"), 1, "only explicit delete() removes a live cell");
+});
+
+test("a cell still participating in the dependency graph (has a dependent) is NOT removed when its own subscribers go away", () => {
+  const g = new CellGraph();
+  g.define("derived", () => g.get<number | undefined>("dep"));
+  g.get("derived"); // registers "derived" as a dependent of "dep", materializing dep's empty record
+  const unsub = g.subscribe("dep", () => {});
+  unsub();
+  assert.equal(
+    g.has("dep"),
+    true,
+    '"dep" still has a dependent ("derived") -- must not be silently removed out from under it',
+  );
+});
+
+test("many dynamically created/destroyed subscription-only cells do not accumulate unboundedly (the ExpressionRow per-row-cell pattern)", () => {
+  const g = new CellGraph();
+  for (let i = 0; i < 50; i++) {
+    const id = `row-${i}`;
+    const unsub = g.subscribe(id, () => {});
+    unsub();
+  }
+  const cells = (g as unknown as { cells: Map<string, unknown> }).cells;
+  const listeners = (g as unknown as { listeners: Map<string, unknown> }).listeners;
+  assert.equal(cells.size, 0, "no phantom cell records survive their subscribers going away");
+  assert.equal(listeners.size, 0, "no empty listener Sets survive their subscribers going away");
+});
+
+test("subscribeWrites: fires on a real set() with the id and new value", () => {
+  const g = new CellGraph();
+  const writes: Array<{ id: string; value: unknown }> = [];
+  g.subscribeWrites((id, value) => writes.push({ id, value }));
+  g.set("a", 1);
+  g.set("a", 2);
+  assert.deepEqual(writes, [
+    { id: "a", value: 1 },
+    { id: "a", value: 2 },
+  ]);
+});
+
+test("subscribeWrites: does NOT fire for a no-op set() (structurally-identical value)", () => {
+  const g = new CellGraph();
+  const writes: unknown[] = [];
+  g.set("a", { x: 1 });
+  g.subscribeWrites((id, value) => writes.push({ id, value }));
+  g.set("a", { x: 1 }); // structurally equal to the existing value -- a no-op
+  assert.deepEqual(writes, []);
+});
+
+test("subscribeWrites: does NOT fire for a define()-driven recompute -- only raw set() calls, matching the live-collaboration use case (issue #47) of broadcasting user-initiated writes, not every derived cascade", () => {
+  const g = new CellGraph();
+  const writes: Array<{ id: string; value: unknown }> = [];
+  g.set("base", 1);
+  g.define("derived", () => g.get<number>("base") * 2);
+  g.subscribeWrites((id, value) => writes.push({ id, value }));
+  g.set("base", 5); // triggers "derived" to recompute on next get(), but that's not a set() call
+  g.get("derived");
+  assert.deepEqual(writes, [{ id: "base", value: 5 }], 'only the raw set() on "base" should appear, never "derived"');
+});
+
+test("subscribeWrites: the returned unsubscribe function stops future notifications", () => {
+  const g = new CellGraph();
+  const writes: unknown[] = [];
+  const unsub = g.subscribeWrites((id, value) => writes.push({ id, value }));
+  g.set("a", 1);
+  unsub();
+  g.set("a", 2);
+  assert.deepEqual(writes, [{ id: "a", value: 1 }]);
+});
+
+// -----------------------------------------------------------------------
+// Regression tests for github.com/johnhenry/mallory-graph issue #234:
+// subscribeAll over-firing (bug 1) and reentrant-write swallowing (bug 2).
+// -----------------------------------------------------------------------
+
+test("subscribeAll: a single set() on the root of a diamond dependency graph fires global listeners exactly once, not once per cascaded dependent (#234 bug 1)", () => {
+  const g = new CellGraph();
+  g.set("root", 1);
+  g.define("left", () => g.get<number>("root") + 1);
+  g.define("right", () => g.get<number>("root") + 2);
+  g.define("bottom", () => g.get<number>("left") + g.get<number>("right"));
+  // Prime everything so it's clean/cached before the edit under test.
+  g.get("left");
+  g.get("right");
+  g.get("bottom");
+
+  let calls = 0;
+  g.subscribeAll(() => calls++);
+
+  g.set("root", 2); // one logical write, cascades dirty through left, right, bottom
+  assert.equal(calls, 1, "one subscribeAll notification for the whole cascade, not one per dirtied cell");
+
+  // A second logical write is its own, separate notification.
+  g.set("root", 3);
+  assert.equal(calls, 2);
+});
+
+test("subscribeAll: a define() redefine that cascades to dependents also fires global listeners exactly once (#234 bug 1)", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  g.define("b", () => g.get<number>("a") * 2);
+  g.define("c", () => g.get<number>("b") + 1);
+  g.get("b");
+  g.get("c");
+
+  let calls = 0;
+  g.subscribeAll(() => calls++);
+
+  g.define("b", () => g.get<number>("a") * 10); // redefine -- recomputes b synchronously, cascades to c
+  assert.equal(calls, 1);
+});
+
+test("subscribeAll: delete() cascading dirty to multiple former dependents still fires global listeners exactly once (#234 bug 1)", () => {
+  const g = new CellGraph();
+  g.set("shared", 1);
+  g.define("readerA", () => g.get<number>("shared") + 1);
+  g.define("readerB", () => g.get<number>("shared") + 2);
+  g.get("readerA");
+  g.get("readerB");
+
+  let calls = 0;
+  g.subscribeAll(() => calls++);
+
+  g.delete("shared"); // dirties both readerA and readerB in one logical write
+  assert.equal(calls, 1);
+});
+
+test("subscribeAll: a reentrant set() on a DIFFERENT cell from inside a global listener is not swallowed -- both changes are eventually delivered (#234 bug 2)", () => {
+  const g = new CellGraph();
+  g.set("x", 1);
+  g.set("y", 1);
+
+  const seen: string[] = [];
+  let reentered = false;
+  g.subscribeAll(() => {
+    seen.push(`fired (x=${g.get("x")}, y=${g.get("y")})`);
+    if (!reentered) {
+      reentered = true;
+      g.set("y", 2); // distinct cell, synchronously, from inside the global listener
+    }
+  });
+
+  g.set("x", 2);
+
+  // Before the fix, the reentrant write to "y" was silently dropped because
+  // the single shared `notifyingGlobal` boolean blocked ANY global
+  // notification while one was already in flight for "x" -- so only 1 call
+  // was ever recorded despite 2 real, distinct cell changes.
+  assert.equal(seen.length, 2, "both the original write and the reentrant write to a different cell notify");
+  assert.equal(g.get("y"), 2, "the reentrant write itself was never lost -- only its notification was");
+});
+
+test("subscribeAll: a reentrant set() on the SAME cell from inside a global listener does not recurse unboundedly (still bounded/sane) (#234 bug 2 edge case)", () => {
+  const g = new CellGraph();
+  g.set("x", 1);
+
+  let calls = 0;
+  g.subscribeAll(() => {
+    calls++;
+    if (g.get<number>("x") < 3) g.set("x", (g.get<number>("x") as number) + 1);
+  });
+
+  g.set("x", 2); // kicks off a same-cell reentrant chain: 2 -> 3, each write its own notification
+  assert.equal(g.get("x"), 3);
+  assert.equal(calls, 2, "one notification per real distinct value the cell actually passed through (2 -> 3)");
+});
+
+test("transaction(): a multi-step set/delete sequence produces exactly ONE subscribeAll notification, not one per step", () => {
+  const g = new CellGraph();
+  g.set("a", 1);
+  g.set("b", 2);
+
+  let notifications = 0;
+  g.subscribeAll(() => notifications++);
+
+  g.transaction(() => {
+    g.set("a", 10);
+    g.set("b", 20);
+    g.delete("a");
+    g.set("c", 30);
+  });
+
+  assert.equal(notifications, 1, "a clear-then-replace-style sequence is one logical write, not four");
+  assert.equal(g.has("a"), false);
+  assert.equal(g.get("b"), 20);
+  assert.equal(g.get("c"), 30);
+});
+
+test("transaction(): nests transparently inside a reentrant listener without producing extra notifications", () => {
+  const g = new CellGraph();
+  g.set("x", 1);
+  let notifications = 0;
+  g.subscribeAll(() => notifications++);
+
+  g.transaction(() => {
+    g.transaction(() => {
+      g.set("x", 2);
+      g.set("y", 3);
+    });
+    g.set("z", 4);
+  });
+
+  assert.equal(notifications, 1, "nested transactions still collapse into one outer logical write");
+  assert.equal(g.get("x"), 2);
+  assert.equal(g.get("y"), 3);
+  assert.equal(g.get("z"), 4);
+});

--- a/packages/math/test/NumberTypes.test.ts
+++ b/packages/math/test/NumberTypes.test.ts
@@ -83,13 +83,41 @@ test("DualNumber gradient", () => {
 
 // --- Interval ---
 
+// Every non-exact Interval op now outward-rounds its result by ~1 ULP per
+// side (see Interval.ts's own `outward` doc comment), so an exact result
+// like [4, 6] comes back as a hair WIDER than [4, 6], not equal to it --
+// checking containment of the mathematically exact bounds is the correct
+// assertion here, not `.equals()`.
+function containsExactly(interval: Interval, lo: number, hi: number): boolean {
+  return interval.lo <= lo && interval.hi >= hi;
+}
+
 test("Interval arithmetic bounds results", () => {
   const a = new Interval(1, 2);
   const b = new Interval(3, 4);
-  assert.ok(a.add(b).equals(new Interval(4, 6)));
-  assert.ok(a.subtract(b).equals(new Interval(-3, -1)));
-  assert.ok(a.multiply(b).equals(new Interval(3, 8)));
-  assert.ok(new Interval(-2, 3).pow(2).equals(new Interval(0, 9)), "even power straddling zero");
+  assert.ok(containsExactly(a.add(b), 4, 6));
+  assert.ok(containsExactly(a.subtract(b), -3, -1));
+  assert.ok(containsExactly(a.multiply(b), 3, 8));
+  assert.ok(containsExactly(new Interval(-2, 3).pow(2), 0, 9), "even power straddling zero");
+});
+
+test("Interval outward rounding: a point input to a transcendental function returns an interval that actually CONTAINS the true irrational result, not a degenerate point excluding it", () => {
+  // Interval.point(2).sqrt() used to return the exact (rounded-to-nearest)
+  // double for sqrt(2) as BOTH endpoints -- a degenerate interval that
+  // provably does not contain the true irrational value.
+  const s = Interval.point(2).sqrt();
+  assert.ok(s.lo < s.hi, "expected outward rounding to produce a non-degenerate interval");
+  // Math.sqrt(2) itself (the nearest double) must lie strictly inside,
+  // with room on both sides for the true value's rounding error.
+  assert.ok(s.lo < Math.sqrt(2) && Math.sqrt(2) < s.hi);
+});
+
+test("Interval outward rounding: exact operations (negate, pow(0), hull, intersect) stay exact, not widened", () => {
+  const a = new Interval(1, 5);
+  assert.ok(a.negate().equals(new Interval(-5, -1)), "negation is exact (sign flip only)");
+  assert.ok(a.pow(0).equals(Interval.point(1)), "n=0 is exactly 1 for any interval");
+  const b = new Interval(3, 8);
+  assert.ok(a.hull(b).equals(new Interval(1, 8)), "hull only compares existing exact endpoints");
 });
 
 test("Interval intersect / hull / contains", () => {

--- a/packages/math/test/Rotor4.test.ts
+++ b/packages/math/test/Rotor4.test.ts
@@ -170,6 +170,90 @@ test("normalize divides every component by the magnitude, and rejects the zero r
   assert.throws(() => new Rotor4(0, Bivector4.Zero, 0).normalize());
 });
 
+test("subtract/negate are component-wise, dot is the 8-component Euclidean inner product", () => {
+  const a = new Rotor4(1, new Bivector4(2, 0, 0, 0, 0, 0), 3);
+  const b = new Rotor4(4, new Bivector4(5, 0, 0, 0, 0, 0), 6);
+  const diff = a.subtract(b);
+  assert.equal(diff.scalar, -3);
+  assert.ok(diff.bivector.equals(new Bivector4(-3, 0, 0, 0, 0, 0)));
+  assert.equal(diff.pseudoscalar, -3);
+  assert.ok(a.negate().equals(new Rotor4(-1, new Bivector4(-2, 0, 0, 0, 0, 0), -3)));
+  assert.equal(a.dot(b), 1 * 4 + 2 * 5 + 3 * 6);
+});
+
+// --- Rotor4.inverse() (#60): distinct from reverse() for a non-unit rotor ---
+
+test("inverse() equals reverse() for a unit rotor (they only diverge once |R| != 1)", () => {
+  const r = Rotor4.fromBivectorAngle(XY, 0.77);
+  assert.ok(r.inverse().equals(r.reverse(), 1e-9));
+});
+
+test("R * R.inverse() == Identity even for a non-unit rotor, unlike R * R.reverse()", () => {
+  // A rotor that's drifted off the unit manifold (e.g. mid floating-point
+  // integration, before renormalization) -- exactly the scenario #60 flags.
+  const drifted = Rotor4.fromBivectorAngle(XY, 0.9).scale(1.4);
+  assert.ok(Math.abs(drifted.magnitude - 1) > 0.1, "sanity check: this rotor is genuinely non-unit");
+
+  assert.ok(drifted.multiply(drifted.inverse()).equals(Rotor4.Identity, 1e-9));
+
+  // reverse() alone does NOT recover the identity here: R * R~ = |R|^2 * Identity.
+  const viaReverse = drifted.multiply(drifted.reverse());
+  assert.ok(Math.abs(viaReverse.scalar - drifted.magnitudeSquared) < 1e-9, "R * R~ scales Identity by |R|^2, not the true inverse");
+  assert.ok(!viaReverse.equals(Rotor4.Identity, 1e-9), "confirms reverse() alone was the wrong operation for a non-unit rotor");
+});
+
+test("inverse() also holds for a compound (double-rotation) rotor", () => {
+  const r1 = Rotor4.fromBivectorAngle(XY, 0.6);
+  const r2 = Rotor4.fromBivectorAngle(ZW, 1.3);
+  const composed = r2.multiply(r1).scale(0.6);
+  assert.ok(composed.multiply(composed.inverse()).equals(Rotor4.Identity, 1e-9));
+});
+
+test("inverse() rejects the zero rotor", () => {
+  assert.throws(() => new Rotor4(0, Bivector4.Zero, 0).inverse());
+});
+
+// --- Rotor4.slerp() (#62): mirrors Quaternion.slerp ---
+
+test("slerp(a, a, t) is a for every t (interpolating a rotor with itself)", () => {
+  const r = Rotor4.fromBivectorAngle(XY, 0.9);
+  for (const t of [0, 0.25, 0.5, 0.75, 1]) {
+    assert.ok(Rotor4.slerp(r, r, t).equals(r, 1e-9));
+  }
+});
+
+test("slerp endpoints: slerp(a, b, 0) == a, slerp(a, b, 1) == b (up to double-cover sign)", () => {
+  const a = Rotor4.Identity;
+  const b = Rotor4.fromBivectorAngle(XY, Math.PI / 2);
+  assert.ok(Rotor4.slerp(a, b, 0).equals(a, 1e-9));
+  const end = Rotor4.slerp(a, b, 1);
+  assert.ok(end.equals(b, 1e-6) || end.equals(b.scale(-1), 1e-6));
+});
+
+test("slerp midpoint of a simple rotation is the half-angle rotation", () => {
+  const a = Rotor4.Identity;
+  const b = Rotor4.fromBivectorAngle(XY, Math.PI / 2);
+  const mid = Rotor4.slerp(a, b, 0.5);
+  const expected = Rotor4.fromBivectorAngle(XY, Math.PI / 4);
+  assert.ok(mid.equals(expected, 1e-9));
+});
+
+test("slerp stays on the unit rotor manifold throughout (magnitude 1 at every t)", () => {
+  const a = Rotor4.fromBivectorAngle(XY, 0.1);
+  const b = Rotor4.fromBivectorAngle(XY, 2.3);
+  for (const t of [0, 0.1, 0.3, 0.5, 0.7, 0.9, 1]) {
+    assert.ok(Math.abs(Rotor4.slerp(a, b, t).magnitude - 1) < 1e-9);
+  }
+});
+
+test("slerp falls back to normalized lerp for near-parallel rotors without dividing by ~zero", () => {
+  const a = Rotor4.fromBivectorAngle(XY, 0.5);
+  const b = Rotor4.fromBivectorAngle(XY, 0.5001);
+  assert.doesNotThrow(() => Rotor4.slerp(a, b, 0.5));
+  const mid = Rotor4.slerp(a, b, 0.5);
+  assert.ok(Math.abs(mid.magnitude - 1) < 1e-9);
+});
+
 test("toString renders scalar, bivector, and pseudoscalar parts", () => {
   const r = new Rotor4(1, Bivector4.Zero, 0);
   assert.match(r.toString(), /^1 \+ \(.*\) \+ 0e1234$/);

--- a/packages/math/test/Rotor4.test.ts
+++ b/packages/math/test/Rotor4.test.ts
@@ -198,8 +198,14 @@ test("R * R.inverse() == Identity even for a non-unit rotor, unlike R * R.revers
 
   // reverse() alone does NOT recover the identity here: R * R~ = |R|^2 * Identity.
   const viaReverse = drifted.multiply(drifted.reverse());
-  assert.ok(Math.abs(viaReverse.scalar - drifted.magnitudeSquared) < 1e-9, "R * R~ scales Identity by |R|^2, not the true inverse");
-  assert.ok(!viaReverse.equals(Rotor4.Identity, 1e-9), "confirms reverse() alone was the wrong operation for a non-unit rotor");
+  assert.ok(
+    Math.abs(viaReverse.scalar - drifted.magnitudeSquared) < 1e-9,
+    "R * R~ scales Identity by |R|^2, not the true inverse",
+  );
+  assert.ok(
+    !viaReverse.equals(Rotor4.Identity, 1e-9),
+    "confirms reverse() alone was the wrong operation for a non-unit rotor",
+  );
 });
 
 test("inverse() also holds for a compound (double-rotation) rotor", () => {


### PR DESCRIPTION
## Summary
First step of #56: mallory-grapher now vendors a frozen copy of mallory-graph's `CellGraph`, which is this monorepo's own "two consumers" trigger for extracting a shared package.

Moved verbatim from mallory-graph's `src/lib/cell-graph.ts` (the more current of the two existing copies — it has `transaction()`, which mallory-grapher's frozen copy predates and doesn't test) into `packages/math/src/CellGraph.ts`, exported alongside `CircularDependencyError`/`CellRole`/`structuralEqual`. Test suite is mallory-grapher's own `test/cell-graph.test.ts` (55 tests, already scoped to the pure API, no app coupling) plus 2 new tests specifically for `transaction()`.

Two mechanical lint fixes applied during the move (`useOptionalChain`, `noAssignInExpressions`) — this monorepo's biome config flags them, mallory-graph's doesn't. No behavior change.

**Deliberately NOT done here** (steps 2/3, tracked to follow once this merges and a version is published):
- Bump `mallory-math`'s version and cut a release — needs `NPM_TOKEN` publish credentials this sandbox doesn't have.
- mallory-graph migrates its `cell-graph.ts` import to the published package and deletes its own copy.
- mallory-grapher does the same with its vendored copy.

## Test plan
- [x] `npm test` (math package: 724/731, 7 pre-existing skips, 0 failures — includes all 57 CellGraph tests)
- [x] `npm run typecheck`
- [x] `npm run check` (biome, clean)
- [x] `npm run build` / `npm run test:build` (dist smoke test passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)