### PR TITLE
Rename to the @johnhenry npm scope; reset versions to 0.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main, master]
   pull_request:
 
+# Supersede an in-flight run when new commits land on the same ref -- the
+# whole family shares this block so a rapid push sequence never queues N
+# redundant runs.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  # JSR dual-publish (issue #13) — same pattern as mallory-plus's release.yml
+  # JSR dual-publish (issue #13) — same pattern as math-plus's release.yml
   # jsr-release job: OIDC Trusted Publishing (no secret; each package on
   # jsr.io links this repo as its publisher — one-time manual setup, done
   # 2026-08-13), continue-on-error per package so an already-published
@@ -72,7 +72,7 @@ jobs:
 
       # jsr.json is committed with the current version, but the publish-time
       # source of truth is package.json — sync here so the two can never
-      # drift (the same no-hand-edited-versions rule as mallory-plus's
+      # drift (the same no-hand-edited-versions rule as math-plus's
       # sync-jsr-configs.mjs).
       - name: Sync jsr.json versions from package.json
         run: |

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The constraints are deliberate and load-bearing:
   stripping, property-based tests via `fast-check`, formatting and linting via Biome.
 
 The engineering counterpart — fixed-width tensors, Rust→WASM kernels, WebGPU, Arrow — lives
-separately in [mallory-plus](https://github.com/johnhenry/mallory-plus), which depends on this
-family rather than absorbing it. The two make opposite trade-offs on purpose: `mallory-math`'s
+separately in [math-plus](https://github.com/johnhenry/math-plus), which depends on this
+family rather than absorbing it. The two make opposite trade-offs on purpose: `@johnhenry/math`'s
 boxed, generic elements are precisely what a SIMD-friendly tensor runtime forbids, and vice versa.
 Neither is a subset of the other.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ required beyond Node and npm to contribute.
 
 | Package | npm | What it is |
 |---|---|---|
-| [`packages/math`](./packages/math) | [`mallory-math`](https://www.npmjs.com/package/mallory-math) | Advanced college-level mathematics for TypeScript: complex/rational/decimal/interval/quaternion/dual numbers, linear algebra over arbitrary algebraic structures, a symbolic CAS, combinatorics, number theory, statistics, and renderer-agnostic plotting geometry |
-| [`packages/iteration`](./packages/iteration) | `mallory-iteration` | Sync + async iterator algebra: transducers, Python-`itertools` parity, terminal consumers, bounded concurrency, cancellation, and backpressure-aware channels |
+| [`packages/math`](./packages/math) | [`@johnhenry/math`](https://www.npmjs.com/package/@johnhenry/math) | Advanced college-level mathematics for TypeScript: complex/rational/decimal/interval/quaternion/dual numbers, linear algebra over arbitrary algebraic structures, a symbolic CAS, combinatorics, number theory, statistics, and renderer-agnostic plotting geometry |
+| [`packages/iteration`](./packages/iteration) | `@johnhenry/iteration` | Sync + async iterator algebra: transducers, Python-`itertools` parity, terminal consumers, bounded concurrency, cancellation, and backpressure-aware channels |
+| [`packages/math-prototype-patch`](./packages/math-prototype-patch) | `@johnhenry/math-prototype-patch` | OPT-IN, collision-checked `Number.prototype` patch adding `@johnhenry/math`'s `ComplexNumber` fluent arithmetic to plain numbers |
 
 ## Philosophy
 
@@ -38,7 +39,7 @@ npm run build        # tsc across all packages
 npm run check        # Biome lint + format check
 ```
 
-Per-package: `npm test -w mallory-math`, `npm run build -w mallory-iteration`, etc.
+Per-package: `npm test -w @johnhenry/math`, `npm run build -w @johnhenry/iteration`, etc.
 
 ## Releasing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "mallory",
+  "name": "math",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mallory",
+      "name": "math",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -205,6 +205,18 @@
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
+    "node_modules/@johnhenry/iteration": {
+      "resolved": "packages/iteration",
+      "link": true
+    },
+    "node_modules/@johnhenry/math": {
+      "resolved": "packages/math",
+      "link": true
+    },
+    "node_modules/@johnhenry/math-prototype-patch": {
+      "resolved": "packages/math-prototype-patch",
+      "link": true
+    },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
@@ -374,18 +386,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/mallory-iteration": {
-      "resolved": "packages/iteration",
-      "link": true
-    },
-    "node_modules/mallory-math": {
-      "resolved": "packages/math",
-      "link": true
-    },
-    "node_modules/mallory-math-prototype-patch": {
-      "resolved": "packages/math-prototype-patch",
-      "link": true
-    },
     "node_modules/markdown-it": {
       "version": "14.3.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
@@ -533,7 +533,7 @@
       }
     },
     "packages/iteration": {
-      "name": "mallory-iteration",
+      "name": "@johnhenry/iteration",
       "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
@@ -546,7 +546,7 @@
       }
     },
     "packages/math": {
-      "name": "mallory-math",
+      "name": "@johnhenry/math",
       "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
@@ -560,11 +560,11 @@
       }
     },
     "packages/math-prototype-patch": {
-      "name": "mallory-math-prototype-patch",
+      "name": "@johnhenry/math-prototype-patch",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "mallory-math": "^0.11.0"
+        "@johnhenry/math": "^0.15.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -572,15 +572,6 @@
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "packages/math-prototype-patch/node_modules/mallory-math": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/mallory-math/-/mallory-math-0.11.0.tgz",
-      "integrity": "sha512-u8kp9N8j/L4rjZDXYGiv6sN5f9HWXUASEIjaNTg52ycyb4fwHilx9E8RA1Y7No2nQodkUMBxwyvrYbutz9cCkg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.6.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -534,7 +534,7 @@
     },
     "packages/iteration": {
       "name": "@johnhenry/iteration",
-      "version": "2.0.0",
+      "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -547,7 +547,7 @@
     },
     "packages/math": {
       "name": "@johnhenry/math",
-      "version": "0.15.0",
+      "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.5.1",
@@ -561,10 +561,10 @@
     },
     "packages/math-prototype-patch": {
       "name": "@johnhenry/math-prototype-patch",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@johnhenry/math": "^0.15.0"
+        "@johnhenry/math": "^0.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "mallory",
+  "name": "math",
   "private": true,
   "type": "module",
-  "description": "The Mallory family of pure-TypeScript libraries — zero runtime dependencies, tsc-only builds, no toolchain beyond npm",
+  "description": "The math family of pure-TypeScript libraries — zero runtime dependencies, tsc-only builds, no toolchain beyond npm",
   "workspaces": [
     "packages/*"
   ],
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/johnhenry/mallory.git"
+    "url": "git+https://github.com/johnhenry/math.git"
   },
   "license": "MIT"
 }

--- a/packages/iteration/docs/discussion/python-itertools.md
+++ b/packages/iteration/docs/discussion/python-itertools.md
@@ -156,13 +156,13 @@ over time.
   (`takeWhileSync`/`takeWhileAsync`) rather than Python's single name — pick
   the one matching your iterable's kind (or check with `isIterator`/
   `isAsyncIterator`/`exhaustable` from the core exports).
-- **Argument order**: the `mallory-iteration/itertools` and
-  `mallory-iteration/combinatorics` functions take the predicate/function
+- **Argument order**: the `@johnhenry/iteration/itertools` and
+  `@johnhenry/iteration/combinatorics` functions take the predicate/function
   first and the iterable(s) last, matching Python's `itertools` argument
   order (e.g. `takeWhileSync(predicate, iterable)`, `starmapSync(fn,
   iterableOfArgArrays)`), so a Python recipe should translate close to
   mechanically.
-- **Currying**: the *transducer* functions in `mallory-iteration/transducers`
+- **Currying**: the *transducer* functions in `@johnhenry/iteration/transducers`
   (`map`, `filter`, `take`, `drop`, `reject`, `group`, `accumulate`) are
   curried factories meant for composition inside `transduceSync`/
   `transduceAsync` — a different shape from the flat itertools-parity

--- a/packages/iteration/docs/installation-usage.md
+++ b/packages/iteration/docs/installation-usage.md
@@ -12,7 +12,7 @@
 ## Installation
 
 ```bash
-npm install mallory-iteration
+npm install @johnhenry/iteration
 ```
 
 ## Usage
@@ -25,7 +25,7 @@ The traditional way to load javascript in browsers.
 
 ```html
 <html>
-  <script src="./node_modules/mallory-iteration/dist/malloryIteration.mjs"></script>
+  <script src="./node_modules/@johnhenry/iteration/dist/malloryIteration.mjs"></script>
   <script>
     // do stuff with malloryIteration
   </script>
@@ -37,7 +37,7 @@ The traditional way to load javascript in browsers.
 The traditional way to load javascript in node.
 
 ```javascript
-const malloryIteration = require("./node_modules/mallory-iteration/dist/cjs/index.cjs");
+const malloryIteration = require("./node_modules/@johnhenry/iteration/dist/cjs/index.cjs");
 // do stuff with malloryIteration
 ```
 
@@ -48,14 +48,14 @@ The modern way to load javascript in browsers and node.
 ```html
 <html>
   <script type="module">
-    import * as malloryIteration from "./node_modules/mallory-iteration/dist/index.mjs";
+    import * as malloryIteration from "./node_modules/@johnhenry/iteration/dist/index.mjs";
     // do stuff with malloryIteration
   </script>
 </html>
 ```
 
 ```javascript
-// import * as malloryIteration from './node_modules/mallory-iteration/dist/index.mjs';
-import * as malloryIteration from "mallory-iteration";
+// import * as malloryIteration from './node_modules/@johnhenry/iteration/dist/index.mjs';
+import * as malloryIteration from "@johnhenry/iteration";
 // do stuff with malloryIteration
 ```

--- a/packages/iteration/docs/readme.html
+++ b/packages/iteration/docs/readme.html
@@ -26,7 +26,7 @@
       >Send output to multiple destinations with tee</a
     >
   </li>
-  <li>How To Guides - Learn how to use mallory-iteration in depth.</li>
+  <li>How To Guides - Learn how to use @johnhenry/iteration in depth.</li>
   <li>
     <a href="./how-to/guessing-game.md"
       >Create a guessing game with AsyncChannel</a

--- a/packages/iteration/docs/readme.md
+++ b/packages/iteration/docs/readme.md
@@ -11,7 +11,7 @@ The module standardizes a core set of fast, memory efficient tools that are usef
   - [Pause output](./tutorial/pause.md)
   - [User input](./tutorial/input.md)
   - [Send output to multiple destinations with tee](./tutorial/tee.md)
-- How To Guides - Learn how to use mallory-iteration in depth.
+- How To Guides - Learn how to use @johnhenry/iteration in depth.
   - [Create a guessing game with AsyncChannel](./how-to/guessing-game.md)
   - [Creating your own transducers](./how-to/creating-your-own-transducers.md)
 - Discussions

--- a/packages/iteration/jsr.json
+++ b/packages/iteration/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnhenry/iteration",
-  "version": "2.0.0",
+  "version": "0.0.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",
@@ -21,6 +21,12 @@
     "./is-iterator": "./src/is-iterator.ts"
   },
   "publish": {
-    "exclude": ["test", "docs", "scripts", "api", "**/*.test.ts"]
+    "exclude": [
+      "test",
+      "docs",
+      "scripts",
+      "api",
+      "**/*.test.ts"
+    ]
   }
 }

--- a/packages/iteration/jsr.json
+++ b/packages/iteration/jsr.json
@@ -21,12 +21,6 @@
     "./is-iterator": "./src/is-iterator.ts"
   },
   "publish": {
-    "exclude": [
-      "test",
-      "docs",
-      "scripts",
-      "api",
-      "**/*.test.ts"
-    ]
+    "exclude": ["test", "docs", "scripts", "api", "**/*.test.ts"]
   }
 }

