### PR TITLE
Fix 0/0 silent simplification and DualNumber.pow(0) NaN

### DIFF
--- a/packages/math/src/DualNumber.ts
+++ b/packages/math/src/DualNumber.ts
@@ -55,6 +55,13 @@ export class DualNumber {
 
   /** Raise to a constant power (chain rule). */
   pow(n: number): DualNumber {
+    // n === 0 is special-cased: the general formula `n * value**(n-1) * deriv`
+    // becomes `0 * Infinity = NaN` when value is also 0 (since `0 ** -1` is
+    // `Infinity` in JS). The derivative of the constant function x^0 = 1 is
+    // 0 everywhere, regardless of the base's own derivative, so skip the
+    // general formula entirely rather than let it hit that indeterminate
+    // form (issue #74).
+    if (n === 0) return new DualNumber(1, 0);
     return new DualNumber(this.value ** n, n * this.value ** (n - 1) * this.deriv);
   }
 

--- a/packages/math/src/Symbolic.ts
+++ b/packages/math/src/Symbolic.ts
@@ -1438,6 +1438,10 @@ function simplifyOnce(e: Expr): Expr {
       if (isConst(r, 1)) return l;
       return mul(l, r);
     case "div":
+      // Check the denominator for zero BEFORE the numerator-zero shortcut
+      // below -- 0/0 is indeterminate and must NOT collapse to 0 just
+      // because the numerator happens to be zero too (issue #73).
+      if (isConst(r, 0)) return div(l, r);
       if (isConst(l, 0)) return num(0);
       if (isConst(r, 1)) return l;
       return div(l, r);

--- a/packages/math/test/NumberTypes.test.ts
+++ b/packages/math/test/NumberTypes.test.ts
@@ -81,6 +81,21 @@ test("DualNumber gradient", () => {
   assert.ok(close(grad[0], 10) && close(grad[1], 3));
 });
 
+test("DualNumber.pow(0) at value===0 is 1 with derivative 0, not NaN", () => {
+  // The general power-rule formula `n * value**(n-1) * deriv` degenerates to
+  // `0 * Infinity = NaN` when n===0 and value===0 (since `0 ** -1` is
+  // Infinity in JS). x^0 = 1 is constant, so its derivative must be 0
+  // everywhere, including at x=0. See issue #74.
+  const r = DualNumber.variable(0).pow(0);
+  assert.equal(r.value, 1);
+  assert.equal(r.deriv, 0);
+  // Sanity: away from value===0, pow(0) should already behave correctly,
+  // and this must remain unaffected by the fix.
+  const r2 = DualNumber.variable(5).pow(0);
+  assert.equal(r2.value, 1);
+  assert.equal(r2.deriv, 0);
+});
+
 // --- Interval ---
 
 // Every non-exact Interval op now outward-rounds its result by ~1 ULP per

--- a/packages/math/test/Symbolic.test.ts
+++ b/packages/math/test/Symbolic.test.ts
@@ -53,6 +53,17 @@ test("simplify applies identities", () => {
   assert.equal(Symbolic.toString(Symbolic.simplify("x^0")), "1");
 });
 
+test("simplify does not collapse 0/0 to 0 (indeterminate form)", () => {
+  // (x-x)/(x-x) simplifies numerator and denominator to the constant 0 on
+  // each side -- the div case must not then fall through to the ordinary
+  // "numerator is 0" shortcut, since the denominator is 0 too. See issue #73.
+  assert.notEqual(Symbolic.toString(Symbolic.simplify("(x-x)/(x-x)")), "0");
+  // The ordinary "0 in numerator, nonzero denominator" case must still
+  // simplify to 0 as before.
+  assert.equal(Symbolic.toString(Symbolic.simplify("0/x")), "0");
+  assert.equal(Symbolic.toString(Symbolic.simplify("(x-x)/x")), "0");
+});
+
 test("simplify folds a constant denominator into the surrounding term's coefficient", () => {
   // The motivating shape from the Bernoulli-ODE investigation: a constant
   // denominator used to be locked inside an opaque div atom, so the


### PR DESCRIPTION
## Summary

Two MEDIUM-severity bug-hunt findings, each fixed with a regression test:

- Fixes #73 — `Symbolic.simplify`'s `div` case checked only `isConst(l, 0)` (numerator zero) and returned `0` unconditionally, so an indeterminate `0/0` (e.g. `(x-x)/(x-x)`) silently collapsed to `0`. Now the denominator is checked for zero first; when it's zero the division is left unevaluated instead of simplified. The ordinary "zero numerator, nonzero denominator" case is unaffected.
- Fixes #74 — `DualNumber.pow(n)` ran every exponent through the general derivative formula `n * value**(n-1) * deriv`, which becomes `0 * Infinity = NaN` when `n === 0` and `value === 0` (since `0 ** -1` is `Infinity`). `n === 0` is now special-cased to return `{value: 1, deriv: 0}` directly, since the derivative of the constant `x^0 = 1` is `0` everywhere.

## Test plan

- [x] `npm run test` — all green, 833 tests passing (baseline 831 + 2 new regression tests), 0 failures
- [x] `npm run typecheck` — clean
- [x] `npm run check` (biome) — clean, no issues
- [x] Manually verified pre-fix repro (`0/0` → `0`, `pow(0)` deriv → `NaN`) and post-fix behavior (`0/0` stays unevaluated as `0/0`, `pow(0)` at value 0 → `{value: 1, deriv: 0}`) by stashing the fix and re-running