--- a/packages/iteration/jsr.json
+++ b/packages/iteration/jsr.json
@@ -1,5 +1,5 @@
 {
-  "name": "@johnhenry/mallory-iteration",
+  "name": "@johnhenry/iteration",
   "version": "2.0.0",
   "license": "MIT",
   "exports": {

--- a/packages/iteration/package.json
+++ b/packages/iteration/package.json
@@ -80,8 +80,8 @@
     "url": "git+https://github.com/johnhenry/math.git",
     "directory": "packages/iteration"
   },
-  "version": "2.0.0",
-  "description": "Sync + async iterator algebra for TypeScript \u2014 transducers, Python-itertools parity, terminal consumers, bounded concurrency, cancellation, and backpressure-aware channels. Zero runtime dependencies.",
+  "version": "0.0.0",
+  "description": "Sync + async iterator algebra for TypeScript — transducers, Python-itertools parity, terminal consumers, bounded concurrency, cancellation, and backpressure-aware channels. Zero runtime dependencies.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/iteration/package.json
+++ b/packages/iteration/package.json
@@ -1,6 +1,10 @@
 {
-  "name": "mallory-iteration",
+  "name": "@johnhenry/iteration",
   "type": "module",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "engines": {
     "node": ">=22.12.0",
     "npm": ">=8.19.2"
@@ -73,7 +77,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/johnhenry/mallory.git",
+    "url": "git+https://github.com/johnhenry/math.git",
     "directory": "packages/iteration"
   },
   "version": "2.0.0",

--- a/packages/iteration/readme.md
+++ b/packages/iteration/readme.md
@@ -1,4 +1,4 @@
-# mallory-iteration
+# @johnhenry/iteration
 
 This module implements a number of asynchronous iterator building blocks inspired by constructs from [Python](https://docs.python.org/3/library/itertools.html), APL, Haskell, and SML. Each has been recast in a form suitable for JavaScript.
 
@@ -12,11 +12,12 @@ Since this library's original release, JavaScript gained native **Iterator Helpe
 
 Requires **Node.js 22.12+** (or an equivalent Iterator-Helpers-capable engine).
 
-> **Provenance.** This library was previously published as `async-itertools`; the 1.x releases
-> and the "2.0" milestones referenced below (transducer rewrite, cancellation, bounded
-> concurrency, backpressure) describe that history under the old name. It now ships as
-> `mallory-iteration`, part of the [Mallory](https://github.com/johnhenry/mallory) family,
-> continuing that lineage at version 2.0.0.
+> **Provenance.** This library has been renamed twice. It started life as `async-itertools`; the
+> 1.x releases and the "2.0" milestones referenced below (transducer rewrite, cancellation, bounded
+> concurrency, backpressure) describe that history under the old name. It was then published as
+> `mallory-iteration`, part of the [Mallory](https://github.com/johnhenry/mallory) family. It now
+> ships as `@johnhenry/iteration`, part of the `johnhenry/math` monorepo, continuing that lineage
+> at version 2.0.0.
 
 ## What's new in 2.0
 
@@ -74,7 +75,7 @@ which is why that's this package's floor) lets `require()` load an ES module
 synchronously:
 
 ```javascript
-const { countSync, someAsync } = require("mallory-iteration");
+const { countSync, someAsync } = require("@johnhenry/iteration");
 ```
 
 No separate CJS build or `"require"` condition in `package.json`'s `exports` is needed or provided — `require(esm)` resolves through the same ESM files everything else uses. This is verified in CI (`scripts/require-esm-smoke-test.cjs`), not just documented.
@@ -82,7 +83,7 @@ No separate CJS build or `"require"` condition in `package.json`'s `exports` is 
 ## Installation
 
 ```bash
-npm install mallory-iteration
+npm install @johnhenry/iteration
 ```
 
 ## Production
@@ -94,7 +95,7 @@ Generally, you'll use this library to transform existing iterators; but we provi
 Create empty iterators
 
 ```javascript
-import { emptySync, emptyAsync } from "mallory-iteration";
+import { emptySync, emptyAsync } from "@johnhenry/iteration";
 for (const a of emptySync()) {
   // dream the impossible
 }
@@ -113,7 +114,7 @@ import {
   countBigSync,
   countAsync,
   countBigAsync,
-} from "mallory-iteration";
+} from "@johnhenry/iteration";
 for (const a of countSync(0, 9)) {
   console.log(a);
 } // logs 1, 2, 3, 4, 5, 6, 7, 8, 9
@@ -133,7 +134,7 @@ for await (const a of countBigAsync(9n, 0n)) {
 Create iterators from given items
 
 ```javascript
-import { syncFrom, asyncFrom } from "mallory-iteration";
+import { syncFrom, asyncFrom } from "@johnhenry/iteration";
 for (const a of syncFrom(1, 2, 3)) {
   console.log(a);
 } // logs 1, 2, 3
@@ -149,7 +150,7 @@ the next value from every input in parallel each round, and accepts a mix of
 sync and async iterables.
 
 ```javascript
-import { zipSync, zipAsync } from "mallory-iteration";
+import { zipSync, zipAsync } from "@johnhenry/iteration";
 for (const pair of zipSync([1, 2, 3], ["a", "b", "c"])) {
   console.log(pair);
 } // logs [1,'a'], [2,'b'], [3,'c']
@@ -170,16 +171,16 @@ to apply transducers to synchronous
 and asynchronous iterators.
 
 ```javascript
-import { transduceSync } from "mallory-iteration";
-// import { transduceSync } from "mallory-iteration/transduce";
+import { transduceSync } from "@johnhenry/iteration";
+// import { transduceSync } from "@johnhenry/iteration/transduce";
 for (const item of transduceSync(/*list of transducers*/)(/*some iterator*/)) {
   // do something with transduced item
 }
 ```
 
 ```javascript
-import { transduceAsync } from "mallory-iteration";
-// import { transduceAsync } from "mallory-iteration/transduce";
+import { transduceAsync } from "@johnhenry/iteration";
+// import { transduceAsync } from "@johnhenry/iteration/transduce";
 for await (const item of transduceAsync(/*list of transducers*/)(/*some asynchronous iterator*/)) {
   // do something with transduced item
 }
@@ -195,9 +196,9 @@ Similiar to [Array.prototype.map](),
 maps items with a given transformation function.
 
 ```javascript
-// import { transducers } from "mallory-iteration";
+// import { transducers } from "@johnhenry/iteration";
 // const { map } = transducers;
-import { map } from "mallory-iteration/transducers";
+import { map } from "@johnhenry/iteration/transducers";
 const addOne = map((x) => x + 1);
 const abs = map(Math.abs);
 for (const x of transduceSync(addOne, abs)([-3, -2, -1, 0, 1, 2, 3])) {
@@ -212,7 +213,7 @@ Similiar to [Array.prototype.filter](),
 filters items that do not match a given predicate
 
 ```javascript
-import { filter } from "mallory-iteration/transducers";
+import { filter } from "@johnhenry/iteration/transducers";
 const removeStrings = map((x) => typeof x !== "string");
 const keepPositive = map((x) => x > 0);
 for (const x of transduceSync(
@@ -230,7 +231,7 @@ Apply function successively to items in iterator.
 Similar to `Array.prototype.reduce`.
 
 ```javascript
-import { accumulate } from "mallory-iteration/transducers";
+import { accumulate } from "@johnhenry/iteration/transducers";
 const sum = accumulate((a, b) => a + b, 0);
 for (const x of transduceSync(sum)([1, 2, 3, 4])) {
   console.log(x);
@@ -245,7 +246,7 @@ once the source is exhausted (via the transducer completion protocol — see
 `transduceSync`/`transduceAsync`).
 
 ```javascript
-import { group } from "mallory-iteration/transducers";
+import { group } from "@johnhenry/iteration/transducers";
 const triplet = group(3);
 for (const x of transduceSync(triplet)([1, 2, 3, 4, 5, 6, 7])) {
   console.log(x);
@@ -258,7 +259,7 @@ for (const x of transduceSync(triplet)([1, 2, 3, 4, 5, 6, 7])) {
 Take only the first N items and drop the rest (see 'drop').
 
 ```javascript
-import { take } from "mallory-iteration/transducers";
+import { take } from "@johnhenry/iteration/transducers";
 const take5 = take(5);
 for (const x of transduceSync(take5)([1, 2, 3, 4, 5, 6, 7, 8, 9])) {
   console.log(x);
@@ -273,7 +274,7 @@ Drop the first N items and take the rest (see 'take'). Previously named
 of `filter`, below.
 
 ```javascript
-import { drop } from "mallory-iteration/transducers";
+import { drop } from "@johnhenry/iteration/transducers";
 const dropDozen = drop(12);
 for (const x of transduceSync(dropDozen)([
   1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
@@ -289,7 +290,7 @@ Reject items matching a predicate and keep the rest — the complement of
 `filter` (see 'filter'). Mirrors Python's `itertools.filterfalse`.
 
 ```javascript
-import { reject } from "mallory-iteration/transducers";
+import { reject } from "@johnhenry/iteration/transducers";
 const rejectEven = reject((x) => x % 2 === 0);
 for (const x of transduceSync(rejectEven)([1, 2, 3, 4, 5])) {
   console.log(x);
@@ -305,7 +306,7 @@ adjacent-only counterpart to `uniqueSync`/`uniqueAsync` (which dedupe
 globally, across the whole stream, not just neighboring items).
 
 ```javascript
-import { dedupe } from "mallory-iteration/transducers";
+import { dedupe } from "@johnhenry/iteration/transducers";
 for (const x of transduceSync(dedupe())([1, 1, 2, 2, 1, 1, 3])) {
   console.log(x);
 }
@@ -318,7 +319,7 @@ Insert a separator between consecutive emitted items — not before the
 first item, and not after the last.
 
 ```javascript
-import { interpose } from "mallory-iteration/transducers";
+import { interpose } from "@johnhenry/iteration/transducers";
 for (const x of transduceSync(interpose(","))([1, 2, 3])) {
   console.log(x);
 }
@@ -334,7 +335,7 @@ a fixed size rather than by a shared key. Like `group`, a trailing partial
 run is flushed once the source completes.
 
 ```javascript
-import { partitionBy } from "mallory-iteration/transducers";
+import { partitionBy } from "@johnhenry/iteration/transducers";
 for (const x of transduceSync(partitionBy())([1, 1, 2, 1, 1])) {
   console.log(x);
 }
@@ -348,7 +349,7 @@ RxJS-style, for debugging or instrumenting a pipeline without altering its
 values.
 
 ```javascript
-import { tap } from "mallory-iteration/transducers";
+import { tap } from "@johnhenry/iteration/transducers";
 const logged = tap((x) => console.log("saw:", x));
 for (const x of transduceSync(logged)([1, 2, 3])) {
   // "saw: 1", "saw: 2", "saw: 3" logged as a side effect;
@@ -359,7 +360,7 @@ for (const x of transduceSync(logged)([1, 2, 3])) {
 Multiple different types of transducers can be applied.
 
 ```javascript
-import { map, filter, take } from "mallory-iteration/transducers";
+import { map, filter, take } from "@johnhenry/iteration/transducers";
 const transformation = transduceSync(
   map((x) => x + 2),
   filter((x) => x % 2),
@@ -380,7 +381,7 @@ this is how `take` works. Renamed from the misspelled `HAULT` in 2.0;
 `HAULT` is still exported as a deprecated alias of the same symbol.
 
 ```javascript
-import { HALT } from "mallory-iteration";
+import { HALT } from "@johnhenry/iteration";
 ```
 
 ### The step protocol (writing custom transducers)
@@ -413,7 +414,7 @@ that `.complete` must cascade to the inner step's own `.complete`) — see
 > itself, or called `reduceSync`/`reduceAsync` with an iterable `init`,
 > needs updating to the array-buffer protocol.
 
-## Python itertools parity (`mallory-iteration/itertools`)
+## Python itertools parity (`@johnhenry/iteration/itertools`)
 
 Flat, non-curried building blocks mirroring functions from Python's
 [`itertools`](https://docs.python.org/3/library/itertools.html) module —
@@ -441,8 +442,8 @@ import {
   zipLongestSync,
   isliceSync,
   // ...and their `*Async` duals: takeWhileAsync, dropWhileAsync, etc.
-} from "mallory-iteration";
-// or: import { ... } from "mallory-iteration/itertools";
+} from "@johnhenry/iteration";
+// or: import { ... } from "@johnhenry/iteration/itertools";
 
 takeWhileSync((x) => x < 3, [1, 2, 3, 4, 1]); // yields 1, 2
 dropWhileSync((x) => x < 3, [1, 2, 3, 4, 1]); // yields 3, 4, 1
@@ -461,16 +462,16 @@ compressSync(["a", "b", "c", "d"], [1, 0, 1, 0]); // yields 'a', 'c'
 [...isliceSync([1, 2, 3, 4, 5, 6, 7, 8], 1, 8, 2)]; // [2,4,6,8]
 ```
 
-## Combinatorics — moved to `mallory-math`
+## Combinatorics — moved to `@johnhenry/math`
 
 `product`, `permutations`, `combinations`, and `combinationsWithReplacement`
-now live in [`mallory-math`](../math)'s `Combinatorics`, alongside the counting
+now live in [`@johnhenry/math`](../math)'s `Combinatorics`, alongside the counting
 functions they pair with (`binomial`, `permutationsCount`, …). Enumeration is
 mathematics rather than stream plumbing, and having both faces in one place
 lets the library assert that they agree.
 
 ```javascript
-import { Combinatorics } from "mallory-math";
+import { Combinatorics } from "@johnhenry/math";
 
 [...Combinatorics.combinations([1, 2, 3], 2)]; // [[1,2],[1,3],[2,3]]
 Combinatorics.binomial(3, 2); // 3n — the count of exactly the above
@@ -481,7 +482,7 @@ The `Async` duals were dropped rather than moved: they only wrapped
 are inherently collect-then-compute, in Python too), so `exhaustAsync` from
 this package plus the sync generator gives the identical result.
 
-## Terminal consumers (`mallory-iteration/consumers`)
+## Terminal consumers (`@johnhenry/iteration/consumers`)
 
 Resolve an iterable to a single value (or a `Promise` of one), rather than
 another iterable. Two families:
@@ -514,8 +515,8 @@ import {
   someSync, everySync, findSync, forEachSync, foldSync,
   firstSync, lastSync, nthSync, quantifySync, minSync, maxSync,
   // ...and their `*Async` duals
-} from "mallory-iteration";
-// or: import { ... } from "mallory-iteration/consumers";
+} from "@johnhenry/iteration";
+// or: import { ... } from "@johnhenry/iteration/consumers";
 
 someSync((x) => x > 2, [1, 2, 3]); // true
 everySync((x) => x > 0, [1, 2, 3]); // true
@@ -544,7 +545,7 @@ accepts one as a second argument. On abort, the source iterator is closed
 the signal's reason — an `"AbortError"` `DOMException` by default:
 
 ```javascript
-import { lastAsync, transduceAsync, transducers } from "mallory-iteration";
+import { lastAsync, transduceAsync, transducers } from "@johnhenry/iteration";
 
 const controller = new AbortController();
 setTimeout(() => controller.abort(), 1000);
@@ -563,10 +564,10 @@ for await (const item of pipeline(source, { signal: controller.signal })) {
 ```
 
 The underlying `abortable(iterable, signal)` async-generator wrapper is
-exported too (also at `mallory-iteration/abort`) if you want the same prompt,
+exported too (also at `@johnhenry/iteration/abort`) if you want the same prompt,
 `return()`-propagating cancellation around any `for await` loop.
 
-## Bounded concurrency (`mallory-iteration/concurrency`, new in 2.0)
+## Bounded concurrency (`@johnhenry/iteration/concurrency`, new in 2.0)
 
 ### `mapConcurrentAsync`
 
@@ -579,8 +580,8 @@ promptly even mid-`fn`, and early consumer exit / `fn` errors / abort all
 close the source via `iterator.return()`.
 
 ```javascript
-import { mapConcurrentAsync } from "mallory-iteration";
-// or: import { mapConcurrentAsync } from "mallory-iteration/concurrency";
+import { mapConcurrentAsync } from "@johnhenry/iteration";
+// or: import { mapConcurrentAsync } from "@johnhenry/iteration/concurrency";
 
 for await (const page of mapConcurrentAsync(
   (url) => fetch(url).then((r) => r.text()),
@@ -599,7 +600,7 @@ slow consumer. `n <= 0` degenerates to plain iteration; early consumer exit
 closes the source via `iterator.return()`.
 
 ```javascript
-import { prefetchAsync } from "mallory-iteration";
+import { prefetchAsync } from "@johnhenry/iteration";
 
 for await (const record of prefetchAsync(8, slowDatabaseCursor())) {
   await expensiveProcessing(record); // next 8 reads already in flight
@@ -615,7 +616,7 @@ This library provides a number of iterator related utilities.
 Test of object is an iterator or asyncIterator, or either.
 
 ```javascript
-import { isIterator, isAsyncIterator, exhaustable } from "mallory-iteration";
+import { isIterator, isAsyncIterator, exhaustable } from "@johnhenry/iteration";
 const iterator = (function* () {})();
 const asyncIterator = (async function* () {})();
 const block = {};
@@ -633,12 +634,12 @@ console.log(exhaustable(block)); // false
 ### `exhaust` & `exhaustSync` & `exhaustAsync`
 
 Exhaust all items from iterator — this library's "collect to an array"
-(`toArray`) operation; see [Terminal consumers](#terminal-consumers-mallory-iterationconsumers)
+(`toArray`) operation; see [Terminal consumers](#terminal-consumers-johnhenryiterationconsumers)
 for other ways to resolve an iterable to a single value.
 Warning: Initial object may have items removed
 
 ```javascript
-import { exhaust, exhaustSync, exhaustAsync } from "mallory-iteration";
+import { exhaust, exhaustSync, exhaustAsync } from "@johnhenry/iteration";
 const iterator = [1, 2, 3];
 const aIterator = (async function* () {
   yield 4;
@@ -657,7 +658,7 @@ Tee iterator onto n other iterators
 Warning: Initial object may be emptied
 
 ```javascript
-import { teeSync, teeAsync } from "mallory-iteration";
+import { teeSync, teeAsync } from "@johnhenry/iteration";
 const iterator = (async function* () {
   yield 1;
   yield 2;
@@ -698,7 +699,7 @@ await bounded.put(item); // suspends the producer while the channel is full
 
 ```javascript
 // file://declare.mjs
-import { AsyncChannel } from "mallory-iteration";
+import { AsyncChannel } from "@johnhenry/iteration";
 export const c = new AsyncChannel();
 setTimeout(async () => {
   for await (const i of c) {
@@ -721,7 +722,7 @@ Automatically place items onto channels via decorators
 ```javascript
 // file://use-websocket.mjs
 import { c } from "./declare.mjs";
-import { withWebSocket } from "mallory-iteration/channel-decorators";
+import { withWebSocket } from "@johnhenry/iteration/channel-decorators";
 const socket = new WebSocket(/*ws url*/);
 withWebSocket(c, socket);
 ```
@@ -729,7 +730,7 @@ withWebSocket(c, socket);
 ```javascript
 // file://use-event-emitter.mjs
 import { c } from "./declare.mjs";
-import { withEmitter } from "mallory-iteration/channel-decorators";
+import { withEmitter } from "@johnhenry/iteration/channel-decorators";
 const source = new EventSource(/*sse url*/);
 withEmitter(c, source);
 ```
@@ -737,7 +738,7 @@ withEmitter(c, source);
 ## Releasing
 
 Publishing is release-gated in GitHub Actions, matching the deployment setup in
-[`johnhenry/mallory`](https://github.com/johnhenry/mallory):
+[`johnhenry/math`](https://github.com/johnhenry/math):
 
 1. Bump `version` in `package.json` (and run `npm install --package-lock-only`
    so the lockfile matches — `npm ci` fails if they diverge).
@@ -754,5 +755,5 @@ Requires the **`NPM_TOKEN`** repository secret — a granular automation token
 with write access to this package:
 
 ```bash
-gh secret set NPM_TOKEN --repo johnhenry/mallory-iteration
+gh secret set NPM_TOKEN --repo johnhenry/math
 ```

--- a/packages/iteration/readme.md
+++ b/packages/iteration/readme.md
@@ -15,7 +15,7 @@ Requires **Node.js 22.12+** (or an equivalent Iterator-Helpers-capable engine).
 > **Provenance.** This library has been renamed twice. It started life as `async-itertools`; the
 > 1.x releases and the "2.0" milestones referenced below (transducer rewrite, cancellation, bounded
 > concurrency, backpressure) describe that history under the old name. It was then published as
-> `mallory-iteration`, part of the [Mallory](https://github.com/johnhenry/mallory) family. It now
+> `@johnhenry/iteration`, part of the [Mallory](https://github.com/johnhenry/mallory) family. It now
 > ships as `@johnhenry/iteration`, part of the `johnhenry/math` monorepo, continuing that lineage
 > at version 2.0.0.
 

--- a/packages/iteration/readme.md
+++ b/packages/iteration/readme.md
@@ -12,12 +12,14 @@ Since this library's original release, JavaScript gained native **Iterator Helpe
 
 Requires **Node.js 22.12+** (or an equivalent Iterator-Helpers-capable engine).
 
-> **Provenance.** This library has been renamed twice. It started life as `async-itertools`; the
-> 1.x releases and the "2.0" milestones referenced below (transducer rewrite, cancellation, bounded
-> concurrency, backpressure) describe that history under the old name. It was then published as
-> `@johnhenry/iteration`, part of the [Mallory](https://github.com/johnhenry/mallory) family. It now
-> ships as `@johnhenry/iteration`, part of the `johnhenry/math` monorepo, continuing that lineage
-> at version 2.0.0.
+> **Provenance.** This library has been renamed twice, so its published history spans three names.
+> It started life as [`async-itertools`](https://github.com/johnhenry/async-itertools) (now
+> archived) — the 1.x releases and the "2.0" milestones described below (transducer rewrite,
+> cancellation, bounded concurrency, backpressure) all happened under that name. It was then
+> absorbed into a pure-TypeScript monorepo as `mallory-iteration`, with full git history preserved
+> via `git subtree`. It now ships as **`@johnhenry/iteration`** from the
+> [`johnhenry/math`](https://github.com/johnhenry/math) monorepo, restarted at `0.0.0` under the
+> new scoped name — the version number is fresh, the code and its lineage are not.
 
 ## What's new in 2.0
 

--- a/packages/iteration/scripts/dist-smoke-test.mjs
+++ b/packages/iteration/scripts/dist-smoke-test.mjs
@@ -34,8 +34,8 @@ for await (const item of channel) seen.push(item);
 assert.deepStrictEqual(seen, [1, 2], "dist AsyncChannel round-trip");
 
 // subpath modules resolve out of dist via the exports map
-// (combinatorics moved to mallory-math's Combinatorics — see readme)
-const { windowedSync } = await import("mallory-iteration/itertools");
+// (combinatorics moved to @johnhenry/math's Combinatorics — see readme)
+const { windowedSync } = await import("@johnhenry/iteration/itertools");
 assert.deepStrictEqual(
   [...windowedSync([1, 2, 3, 4], 2)],
   [
@@ -45,7 +45,7 @@ assert.deepStrictEqual(
   ],
   "dist subpath export resolves",
 );
-const assertion = await import("mallory-iteration/pop-quiz/asserteventualequal");
+const assertion = await import("@johnhenry/iteration/pop-quiz/asserteventualequal");
 assert.strictEqual(typeof assertion.default, "function");
 
 console.log("dist smoke test passed");

--- a/packages/iteration/src/assertions/eventualequal.ts
+++ b/packages/iteration/src/assertions/eventualequal.ts
@@ -1,7 +1,7 @@
 // Historically this module was a pop-quiz assertion and imported
 // pop-quiz/testerror. pop-quiz is no longer a dependency (the test suite
 // moved to node:test), so a structurally-compatible TestError is inlined
-// here to keep the "mallory-iteration/pop-quiz/asserteventualequal" subpath
+// here to keep the "@johnhenry/iteration/pop-quiz/asserteventualequal" subpath
 // export working for existing consumers: it extends Error, exposes the
 // details on `.val`, and is iterable over the [key, value] entries --
 // exactly the shape pop-quiz@1's TestError had.

--- a/packages/iteration/src/count.ts
+++ b/packages/iteration/src/count.ts
@@ -36,7 +36,7 @@ const count = <N extends Numeric>(zero: N, one: N) =>
  * @see countAsync
  * @example <caption>Log an infinite sequence of numbers starting with 5 </caption>
  * ```javascript
- * import { countSync } from 'mallory-iteration';
+ * import { countSync } from '@johnhenry/iteration';
  * for(const num of countSync(5, Infinity)){
  *   console.log(num);
  * }
@@ -54,7 +54,7 @@ export const countBigSync = count<bigint>(0n, 1n);
  * @see countSync
  * @example <caption>Log an infinite sequence of numbers starting with 5 </caption>
  * ```javascript
- * import { countAsync } from 'mallory-iteration';
+ * import { countAsync } from '@johnhenry/iteration';
  * for await(const num of countAsync(5, Infinity)){
  *   console.log(num);
  * }

--- a/packages/iteration/src/tee.ts
+++ b/packages/iteration/src/tee.ts
@@ -6,7 +6,7 @@
  * @returns function
  * @example <caption>Split an iterator into 4 </caption>
  * ```javascript
- * import { teeAsync, countAsync } from 'mallory-iteration';
+ * import { teeAsync, countAsync } from '@johnhenry/iteration';
  * const streams = teeAsync(4)(countAsync(Infinity))
  * for await (const num of streams[0]){
  *   console.info(num);

--- a/packages/iteration/src/transduce.ts
+++ b/packages/iteration/src/transduce.ts
@@ -52,7 +52,7 @@ const composeFunctions =
  * @see transduceSync
  * @example <caption>Asynchronously log transduced numbers </caption>
  * ```javascript
- * import { transduceAsync, transducers, countAsync } from 'mallory-iteration';
+ * import { transduceAsync, transducers, countAsync } from '@johnhenry/iteration';
  * const {
  *     map,
  *     filter,
@@ -113,7 +113,7 @@ export function transduceAsync(...functions: Array<Transducer<any, any>>) {
  * @see transduceAsync
  * @example <caption>Synchronously log transduced numbers </caption>
  * ```javascript
- * import { transduceSync, transducers, countSync } from 'mallory-iteration';
+ * import { transduceSync, transducers, countSync } from '@johnhenry/iteration';
  * const {
  *     map,
  *     filter,

--- a/packages/iteration/test/eventualequal.test.ts
+++ b/packages/iteration/test/eventualequal.test.ts
@@ -19,7 +19,7 @@ test("eventualequal resolves false for differing async iterables", async () => {
   assert.strictEqual(await eventualequal(asyncFrom(1, 2, 3), asyncFrom(1, 2)), false);
 });
 
-// The "mallory-iteration/pop-quiz/asserteventualequal" subpath export must
+// The "@johnhenry/iteration/pop-quiz/asserteventualequal" subpath export must
 // keep working even though pop-quiz itself is no longer a dependency: it
 // returns the message on success, and a TestError (Error subclass carrying
 // actual/expected/operator on .val, iterable over its entries) on failure.

--- a/packages/math-prototype-patch/README.md
+++ b/packages/math-prototype-patch/README.md
@@ -1,13 +1,13 @@
-# mallory-math-prototype-patch
+# @johnhenry/math-prototype-patch
 
 An **opt-in**, collision-checked patch of `Number.prototype` with
-[`mallory-math`](https://www.npmjs.com/package/mallory-math)'s `ComplexNumber`
+[`@johnhenry/math`](https://www.npmjs.com/package/@johnhenry/math)'s `ComplexNumber`
 fluent arithmetic/trig methods, so a plain JS number can participate directly
 in complex arithmetic:
 
 ```ts
-import { ComplexNumber } from "mallory-math";
-import { patchNumberPrototype } from "mallory-math-prototype-patch";
+import { ComplexNumber } from "@johnhenry/math";
+import { patchNumberPrototype } from "@johnhenry/math-prototype-patch";
 
 patchNumberPrototype();
 
@@ -23,13 +23,13 @@ means for **every module that runs afterward** — not just the file that
 called it, and not just code that imported this package. That's a
 categorically bigger risk surface than adding a method to `ComplexNumber`
 itself, which is exactly why this is a separate package and not part of
-`mallory-math` core (see
-[johnhenry/mallory#28](https://github.com/johnhenry/mallory/issues/28)).
+`@johnhenry/math` core (see
+[johnhenry/math#28](https://github.com/johnhenry/math/issues/28)).
 
 Nothing runs on import. You always opt in explicitly:
 
 ```ts
-import { patchNumberPrototype } from "mallory-math-prototype-patch";
+import { patchNumberPrototype } from "@johnhenry/math-prototype-patch";
 patchNumberPrototype(); // <-- the actual mutation happens here, and only here
 ```
 
@@ -45,7 +45,7 @@ previous call from unrelated code — it throws a
 self-collision.
 
 ```ts
-import { NumberPrototypeCollisionError, patchNumberPrototype } from "mallory-math-prototype-patch";
+import { NumberPrototypeCollisionError, patchNumberPrototype } from "@johnhenry/math-prototype-patch";
 
 try {
   patchNumberPrototype();
@@ -59,7 +59,7 @@ try {
 ## Undoing it
 
 ```ts
-import { unpatchNumberPrototype, isNumberPrototypePatched } from "mallory-math-prototype-patch";
+import { unpatchNumberPrototype, isNumberPrototypePatched } from "@johnhenry/math-prototype-patch";
 
 unpatchNumberPrototype();       // removes exactly what patchNumberPrototype() added; no-op if not patched
 isNumberPrototypePatched();     // false
@@ -81,8 +81,8 @@ Calling `patchNumberPrototype()` doesn't change what TypeScript thinks
 *also* opt into the ambient type augmentation, as a **separate** import:
 
 ```ts
-import "mallory-math-prototype-patch/global"; // ambient `interface Number { add(...): ComplexNumber; ... }`
-import { patchNumberPrototype } from "mallory-math-prototype-patch";
+import "@johnhenry/math-prototype-patch/global"; // ambient `interface Number { add(...): ComplexNumber; ... }`
+import { patchNumberPrototype } from "@johnhenry/math-prototype-patch";
 
 patchNumberPrototype();
 const z = (3).add(1); // now type-checks as ComplexNumber, no cast needed
@@ -91,7 +91,7 @@ const z = (3).add(1); // now type-checks as ComplexNumber, no cast needed
 This is deliberately split from the main entry point: a `declare global`
 block is a whole-program effect the instant *any* file imports it, whether
 or not `patchNumberPrototype()` was ever actually called at runtime.
-Importing `"mallory-math-prototype-patch/global"` without calling
+Importing `"@johnhenry/math-prototype-patch/global"` without calling
 `patchNumberPrototype()` gives you types for methods that don't exist yet;
 calling `patchNumberPrototype()` without importing `/global` gives you real
 methods TypeScript doesn't know about. Do both, deliberately, or neither.
@@ -99,7 +99,7 @@ methods TypeScript doesn't know about. Do both, deliberately, or neither.
 ## Install & use
 
 ```bash
-npm install mallory-math-prototype-patch
+npm install @johnhenry/math-prototype-patch
 npm test           # run the node:test suite
 npm run typecheck  # tsc --noEmit (src/ only, matching this monorepo's convention)
 npm run build      # emit ./dist (ESM + .d.ts)

--- a/packages/math-prototype-patch/jsr.json
+++ b/packages/math-prototype-patch/jsr.json
@@ -1,5 +1,5 @@
 {
-  "name": "@johnhenry/mallory-math-prototype-patch",
+  "name": "@johnhenry/math-prototype-patch",
   "version": "0.1.0",
   "license": "MIT",
   "exports": {

--- a/packages/math-prototype-patch/jsr.json
+++ b/packages/math-prototype-patch/jsr.json
@@ -7,9 +7,6 @@
     "./global": "./src/global.ts"
   },
   "publish": {
-    "exclude": [
-      "test",
-      "**/*.test.ts"
-    ]
+    "exclude": ["test", "**/*.test.ts"]
   }
 }

--- a/packages/math-prototype-patch/jsr.json
+++ b/packages/math-prototype-patch/jsr.json
@@ -1,12 +1,15 @@
 {
   "name": "@johnhenry/math-prototype-patch",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",
     "./global": "./src/global.ts"
   },
   "publish": {
-    "exclude": ["test", "**/*.test.ts"]
+    "exclude": [
+      "test",
+      "**/*.test.ts"
+    ]
   }
 }

--- a/packages/math-prototype-patch/package.json
+++ b/packages/math-prototype-patch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnhenry/math-prototype-patch",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "OPT-IN, collision-checked Number.prototype patch adding @johnhenry/math's ComplexNumber fluent arithmetic to plain numbers. Never merged into core @johnhenry/math -- see the README before using.",
   "type": "module",
   "publishConfig": {
@@ -47,7 +47,7 @@
   "author": "John Henry",
   "license": "MIT",
   "dependencies": {
-    "@johnhenry/math": "^0.15.0"
+    "@johnhenry/math": "^0.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/math-prototype-patch/package.json
+++ b/packages/math-prototype-patch/package.json
@@ -1,8 +1,12 @@
 {
-  "name": "mallory-math-prototype-patch",
+  "name": "@johnhenry/math-prototype-patch",
   "version": "0.1.0",
-  "description": "OPT-IN, collision-checked Number.prototype patch adding mallory-math's ComplexNumber fluent arithmetic to plain numbers. Never merged into core mallory-math -- see the README before using.",
+  "description": "OPT-IN, collision-checked Number.prototype patch adding @johnhenry/math's ComplexNumber fluent arithmetic to plain numbers. Never merged into core @johnhenry/math -- see the README before using.",
   "type": "module",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -31,7 +35,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/johnhenry/mallory.git",
+    "url": "git+https://github.com/johnhenry/math.git",
     "directory": "packages/math-prototype-patch"
   },
   "keywords": [
@@ -43,7 +47,7 @@
   "author": "John Henry",
   "license": "MIT",
   "dependencies": {
-    "mallory-math": "^0.11.0"
+    "@johnhenry/math": "^0.15.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/math-prototype-patch/src/global.ts
+++ b/packages/math-prototype-patch/src/global.ts
@@ -1,7 +1,7 @@
 /**
  * Ambient TYPE augmentation for `Number.prototype`, matching the methods
  * `patchNumberPrototype()` (see `./index.ts`) adds at runtime -- kept as a
- * SEPARATE opt-in import (`import "mallory-math-prototype-patch/global";`)
+ * SEPARATE opt-in import (`import "@johnhenry/math-prototype-patch/global";`)
  * rather than folded into the main entry point, since a `declare global`
  * block is a whole-program effect the moment ANY file imports it,
  * regardless of whether `patchNumberPrototype()` was ever actually
@@ -12,7 +12,7 @@
  */
 import type { ComplexNumber } from "@johnhenry/math";
 
-/** See index.ts's identical local alias -- mallory-math doesn't export `CNInput` publicly. */
+/** See index.ts's identical local alias -- @johnhenry/math doesn't export `CNInput` publicly. */
 type CNInput = ComplexNumber | number;
 
 declare global {

--- a/packages/math-prototype-patch/src/global.ts
+++ b/packages/math-prototype-patch/src/global.ts
@@ -10,7 +10,7 @@
  * `patchNumberPrototype()` without this gives you real methods TypeScript
  * doesn't know about. Do both, deliberately, or neither.
  */
-import type { ComplexNumber } from "mallory-math";
+import type { ComplexNumber } from "@johnhenry/math";
 
 /** See index.ts's identical local alias -- mallory-math doesn't export `CNInput` publicly. */
 type CNInput = ComplexNumber | number;

--- a/packages/math-prototype-patch/src/index.ts
+++ b/packages/math-prototype-patch/src/index.ts
@@ -1,11 +1,11 @@
 /**
- * mallory-math-prototype-patch (issue #28) — an OPT-IN, collision-checked
+ * @johnhenry/math-prototype-patch (issue #28) — an OPT-IN, collision-checked
  * patch of `Number.prototype` with `ComplexNumber`'s fluent arithmetic/
  * trig methods, so a plain JS number can participate directly in complex
  * arithmetic: `(3).add(new ComplexNumber(1, 2))` instead of
  * `new ComplexNumber(3).add(...)`.
  *
- * Deliberately a SEPARATE package from `mallory-math` itself, never
+ * Deliberately a SEPARATE package from `@johnhenry/math` itself, never
  * merged into core -- patching a built-in prototype is a process-wide,
  * global-realm effect (every module in the process observes it, not just
  * callers that imported this package), a categorically bigger risk
@@ -16,9 +16,9 @@
 import { ComplexNumber } from "@johnhenry/math";
 
 /**
- * mirrors mallory-math's own (internal, unexported) `CNInput` -- anything
+ * mirrors @johnhenry/math's own (internal, unexported) `CNInput` -- anything
  * `ComplexNumber`'s fluent methods accept as an operand. Defined locally
- * rather than depending on an export mallory-math doesn't make public,
+ * rather than depending on an export @johnhenry/math doesn't make public,
  * keeping this package's surface fully self-contained.
  */
 type CNInput = ComplexNumber | number;
@@ -82,7 +82,7 @@ export class NumberPrototypeCollisionError extends Error {
   constructor(collidingNames: readonly string[]) {
     super(
       `Number.prototype already defines: ${collidingNames.join(", ")}. ` +
-        "mallory-math-prototype-patch refuses to overwrite an existing member -- " +
+        "@johnhenry/math-prototype-patch refuses to overwrite an existing member -- " +
         "something else (another library, a polyfill, a previous patch) already claimed it.",
     );
     this.name = "NumberPrototypeCollisionError";

--- a/packages/math-prototype-patch/src/index.ts
+++ b/packages/math-prototype-patch/src/index.ts
@@ -13,7 +13,7 @@
  * import: `patchNumberPrototype()` must be called explicitly. See the
  * README before calling it.
  */
-import { ComplexNumber } from "mallory-math";
+import { ComplexNumber } from "@johnhenry/math";
 
 /**
  * mirrors mallory-math's own (internal, unexported) `CNInput` -- anything

--- a/packages/math-prototype-patch/test/global-types.test.ts
+++ b/packages/math-prototype-patch/test/global-types.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
-import { ComplexNumber } from "mallory-math";
+import { ComplexNumber } from "@johnhenry/math";
 import "../src/global.ts";
 import { patchNumberPrototype, unpatchNumberPrototype } from "../src/index.ts";
 

--- a/packages/math-prototype-patch/test/index.test.ts
+++ b/packages/math-prototype-patch/test/index.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { afterEach, test } from "node:test";
-import { ComplexNumber } from "mallory-math";
+import { ComplexNumber } from "@johnhenry/math";
 import {
   isNumberPrototypePatched,
   NumberPrototypeCollisionError,

--- a/packages/math/PROGRESS.md
+++ b/packages/math/PROGRESS.md
@@ -1,6 +1,6 @@
 # Mallory → TypeScript port — COMPLETE
 
-Ported `johnhenry/mallory` (ActionScript 3, ~11.4k LOC, 23 classes) to modern,
+Ported `johnhenry/math` (ActionScript 3, ~11.4k LOC, 23 classes) to modern,
 fully-typed TypeScript with `node:test`. Tests written **before** each module;
 bugs fixed rather than carried over.
 

--- a/packages/math/README.md
+++ b/packages/math/README.md
@@ -1,8 +1,8 @@
-# mallory
+# @johnhenry/math
 
 **Advanced college-level mathematics for TypeScript** — a modern, fully-typed,
 test-covered port of the Mallory ActionScript 3 library (a project worked on,
-on and off, since 2004), published to npm as `mallory-math`.
+on and off, since 2004), published to npm as `@johnhenry/math`.
 
 Complex numbers, linear algebra over arbitrary algebraic structures,
 combinatorics and number theory, an expression evaluator, and renderer-agnostic
@@ -10,7 +10,7 @@ graphing geometry — all rewritten in modern TypeScript with `node:test`
 (example-based and, for algebraic laws, property-based via `fast-check`).
 
 ```ts
-import { ComplexNumber, Structure, Vector, StringEvaluator } from "mallory-math";
+import { ComplexNumber, Structure, Vector, StringEvaluator } from "@johnhenry/math";
 
 ComplexNumber.E.power(new ComplexNumber(0, Math.PI)); // ≈ -1  (Euler)
 Structure.realField().determinant(/* 3×3 matrix, as Vector<Vector<number>> */);
@@ -21,6 +21,12 @@ StringEvaluator.evaluate("sin(pi/2) + 2^3", StringEvaluator.mathEnvironment()); 
 
 Requires Node.js ≥ 22.6 (the test suite runs `.ts` directly via Node's built-in
 type stripping).
+
+```bash
+npm install @johnhenry/math
+```
+
+To work on the library itself from within this monorepo:
 
 ```bash
 npm install

--- a/packages/math/docs/COOKBOOK.md
+++ b/packages/math/docs/COOKBOOK.md
@@ -7,13 +7,13 @@ against it) — see the linked test file if you want the full context.
 All examples assume:
 
 ```ts
-import { /* ... */ } from "mallory-math";
+import { /* ... */ } from "@johnhenry/math";
 ```
 
 ## Complex numbers & Euler's identity
 
 ```ts
-import { ComplexNumber } from "mallory-math";
+import { ComplexNumber } from "@johnhenry/math";
 
 const eulers = ComplexNumber.E.power(new ComplexNumber(0, Math.PI));
 // eulers ≈ -1 + 0i
@@ -24,7 +24,7 @@ See [`test/ComplexNumber.test.ts`](../test/ComplexNumber.test.ts).
 ## Descriptive statistics
 
 ```ts
-import { Statistics, Vector } from "mallory-math";
+import { Statistics, Vector } from "@johnhenry/math";
 
 const sample = Vector.fromArray([2, 4, 4, 4, 5, 5, 7, 9]);
 Statistics.mean(sample); // => 5
@@ -39,7 +39,7 @@ For small dense matrices with a single number type, `Structure.realField()`
 API used for arbitrary fields below:
 
 ```ts
-import { Structure, Vector } from "mallory-math";
+import { Structure, Vector } from "@johnhenry/math";
 
 const A = Vector.fromArray([Vector.fromArray([4, 3]), Vector.fromArray([6, 3])]);
 const real = Structure.realField();
@@ -54,7 +54,7 @@ real.multiplyMatrix(A, inv); // ≈ identity
 finite fields, rationals, quaternions, dual numbers — via one generic API:
 
 ```ts
-import { Structure, Vector } from "mallory-math";
+import { Structure, Vector } from "@johnhenry/math";
 
 const gf7 = Structure.integersModulo(7); // GF(7), a finite field
 // 3 * 5 = 15 ≡ 1 mod 7:
@@ -76,7 +76,7 @@ over those number types with no extra wiring. See
 `MatrixMath` accepts either a `Matrix<number>` or a plain `number[][]`:
 
 ```ts
-import { MatrixMath } from "mallory-math";
+import { MatrixMath } from "@johnhenry/math";
 
 const A = [
   [4, 3, 2],
@@ -101,7 +101,7 @@ See [`test/MatrixMath.test.ts`](../test/MatrixMath.test.ts).
 ## Evaluating math expression strings
 
 ```ts
-import { StringEvaluator } from "mallory-math";
+import { StringEvaluator } from "@johnhenry/math";
 
 const env = StringEvaluator.mathEnvironment(); // pi, e, sin, cos, sqrt, ...
 StringEvaluator.evaluate("sin(pi/2) + 2^3", env); // ComplexNumber ≈ 9
@@ -117,7 +117,7 @@ Real-number polynomials are `PolynomialRing(Structure.realField())`, plus two
 real-only helpers for the `"3*x^2-2*x+1"` string notation:
 
 ```ts
-import { PolynomialRing, Structure, parsePolynomial, polynomialToString } from "mallory-math";
+import { PolynomialRing, Structure, parsePolynomial, polynomialToString } from "@johnhenry/math";
 
 const R = new PolynomialRing(Structure.realField());
 const p = parsePolynomial("x^2 + 2x + 1"); // parses polynomialToString's own format
@@ -130,7 +130,7 @@ polynomialToString(p); // => "1*x^2+2*x+1"
 ## Counting mathematics (combinatorics)
 
 ```ts
-import { Combinatorics } from "mallory-math";
+import { Combinatorics } from "@johnhenry/math";
 
 Combinatorics.factorial(5); // => 120n
 Combinatorics.binomial(10, 3); // => 120n
@@ -157,7 +157,7 @@ reaches 20. See
 ## Arbitrary-precision decimals
 
 ```ts
-import { Decimal, Structure } from "mallory-math";
+import { Decimal, Structure } from "@johnhenry/math";
 
 // Exact decimal arithmetic — no float drift:
 Decimal.from("0.1").add(Decimal.from("0.2")).toString(); // => "0.3"
@@ -179,7 +179,7 @@ real numbers (as in the recipe above), and so on — mirroring `GroupTheory`'s
 idiom of taking the algebra as a constructor parameter:
 
 ```ts
-import { PolynomialRing, Structure } from "mallory-math";
+import { PolynomialRing, Structure } from "@johnhenry/math";
 
 const gf7 = Structure.integersModulo(7); // GF(7), a finite field
 const R = new PolynomialRing(gf7);
@@ -200,7 +200,7 @@ rationals. See
 ## Symbolic calculus
 
 ```ts
-import { Symbolic } from "mallory-math";
+import { Symbolic } from "@johnhenry/math";
 
 Symbolic.toString(Symbolic.differentiate("x^3")); // => "3*x^2"
 Symbolic.toString(Symbolic.integrate("cos(x)")); // => "sin(x)"
@@ -305,7 +305,7 @@ throws `NotIntegrableError` rather than returning a wrong answer — e.g.
 `Symbolic.integrate("sin(x^2)")` (no accompanying factor to substitute with).
 
 ```ts
-import { Symbolic } from "mallory-math";
+import { Symbolic } from "@johnhenry/math";
 
 // u-substitution: 2x*sin(x^2) -> -cos(x^2), 3x^2*exp(x^3) -> exp(x^3)
 Symbolic.toString(Symbolic.integrate("2*x*sin(x^2)")); // => "-cos(x^2)"
@@ -352,7 +352,7 @@ operators (`x + 1 < 2*x` parses as `(x+1) < (2*x)`) and are non-chaining.
 "locally constant" convention); `piecewise` differentiates branch-wise.
 
 ```ts
-import { Rational, Structure, Symbolic } from "mallory-math";
+import { Rational, Structure, Symbolic } from "@johnhenry/math";
 
 // Exact evaluation over Rational arithmetic instead of floats -- throws for
 // anything not exactly representable (func/call2 nodes, non-integer pow
@@ -369,7 +369,7 @@ Symbolic.evaluateOverStructure("3+5", Structure.integersModulo(7)); // => 1
 ## Multivariable calculus
 
 ```ts
-import { DualNumber, VectorCalculus } from "mallory-math";
+import { DualNumber, VectorCalculus } from "@johnhenry/math";
 
 // f(x, y) = x^2*y + y^3
 const f = (xs: DualNumber[]) => xs[0].pow(2).multiply(xs[1]).add(xs[1].pow(3));
@@ -400,7 +400,7 @@ gradient, not of `f` itself. See
 ## Exact and specialized number types
 
 ```ts
-import { Rational, Quaternion, DualNumber, Interval } from "mallory-math";
+import { Rational, Quaternion, DualNumber, Interval } from "@johnhenry/math";
 
 // Exact fractions (no floating-point drift)
 Rational.from(1).divide(new Rational(3n)).add(Rational.from(1).divide(new Rational(6n))); // 1/2 exactly
@@ -421,7 +421,7 @@ See [`test/NumberTypes.test.ts`](../test/NumberTypes.test.ts).
 ## Number theory
 
 ```ts
-import { NumberTheory } from "mallory-math";
+import { NumberTheory } from "@johnhenry/math";
 
 // a Mersenne prime:
 NumberTheory.isProbablePrime(2n ** 61n - 1n); // => true
@@ -437,7 +437,7 @@ Everything here is `bigint`-based, so it's exact for arbitrarily large inputs
 ## Group theory
 
 ```ts
-import { Structure, GroupTheory } from "mallory-math";
+import { Structure, GroupTheory } from "@johnhenry/math";
 
 // GroupTheory composes with any Structure preset:
 const gf7 = Structure.integersModulo(7);
@@ -457,7 +457,7 @@ non-abelian example and the Lagrange's-theorem cosets/index check.
 ## Root-finding, quadrature, and ODEs
 
 ```ts
-import { Numerical } from "mallory-math";
+import { Numerical } from "@johnhenry/math";
 
 // √2, quadratic convergence:
 Numerical.newton((x) => x * x - 2, 1); // => Math.SQRT2
@@ -472,7 +472,7 @@ Numerical.rk4((_t, y) => [y[0]], [1], 0, 1, 0.01); // y' = y, y(0)=1 -> y(1) ≈
 ## Special functions & probability
 
 ```ts
-import { SpecialFunctions, Distributions, HypothesisTests } from "mallory-math";
+import { SpecialFunctions, Distributions, HypothesisTests } from "@johnhenry/math";
 
 SpecialFunctions.gamma(5); // => 24
 SpecialFunctions.regularizedIncompleteBeta(0.5, 2, 3);
@@ -491,7 +491,7 @@ rather than numeric integration.
 ## FFT and convolution
 
 ```ts
-import { FFT } from "mallory-math";
+import { FFT } from "@johnhenry/math";
 
 FFT.fft([1, 0, 0, 0]); // flat spectrum (power-of-two length required)
 FFT.fftPadded([1, 2, 3]); // zero-pads to the next power of two
@@ -501,7 +501,7 @@ FFT.convolve([1, 2, 3], [4, 5, 6]); // ≈ [4, 13, 28, 27, 18] as ComplexNumbers
 ## Computational geometry
 
 ```ts
-import { Geometry, Transform2D, type Point } from "mallory-math";
+import { Geometry, Transform2D, type Point } from "@johnhenry/math";
 
 const cloud: Point[] = [[0,0],[1,1],[2,2],[2,0],[0,2],[1,0.5]];
 Geometry.convexHull(cloud); // the 4 outer corners; interior/collinear points drop out
@@ -517,7 +517,7 @@ t.apply([1, 0]); // => [1, 3]
 ## Graph algorithms
 
 ```ts
-import { Graph } from "mallory-math";
+import { Graph } from "@johnhenry/math";
 
 const g = new Graph<string>(true); // directed
 g.addEdge("a", "b", 1).addEdge("b", "c", 2).addEdge("a", "c", 10);
@@ -532,7 +532,7 @@ g.floydWarshall(); // { distances, order } — all-pairs shortest paths
 ## Permutations and cycles
 
 ```ts
-import { Permutation, Cycle } from "mallory-math";
+import { Permutation, Cycle } from "@johnhenry/math";
 
 const sigma = new Permutation([0, 1, 2], [1, 2, 0]); // 0->1, 1->2, 2->0
 Permutation.compose(sigma, sigma); // apply sigma twice

--- a/packages/math/jsr.json
+++ b/packages/math/jsr.json
@@ -1,5 +1,5 @@
 {
-  "name": "@johnhenry/mallory-math",
+  "name": "@johnhenry/math",
   "version": "0.9.0",
   "license": "MIT",
   "exports": {

--- a/packages/math/jsr.json
+++ b/packages/math/jsr.json
@@ -1,11 +1,17 @@
 {
   "name": "@johnhenry/math",
-  "version": "0.9.0",
+  "version": "0.0.0",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts"
   },
   "publish": {
-    "exclude": ["test", "docs", "scripts", "api", "**/*.test.ts"]
+    "exclude": [
+      "test",
+      "docs",
+      "scripts",
+      "api",
+      "**/*.test.ts"
+    ]
   }
 }

--- a/packages/math/jsr.json
+++ b/packages/math/jsr.json
@@ -6,12 +6,6 @@
     ".": "./src/index.ts"
   },
   "publish": {
-    "exclude": [
-      "test",
-      "docs",
-      "scripts",
-      "api",
-      "**/*.test.ts"
-    ]
+    "exclude": ["test", "docs", "scripts", "api", "**/*.test.ts"]
   }
 }

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,6 +1,10 @@
 {
-  "name": "mallory-math",
+  "name": "@johnhenry/math",
   "version": "0.15.0",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "description": "Advanced college-level mathematics library \u2014 a modern TypeScript port of the Mallory ActionScript 3 library.",
   "type": "module",
   "exports": {
@@ -45,12 +49,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/johnhenry/mallory.git"
+    "url": "git+https://github.com/johnhenry/math.git"
   },
   "bugs": {
-    "url": "https://github.com/johnhenry/mallory/issues"
+    "url": "https://github.com/johnhenry/math/issues"
   },
-  "homepage": "https://github.com/johnhenry/mallory#readme",
+  "homepage": "https://github.com/johnhenry/math#readme",
   "devDependencies": {
     "@biomejs/biome": "^2.5.1",
     "fast-check": "^4.8.0",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@johnhenry/math",
-  "version": "0.15.0",
+  "version": "0.0.0",
   "publishConfig": {
     "access": "public",
     "provenance": true
   },
-  "description": "Advanced college-level mathematics library \u2014 a modern TypeScript port of the Mallory ActionScript 3 library.",
+  "description": "Advanced college-level mathematics library — a modern TypeScript port of the Mallory ActionScript 3 library.",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -5,7 +5,7 @@
     "access": "public",
     "provenance": true
   },
-  "description": "Advanced college-level mathematics library — a modern TypeScript port of the Mallory ActionScript 3 library.",
+  "description": "Advanced college-level mathematics library \u2014 a modern TypeScript port of the Mallory ActionScript 3 library.",
   "type": "module",
   "exports": {
     ".": {
@@ -49,7 +49,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/johnhenry/math.git"
+    "url": "git+https://github.com/johnhenry/math.git",
+    "directory": "packages/math"
   },
   "bugs": {
     "url": "https://github.com/johnhenry/math/issues"

--- a/packages/math/scripts/rubi-convert.mjs
+++ b/packages/math/scripts/rubi-convert.mjs
@@ -169,7 +169,7 @@ for (const category of categories.sort()) {
 
 const out = {
   attribution:
-    "Derived from RuleBasedIntegration/MaximaSyntaxTestSuite (https://github.com/RuleBasedIntegration/MaximaSyntaxTestSuite), MIT License, Copyright (c) 2018 Rule-based Integration. Converted by scripts/rubi-convert.mjs (Maxima -> mallory-math Symbolic syntax).",
+    "Derived from RuleBasedIntegration/MaximaSyntaxTestSuite (https://github.com/RuleBasedIntegration/MaximaSyntaxTestSuite), MIT License, Copyright (c) 2018 Rule-based Integration. Converted by scripts/rubi-convert.mjs (Maxima -> @johnhenry/math Symbolic syntax).",
   problems: fixture,
 };
 writeFileSync(new URL("../test/fixtures/rubi-corpus.json", import.meta.url), `${JSON.stringify(out, null, 1)}\n`);

--- a/packages/math/scripts/sympy_oracle.py
+++ b/packages/math/scripts/sympy_oracle.py
@@ -3,7 +3,7 @@
 
 Protocol (batch -- SymPy import dominates startup, so callers send many jobs
 per invocation): a JSON object {"jobs": [...]} on stdin, {"results": [...]}
-on stdout, one result per job in order. Each job carries mallory-math's Expr
+on stdout, one result per job in order. Each job carries @johnhenry/math's Expr
 AST verbatim (it is a plain JSON discriminated union); this script rebuilds
 it as a SymPy expression -- an INDEPENDENT reimplementation of the semantics,
 which is the whole point.
@@ -41,7 +41,7 @@ UNARY = {
     "acoth": sp.acoth, "asech": sp.asech, "acsch": sp.acsch,
     "abs": sp.Abs,
     "log10": lambda a: sp.log(a, 10), "log2": lambda a: sp.log(a, 2),
-    "cbrt": lambda a: sp.real_root(a, 3),  # mallory's cbrt is the REAL cube root (Math.cbrt)
+    "cbrt": lambda a: sp.real_root(a, 3),  # this library's cbrt is the REAL cube root (Math.cbrt)
     "floor": sp.floor, "ceil": sp.ceiling,
     "sign": sp.sign,
     "expm1": lambda a: sp.exp(a) - 1, "log1p": lambda a: sp.log(1 + a),

--- a/packages/math/src/CellGraph.ts
+++ b/packages/math/src/CellGraph.ts
@@ -12,11 +12,11 @@
  * value that's deep-equal to what was already cached, so unaffected
  * downstream consumers don't re-render.
  *
- * Promoted here from johnhenry/mallory-graph (originally `src/lib/cell-
+ * Promoted here from johnhenry/mallory (originally `src/lib/cell-
  * graph.ts`, powering every panel there via `useCell`/`useSyncExternalStore`)
- * once johnhenry/mallory-grapher became a second consumer of a frozen
+ * once johnhenry/math-grapher became a second consumer of a frozen
  * vendored copy — two consumers is this monorepo's own extract-to-a-package
- * trigger. See johnhenry/mallory#56. UI-framework-agnostic and dependency-
+ * trigger. See johnhenry/math#56. UI-framework-agnostic and dependency-
  * free by design: nothing here references React or any host application.
  */
 

--- a/packages/math/src/CombinatoricsGenerators.ts
+++ b/packages/math/src/CombinatoricsGenerators.ts
@@ -15,10 +15,10 @@
  * so a fully lazy formulation isn't available. Pools are therefore buffered in
  * memory; enumerating a large product is bounded by that, not by laziness.
  *
- * Originally written for the library now published as `mallory-iteration`;
+ * Originally written for the library now published as `@johnhenry/iteration`;
  * moved here because enumeration is mathematics rather than stream plumbing.
  * The async duals stayed behind — they only added a "collect the source, then
- * run this same sync generator" wrapper, and mallory-math is deliberately
+ * run this same sync generator" wrapper, and @johnhenry/math is deliberately
  * synchronous throughout.
  */
 

--- a/packages/math/src/Lattice.ts
+++ b/packages/math/src/Lattice.ts
@@ -1,8 +1,8 @@
 /**
  * Lattice — axial-coordinate neighbor helpers for hexagonal and triangular
- * grids (part of johnhenry/mallory#30's "lattice-geometry helpers" item,
+ * grids (part of johnhenry/math#30's "lattice-geometry helpers" item,
  * upstream for the generalized Wang tile laboratory,
- * johnhenry/mallory-graph#92). Both the solver (adjacency for constraint
+ * johnhenry/mallory#92). Both the solver (adjacency for constraint
  * propagation) and the app (drawing) need a shared, tested "direction d's
  * neighbor" definition per lattice — this is that definition, kept purely
  * combinatorial (integer coordinate offsets), independent of any pixel

--- a/packages/math/src/Symbolic.ts
+++ b/packages/math/src/Symbolic.ts
@@ -3215,7 +3215,7 @@ function compileExpr(e: Expr): (env: Record<string, number>) => number {
 }
 
 // -- exact (Rational) and structure-aware evaluation -------------------------
-// Moved here from mallory-graph's app-level rational-eval.ts/structure-eval.ts:
+// Moved here from mallory's app-level rational-eval.ts/structure-eval.ts:
 // these are generic "evaluate an Expr over an alternate algebra" utilities
 // with no graphing-calculator-specific logic, so they belong alongside
 // evalExpr/compileExpr where this file's own exhaustiveness checking keeps

--- a/packages/math/src/Symbolic.ts
+++ b/packages/math/src/Symbolic.ts
@@ -861,7 +861,7 @@ export class Symbolic {
   }
 
   /**
-   * Solve `expr = 0` for `variable`, returning every *real* root mallory-math
+   * Solve `expr = 0` for `variable`, returning every *real* root @johnhenry/math
    * can find as an exact `Expr` (rationals and `sqrt`-radicals where
    * possible) — complex roots are not returned (e.g. `x^2 + 1` yields `[]`).
    * Supports polynomials up to degree 6: linear and quadratic are solved in
@@ -1143,7 +1143,7 @@ export class Symbolic {
    * common power of `variable`, then repeatedly pulls out rational linear
    * factors `(variable - r)` via the rational root theorem, falling back to
    * the quadratic formula for a final degree-2 remainder. Any remaining
-   * factor mallory-math can't reduce further (e.g. an irreducible cubic) is
+   * factor @johnhenry/math can't reduce further (e.g. an irreducible cubic) is
    * left as-is. Returns `expr` unchanged (simplified) if it isn't a
    * polynomial in `variable`.
    */

--- a/packages/math/src/differentiation-rules.ts
+++ b/packages/math/src/differentiation-rules.ts
@@ -2,7 +2,7 @@
  * Data-driven derivative rules for single-argument elementary functions --
  * the `func` `Expr` variant (`sin`, `exp`, `asinh`, etc.). This is the
  * "declarative rewrite-rule table" from the Woxi-study design note
- * (github.com/johnhenry/mallory#15): each `FuncName` maps to a pure function
+ * (github.com/johnhenry/math#15): each `FuncName` maps to a pure function
  * from (the function's argument `u`, its already-differentiated form `du`)
  * to d/dx[f(u)]. The chain-rule wrapping itself (computing `du` and
  * dispatching on `e.name`) stays in Symbolic.ts, since that's structural

--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -7,9 +7,9 @@
 // 4D geometric algebra (vectors, bivectors, rotors) -- see report/MIEGAKURE_REPORT.md
 // in johnhenry/miegakure-archive for the design context this was built for.
 export { Bivector4 } from "./Bivector4.ts";
-// Reactive, pull-based dependency graph -- promoted from johnhenry/mallory-graph
-// (its src/lib/cell-graph.ts), which mallory-grapher also vendored a frozen
-// copy of; both now import it from here instead. See johnhenry/mallory#56.
+// Reactive, pull-based dependency graph -- promoted from johnhenry/mallory
+// (its src/lib/cell-graph.ts), which math-grapher also vendored a frozen
+// copy of; both now import it from here instead. See johnhenry/math#56.
 export { CellGraph, type CellRole, CircularDependencyError, structuralEqual } from "./CellGraph.ts";
 // Counting mathematics
 export { Combinatorics } from "./Combinatorics.ts";

--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * mallory-ts — advanced college-level mathematics for TypeScript.
+ * @johnhenry/math — advanced college-level mathematics for TypeScript.
  *
  * A modern, tested TypeScript port of the Mallory ActionScript 3 library.
  */

--- a/packages/math/test/CellGraph.test.ts
+++ b/packages/math/test/CellGraph.test.ts
@@ -177,7 +177,7 @@ test("throws on a circular dependency", () => {
 });
 
 // The four tests below investigate a specific concern raised while surveying
-// this repo for cross-repo interop opportunities (see the mallory-plus
+// this repo for cross-repo interop opportunities (see the math-plus
 // FAMILY.md doc and this repo's own issue #18): could redefining a cell to
 // complete a cycle, at a moment when an INTERMEDIATE cell in that cycle is
 // clean/cached (not currently on the live call stack), let a genuine
@@ -344,7 +344,7 @@ test("get() on a deleted id re-creates an empty record with 'never existed' sema
   assert.equal(g.hasValue("a"), false);
 });
 
-test("a compute that reads a sibling id before it's ever been set/defined sees undefined, then recomputes once that sibling is later defined (the mallory-graph#10 pattern)", () => {
+test("a compute that reads a sibling id before it's ever been set/defined sees undefined, then recomputes once that sibling is later defined (the mallory#10 pattern)", () => {
   const g = new CellGraph();
   // Mirrors LinkedGraphPanes/Linked3DView's combinedDuration: defined before
   // either "pane" has mounted and defined its own timelineDuration cell.
@@ -371,7 +371,7 @@ test("a compute that reads a sibling id before it's ever been set/defined sees u
 });
 
 // -----------------------------------------------------------------------
-// Regression tests for github.com/johnhenry/mallory-graph issues #12-#16
+// Regression tests for github.com/johnhenry/mallory issues #12-#16
 // -----------------------------------------------------------------------
 
 // #12 -- set() on a dependent cell leaks stale dependency edges
@@ -567,7 +567,7 @@ test("define() redefining with a throwing compute does not throw synchronously, 
 test("define() still eagerly notifies dependents on a first-ever definition (no prior value to compare against)", () => {
   // A first define() has no cached value to defer against -- hasValue flips
   // false -> true unconditionally, so the existing eager-cascade behavior
-  // (relied on by the mallory-graph#10-pattern test above) must be
+  // (relied on by the mallory#10-pattern test above) must be
   // untouched by the #15 fix.
   const g = new CellGraph();
   let notified = 0;
@@ -685,7 +685,7 @@ test("subscribeWrites: the returned unsubscribe function stops future notificati
 });
 
 // -----------------------------------------------------------------------
-// Regression tests for github.com/johnhenry/mallory-graph issue #234:
+// Regression tests for github.com/johnhenry/mallory issue #234:
 // subscribeAll over-firing (bug 1) and reentrant-write swallowing (bug 2).
 // -----------------------------------------------------------------------
 

--- a/packages/math/test/CombinatoricsGenerators.test.ts
+++ b/packages/math/test/CombinatoricsGenerators.test.ts
@@ -71,7 +71,7 @@ test("combinationsWithReplacement", () => {
 });
 
 // The point of housing enumeration alongside counting: the two must agree.
-// These cross-checks are only expressible now that both live in mallory-math.
+// These cross-checks are only expressible now that both live in @johnhenry/math.
 
 test("binomial counts exactly what combinations enumerates", () => {
   const pool = [1, 2, 3, 4, 5, 6];

--- a/packages/math/test/Cookbook.test.ts
+++ b/packages/math/test/Cookbook.test.ts
@@ -7,7 +7,7 @@
  * Two levels of checking:
  *
  * 1. Every block must run to completion (imports rewritten from
- *    "mallory-math" to this package's src/index.ts; blocks execute as real
+ *    "@johnhenry/math" to this package's src/index.ts; blocks execute as real
  *    ES modules under Node's type stripping). This catches API renames,
  *    signature changes, and removed exports — the dominant doc-rot mode.
  *
@@ -102,7 +102,10 @@ function materialize(block: DocBlock): string {
   ];
   const lines = block.code.split("\n");
   for (let i = 0; i < lines.length; i++) {
-    const line = (lines[i] as string).replace(/from\s+"mallory-math"/g, `from ${JSON.stringify(INDEX_URL)}`);
+    const line = (lines[i] as string).replace(
+      /from\s+"(?:mallory-math|@johnhenry\/math)"/g,
+      `from ${JSON.stringify(INDEX_URL)}`,
+    );
     const m = line.match(CHECK_RE);
     const stmt = m?.[2] ?? "";
     const isCheckable =

--- a/packages/math/test/Cookbook.test.ts
+++ b/packages/math/test/Cookbook.test.ts
@@ -1,6 +1,6 @@
 /**
  * Docs-as-tests (issue #17, pattern from Woxi's scrut-run documentation —
- * see mallory-plus's docs/spikes/woxi-study.md): every fenced ```ts block in
+ * see math-plus's docs/spikes/woxi-study.md): every fenced ```ts block in
  * docs/COOKBOOK.md is EXECUTED by this suite, so a documented example that
  * stops compiling or starts throwing fails CI instead of silently rotting.
  *
@@ -102,10 +102,7 @@ function materialize(block: DocBlock): string {
   ];
   const lines = block.code.split("\n");
   for (let i = 0; i < lines.length; i++) {
-    const line = (lines[i] as string).replace(
-      /from\s+"(?:mallory-math|@johnhenry\/math)"/g,
-      `from ${JSON.stringify(INDEX_URL)}`,
-    );
+    const line = (lines[i] as string).replace(/from\s+"@johnhenry\/math"/g, `from ${JSON.stringify(INDEX_URL)}`);
     const m = line.match(CHECK_RE);
     const stmt = m?.[2] ?? "";
     const isCheckable =

--- a/packages/math/test/DiscreteMath.test.ts
+++ b/packages/math/test/DiscreteMath.test.ts
@@ -102,7 +102,7 @@ test("dijkstra shortest path", () => {
   assert.deepEqual(path, ["a", "b", "c", "d"]);
 });
 
-// Regression test for https://github.com/johnhenry/mallory/issues/38 — dijkstra/shortestPath
+// Regression test for https://github.com/johnhenry/math/issues/38 — dijkstra/shortestPath
 // used to do a linear "find min unvisited vertex" scan on every iteration (O(V^2)), which
 // measured at 9-12s on a 20,000-node chain graph. A heap-based implementation should stay
 // well under a second. The threshold below is generous (2s) to avoid flakiness on slow CI

--- a/packages/math/test/Symbolic.test.ts
+++ b/packages/math/test/Symbolic.test.ts
@@ -956,7 +956,7 @@ test("solve finds x=0 as a root of degree>=3 polynomials with a zero constant te
   assert.deepEqual(rootsOf("x^4 - 2*x^3 - 3*x^2"), [-1, 0, 0, 3]); // x^2*(x+1)*(x-3): 0 has multiplicity 2
   assert.deepEqual(rootsOf("x^5 - 5*x^3 + 4*x"), [-2, -1, 0, 1, 2]); // x*(x^2-1)*(x^2-4)
 
-  // 0 as a root with multiplicity > 1 (mallory-graph#254's excluded case,
+  // 0 as a root with multiplicity > 1 (mallory#254's excluded case,
   // generalized): x^2*(x-3)*(x+2) has a double root at 0.
   assert.deepEqual(rootsOf("x^4 - x^3 - 6*x^2"), [-2, 0, 0, 3]);
   // Triple root at 0: x^3*(x-5).

--- a/packages/math/test/SympyOracle.test.ts
+++ b/packages/math/test/SympyOracle.test.ts
@@ -1,5 +1,5 @@
 /**
- * SymPy differential oracle for Symbolic (issue #14) — mallory-plus's proven
+ * SymPy differential oracle for Symbolic (issue #14) — math-plus's proven
  * subprocess-oracle pattern (numpy_oracle.py / scipy_oracle.py) applied to
  * this repo's own CAS. SymPy rebuilds mallory's Expr AST independently
  * (scripts/sympy_oracle.py), so agreement is two implementations agreeing,
@@ -268,7 +268,7 @@ function mulberry32(seed: number): () => number {
 /** Smooth, sympy-translatable, non-piecewise subset — the property leg's
  * spec table. Kinked/discrete funcs (abs/floor/relu/min/max/...) are pinned
  * by the fixed suites; FD-meaningless at kinks applies to derivatives here
- * exactly as it did in mallory-plus's fuzzer. */
+ * exactly as it did in math-plus's fuzzer. */
 const GEN_FUNCS = ["sin", "cos", "exp", "tanh", "sinh", "atan", "sigmoid", "sqrt", "ln", "erf", "asinh"] as const;
 
 function genExpr(rng: () => number, depth: number): Expr {

--- a/packages/math/test/fixtures/rubi-corpus.json
+++ b/packages/math/test/fixtures/rubi-corpus.json
@@ -1,5 +1,5 @@
 {
- "attribution": "Derived from RuleBasedIntegration/MaximaSyntaxTestSuite (https://github.com/RuleBasedIntegration/MaximaSyntaxTestSuite), MIT License, Copyright (c) 2018 Rule-based Integration. Converted by scripts/rubi-convert.mjs (Maxima -> mallory-math Symbolic syntax).",
+ "attribution": "Derived from RuleBasedIntegration/MaximaSyntaxTestSuite (https://github.com/RuleBasedIntegration/MaximaSyntaxTestSuite), MIT License, Copyright (c) 2018 Rule-based Integration. Converted by scripts/rubi-convert.mjs (Maxima -> @johnhenry/math Symbolic syntax).",
  "problems": [
   {
    "source": "0 Independent test suites/Apostol Problems.mac",

--- a/packages/math/typedoc.json
+++ b/packages/math/typedoc.json
@@ -3,14 +3,14 @@
   "entryPoints": ["src/index.ts"],
   "tsconfig": "tsconfig.json",
   "out": "docs/api",
-  "name": "mallory-ts",
+  "name": "@johnhenry/math",
   "readme": "README.md",
   "excludeExternals": true,
   "excludePrivate": true,
   "excludeInternal": true,
   "navigationLinks": {
-    "GitHub": "https://github.com/johnhenry/mallory-ts",
-    "Cookbook": "https://github.com/johnhenry/mallory-ts/blob/main/docs/COOKBOOK.md"
+    "GitHub": "https://github.com/johnhenry/math",
+    "Cookbook": "https://github.com/johnhenry/math/blob/main/docs/COOKBOOK.md"
   },
   "sort": ["alphabetical"],
   "categorizeByGroup": true,


### PR DESCRIPTION
Wave 1 of the family-wide rename. **This repo must merge and publish first** — every other repo in the family depends on `@johnhenry/math`, and their CI 404s until it exists on the registry. This repo is self-contained (workspaces resolve internally), so its CI passes standalone.

Also note: the GitHub rename to `johnhenry/math` must happen **before** publishing — `--provenance` validates `repository.url` against the repo running the workflow, and these manifests already point at `johnhenry/math`.

## Renames
| old | new |
|---|---|
| `mallory-math` | `@johnhenry/math` |
| `mallory-iteration` | `@johnhenry/iteration` |
| `mallory-math-prototype-patch` | `@johnhenry/math-prototype-patch` |

Plus `publishConfig.access: public` on all three (scoped packages default to restricted), `repository`/`homepage`/`bugs` retargeted at `johnhenry/math`, and jsr.json names updated.

## Versions
Everything resets to `0.0.0`, with intra-family ranges at `^0.0.0`. These must move together: rescoped packages publish fresh with only their current version on the registry, so a range that doesn't match what's being published can't resolve. (`^0.0.0` matches exactly `0.0.0` under pre-1.0 semver — intentional for a coordinated fresh start.)

Also fixes a pre-existing bug: `math-prototype-patch` depended on `mallory-math@^0.11.0`, which never matched the real 0.15.0.

## Things that execute, not just document
Changed in lockstep or CI silently breaks:
- `Cookbook.test.ts` regex-rewrites and **executes** every `from "mallory-math"` line in `COOKBOOK.md`.
- `dist-smoke-test.mjs` imports the package **by its own npm name** to prove the `exports` map works.

## User-facing surfaces the first pass missed
`npm install mallory-iteration` in the install docs, copy-pasteable JSDoc `@example` imports, a **runtime error message** naming the old package, the documented opt-in path `import "mallory-math-prototype-patch/global"`, and a `typedoc.json` still pointing at `mallory-ts`.

## CI
Trigger widened to `[main, master]`; shared concurrency group added (family-wide standard).

## Verification
`npm ci` clean · typecheck · biome · **824/824 tests** (88 iteration + 724 math incl. all 24 live-executed cookbook blocks + 12 prototype-patch) · build · dist smoke tests.
